### PR TITLE
CoreShutdownTests: cover a focused TextBox alive at core shutdown

### DIFF
--- a/dxaml/test/native/external/framework/lifetime/tests/CoreShutdownTests.cpp
+++ b/dxaml/test/native/external/framework/lifetime/tests/CoreShutdownTests.cpp
@@ -109,4 +109,52 @@ void CoreShutdownTests::RoutedEventArgsCleanup()
     preservedArgs = nullptr;
 }
 
+// Regression test for the shutdown access violation in CInputServices::GetPrimaryRegisteredIslandInputSite.
+//
+// A TextBox that still has focus when the core is torn down is kept alive by the text core rather than
+// by the visual tree, so it outlives ResetCoreWindowVisualTree and is destroyed by CCoreServices::~CCoreServices
+// at "delete m_pTextCore". That teardown synchronously re-enters input:
+//   CTextBoxBase::Destroy -> OnTxInPlaceDeactivate -> ShowGrippers -> TxGetWindow
+//     -> CDependencyObject::GetElementIslandInputSite -> CInputServices::GetPrimaryRegisteredIslandInputSite
+// m_inputServices is an xref_ptr, so resetting it before the text core is deleted destroys CInputServices
+// and that callback then runs on a null instance, faulting while reading m_islandInputSiteRegistrations.
+//
+// The test deliberately leaves the focused TextBox in the tree across shutdown. It fails as an access
+// violation (0xC0000005) if the reset is ordered before the text core teardown.
+void CoreShutdownTests::FocusedTextBoxAtCoreShutdown()
+{
+    TestServices::WindowHelper->InitializeXaml();
+
+    auto shutdownGuard = wil::scope_exit([]
+    {
+        TestServices::WindowHelper->ShutdownXaml();
+    });
+
+    xaml_controls::TextBox^ textBox = nullptr;
+
+    RunOnUIThread([&]
+    {
+        textBox = ref new xaml_controls::TextBox();
+        textBox->Text = L"focused text input at shutdown";
+        TestServices::WindowHelper->WindowContent = textBox;
+    });
+    TestServices::WindowHelper->WaitForIdle();
+
+    // Focus activates the RichEdit host in place, which is what arms the deactivation callback below.
+    RunOnUIThread([&]
+    {
+        VERIFY_IS_TRUE(textBox->Focus(xaml::FocusState::Programmatic));
+    });
+    TestServices::WindowHelper->WaitForIdle();
+
+    // Release the test's reference but deliberately leave the TextBox focused and in the tree, so the
+    // text core owns the final reference and drops it during core destruction.
+    RunOnUIThread([&]
+    {
+        textBox = nullptr;
+    });
+
+    shutdownGuard.reset();
+}
+
 } } } } } }

--- a/dxaml/test/native/external/framework/lifetime/tests/CoreShutdownTests.h
+++ b/dxaml/test/native/external/framework/lifetime/tests/CoreShutdownTests.h
@@ -31,5 +31,11 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
             TEST_METHOD_PROPERTY(L"TestPass:IncludeOnlyOn", L"Desktop")
             TEST_METHOD_PROPERTY(L"Hosting:Mode", L"UAP")
         END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(FocusedTextBoxAtCoreShutdown)
+            TEST_METHOD_PROPERTY(L"Description", L"Tear down the core with a focused TextBox still in the tree without faulting in input services.")
+            TEST_METHOD_PROPERTY(L"TestPass:IncludeOnlyOn", L"Desktop")
+            TEST_METHOD_PROPERTY(L"Hosting:Mode", L"UAP")
+        END_TEST_METHOD()
     };
 } } } } } }


### PR DESCRIPTION
Description:
Adds a regression test for the shutdown access violation in CInputServices::GetPrimaryRegisteredIslandInputSite reported in #11653 / #11654, which is already fixed at the root cause in main by 691c6a72c95a0f40a3b331d7af9b61e1be58afd6 but is still live on the 1.7, 1.8 and 2.x release branches because the fix has not been serviced there yet.

CoreShutdownTests::FocusedTextBoxAtCoreShutdown leaves a focused TextBox in the tree across shutdown so the text core drops the final reference during CCoreServices::~CCoreServices, and faults with 0xC0000005 if m_inputServices is reset before the text core teardown.