### PR TITLE
SourceFileManager::PropagateOutOfDateStatus: don't fail the task when the x:Class pre-read fails

### DIFF
--- a/src/XamlCompiler/BuildTasks/SourceFileManager.cs
+++ b/src/XamlCompiler/BuildTasks/SourceFileManager.cs
@@ -125,9 +125,10 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
                     // look to see if a new class was specified; if so, we guessed wrong before, undo that.
                     // Note that both the old and new classes are out of date.
                     string newClassFullName = null;
-                    using (var fileReader = TaskFileService.GetFileContents(tif.SourceXamlFullPath))
+                    if (!TryReadClassFullName(tif, context, out newClassFullName))
                     {
-                        newClassFullName = XamlNodeStreamHelper.ReadXClassFromXamlFileStream(fileReader, context);
+                        // Can't tell whether the class was renamed; leave the cached name, the file is already out of date.
+                        continue;
                     }
 
                     if (newClassFullName != tif.ClassFullName)
@@ -166,6 +167,24 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
                         }
                     }
                 }
+            }
+        }
+
+        // Returns false when the x:Class can't be determined (malformed markup, unreadable file, schema failure).
+        private bool TryReadClassFullName(TaskItemFilename tif, DirectUI.DirectUISchemaContext context, out string classFullName)
+        {
+            try
+            {
+                using (var fileReader = TaskFileService.GetFileContents(tif.SourceXamlFullPath))
+                {
+                    classFullName = XamlNodeStreamHelper.ReadXClassFromXamlFileStream(fileReader, context);
+                }
+                return true;
+            }
+            catch (Exception)
+            {
+                classFullName = null;
+                return false;
             }
         }
 


### PR DESCRIPTION
Description:  
Typing any character before the first `<` in MainWindow.xaml fails the build with a diagnostic that blames the SDK targets file and never names the XAML file.

```
Microsoft.UI.Xaml.Markup.Compiler.interop.targets(505,9): Xaml Internal Error error WMC9999: Data at the root level is invalid. Line 1, position 1.
```

No .xaml file appears anywhere in the output, so on a project with many pages there is nothing to go on.

Root cause:  
`SourceFileManager::PropagateOutOfDateStatus` re-reads x:Class from every out-of-date XAML file to detect a class rename since the last incremental build. It is incremental bookkeeping, and it has three possible outcomes: same, renamed, or cannot be determined. Only the first two are implemented.

Fix:  
Give the pre-read the missing outcome. `TryReadClassFullName` returns false when x:Class cannot be determined for any reason, following the same shape as FingerPrinter's hash checks, and the caller skips the rename comparison for that file. The file is already out of date, so it is recompiled and `LoadXamlDom` reports the real failure against it.

The cached class name is deliberately kept rather than cleared, the task item is registered in the class map, and clearing it there would unregister a class that is still needed for the rest of the walk.

Build output, one malformed MainWindow.xaml
```
before
...\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.interop.targets(518,9): Xaml Internal Error error WMC9999: Data at the root level is invalid. Line 1, position 1. [App.csproj]

after
...\AppPopup\MainWindow.xaml : Xaml Xml Parsing Error error WMC9997: Data at the root level is invalid. Line 1, position 1. [App.csproj]
```
Two malformed files, MainWindow.xaml and ReproPage.xaml
```
before
...\buildTransitive\Microsoft.UI.Xaml.Markup.Compiler.interop.targets(518,9): Xaml Internal Error error WMC9999: Data at the root level is invalid. Line 1, position 1. [App.csproj]

after
...\AppPopup\MainWindow.xaml : Xaml Xml Parsing Error error WMC9997: Data at the root level is invalid. Line 1, position 1. [App.csproj]
...\AppPopup\ReproPage.xaml : Xaml Xml Parsing Error error WMC9997: Data at the root level is invalid. Line 1, position 1. [App.csproj]

```
Behavior:  
Callers on a readable file are unaffected: the class name is compared and a rename is registered exactly as before.

A file that cannot be read no longer fails the task, so the compile proceeds and the diagnostic is attributed to that .xaml.

Because the task no longer stops at the first bad file, every malformed file is reported rather than just one.

Testing:  
Repro'd locally in a WinUI 3 app, merge base against the fix, msbuild.exe amd64 with the in-proc CompileXaml task, swapping only Microsoft.UI.Xaml.Markup.Compiler.dll via XamlCompilerTaskPath.

| case | merge base | fix |
| --- | --- | --- |
| stray character before the first `<` | interop.targets(518,9) WMC9999, no file | MainWindow.xaml WMC9997 |
| two malformed XAML files | 1 error, fileless WMC9999 | 2 errors, both files named |
| MainWindow.xaml locked for reading | interop.targets(518,9) WMC9999 | MainWindow.xaml WMC9999 |
| stray end tag on line 31 | MainWindow.xaml WMC9997 | MainWindow.xaml WMC9997 |
| valid XAML | builds clean | builds clean |
| unknown type | MainWindow.xaml(31,14) WMC0001 | MainWindow.xaml(31,14) WMC0001 |
| break, repair, rebuild without a clean | recovers | recovers |
| x:Class renamed across incremental builds | same generated .g.cs | same generated .g.cs |