### PR TITLE
Align ExtendsContentIntoTitleBar top borders

### DIFF
--- a/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
+++ b/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
@@ -64,6 +64,7 @@ namespace MUXControlsTestApp.Utilities
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.OptimizeApplyStyles));
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.DefaultStyleOptimizations));
             Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.DeferContextFlyoutInit));
+            Verify.IsTrue(XamlOptionalChanges.EnableChange(XamlChangeId.AlignExtendsContentIntoTitleBarBehavior));
         }
 
         public void UpdateXamlOptionalChanges()
@@ -169,6 +170,10 @@ namespace MUXControlsTestApp.Utilities
                         else if (string.Equals(name, "DeferContextFlyoutInit", StringComparison.OrdinalIgnoreCase))
                         {
                             changeId = XamlChangeId.DeferContextFlyoutInit;
+                        }
+                        else if (string.Equals(name, "AlignExtendsContentIntoTitleBarBehavior", StringComparison.OrdinalIgnoreCase))
+                        {
+                            changeId = XamlChangeId.AlignExtendsContentIntoTitleBarBehavior;
                         }
 
                         Verify.AreNotEqual(changeId, XamlChangeId._Reserved, "Unknown XamlChangeId: " + name);

--- a/docs/design-notes/customtitlebar.md
+++ b/docs/design-notes/customtitlebar.md
@@ -5,24 +5,23 @@
 - [Under the hood](#under-the-hood)
   - [Glass window: concept](#glass-window-concept)
   - [Glass window: implementation](#glass-window-implementation)
+  - [Client area and top border](#client-area-and-top-border)
   - [Min/Max/Close buttons and dragging](#minmaxclose-buttons-and-dragging)
   - [NCHITTEST behavior](#nchittest-behavior)
   - [Files](#files)
 
 WinUI allows an app developer to use her own custom UI element as a title bar instead of a system provided one. More 
 details can be found in the public documentation for 
-[Window.SetTitleBar()](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window.settitlebar?view=windows-app-sdk-1.2).
+[Window.SetTitleBar()](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.window.settitlebar).
 [Spec document](./customtitlebar-spec.md)
 ## Under the hood
 
-The implementation of this feature involves 3 important parts:
-1. Hide system drawn title bar from app's main window
-2. Create another window on top of main window which acts as a **glass window**. 
-Creating this glass window is the secret sauce to get custom title bar working. It is an important concept which is 
-used in multiple areas of WinUI (like InputSite's BridgeWindow).
-3. Create another small window which draws min/max/close caption buttons and handles their hit-testing responses.
+The current implementation has 3 important parts:
+1. AppWindow hides the system-drawn title bar and extends the client area.
+2. `Microsoft.UI.Input.InputNonClientPointerSource` provides a transparent **glass window** for caption drag regions.
+3. AppWindow provides the system min/max/close caption controls.
 
-Parts 2. and 3. are done by calling `Microsoft.UI.Input.InputNonClientPointerSource` apis.
+AppWindow and `InputNonClientPointerSource` are Windows App SDK components whose implementations are outside this repository.
 
 ### Glass window: concept
 
@@ -39,59 +38,98 @@ This can be used in many powerful ways. Implementing a custom title bar is a goo
 
 ### Glass window: implementation
 
-In the custom title bar scenario, the glass window is created just above the custom UI element the developer is using 
-as a title bar, and should have the same dimensions as the UI element. It can be any width or height.
+In the custom title bar scenario, WinUI registers the custom title-bar element's bounds as a caption region with
+`InputNonClientPointerSource`.
 
-We hide the system title bar by handling the `WM_NCCALCSIZE` message to extend the client area over the non-client 
-area.
+The Windows App SDK windowing layer hides the system title bar by handling `WM_NCCALCSIZE` to extend the client area
+over the non-client area.
 
 ![Glass window example](./images/customtitlebar-glasswindow.png) 
 
-In the default case, WinUI 3 custom titlebar uses 2 special windows -
-first one is a glass window which covers the entire non client regin i.e. titlebar region
-and provides dragging capability, second one draws min/max/close caption buttons and places
-it at top right corner (top left for RTL cases), above any dragging glass window window in hit testing z-order. 
+The Windows App SDK implementation uses a glass window for drag regions and a separate window for caption controls.
+It owns their z-order and places the caption controls at the top-right corner (top-left for RTL).
 
-User code can create any number of glass windows for multiple drag regions. The api creates as many glass windows per drag region
-and uses [`SetWindowRgn`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowrgn) to cut holes
-and allow interactive controls like buttons to be placed in them. See `Microsoft.UI.Input.InputNonClientPointerSource` implementation
-for details.
+Apps can register multiple caption rectangles and leave interactive XAML elements outside those regions. See the public
+[`InputNonClientPointerSource`](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource)
+documentation for the supported API behavior.
+
+### Client area and top border
+
+Windows normally divides a top-level window into a non-client area containing
+the caption and resize frame, and a client area containing app content.
+
+Windows sends
+[`WM_NCCALCSIZE`](https://learn.microsoft.com/windows/win32/winmsg/wm-nccalcsize)
+when it needs the client rectangle. When `wParam` is `TRUE`,
+`NCCALCSIZE_PARAMS.rgrc[0]` is an input/output value. On entry it contains the
+proposed outer window rectangle. Before returning, the handler replaces it with
+the rectangle that should become the client area.
+
+The return value does not contain the client rectangle. Returning zero selects
+the default preservation behavior, which aligns the old client area with the
+upper-left corner of the new client area. Windows reads the new client rectangle
+from the updated `rgrc[0]`.
+
+When content extends into the title bar, the Windows App SDK windowing layer
+keeps the top of the proposed window rectangle instead of accepting the caption
+inset calculated by `DefWindowProc`. The former caption region therefore becomes
+client area. The AppWindow implementation that performs this calculation is
+outside this repository.
+
+```text
+Normal window
+
++---------------------------+
+| native caption            | non-client
++---------------------------+
+| app client area           | client
++---------------------------+
+
+Content extended into title bar
+
++---------------------------+ client y=0
+| former caption area       | client
+| app client area           |
++---------------------------+
+```
+
+`DesktopWindowImpl` hosts the XAML tree in a private
+`Microsoft.UI.Content.DesktopChildSiteBridge` HWND. For a normal,
+non-maximized window using `Window.ExtendsContentIntoTitleBar`,
+`CWindowChrome` positions that child HWND at client y=1 and reduces its height
+by one physical pixel:
+
+```text
++---------------------------+ client y=0
+| row reserved for DWM      | 1 physical pixel
++---------------------------+ client y=1
+| DesktopChildSiteBridge    |
+| WinUI content             |
++---------------------------+
+```
+
+The reserved row prevents the composition island and the native top border from
+claiming the same pixel. On Windows 11, DWM draws the native top border in this
+row, followed immediately by WinUI content. Windows 10 does not compose this
+row identically when the top-level HWND has an opaque GDI redirection surface.
+
+The visible one-pixel row is not the complete resize target. Windows uses its
+DPI-aware resize-frame metrics to provide a larger top resize target.
+
 ### Min/Max/Close buttons and dragging
 
-The glass window captures the input to perform the drag operation when mouse drag happens. When a drag operation 
-happens on the glass window, the code moves the main window around accordingly. From a user's point of view, dragging 
-of main window is happening (without system title bar being present) with no information of glass window acting as a 
-mediator. Similarly for resize operations. Such a workaround is needed because we cannot directly do drag operations on 
-the main window. Non-client messages (NC messages) are needed for such operations to work but they never reach the main 
-window and are filtered  by InputSite's Bridge Window (more on this later). Glass window provides a good workaround 
-solution for it.
+`CWindowChrome` converts the custom title-bar bounds from XAML logical coordinates to physical client coordinates and
+registers them with `InputNonClientPointerSource` as caption regions. The Windows App SDK then provides standard dragging
+behavior. The min/max/close buttons remain AppWindow caption controls.
 
 ### NCHITTEST behavior
 
-There is an **input sink** provided by Input that covers the entire main HWND and captures all input coming to it. Xaml 
-doesn't draw to the main HWND, but rather a child Hwnd called `BridgeWindow` provided by the input sink. The input sink 
-captures all input and transfers it to the `BridgeWindow`.
-
-The input sink intentionally filters out NC ("non-client") messages by design. 
-Therefore, messages such as [WM_NCHITTEST](https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-nchittest) never 
-reach Xaml code and get eaten up. In order to work around this, we leverage the existing "glass window" (called the 
-**drag** window) and extend it over the min/max/close caption buttons. These min/max/close buttons are regular buttons
-(though hosted in their own separate window)
-which are hooked up to perform same operations as the system provided min/max/close buttons (as they were 
-removed along with system title bar). Now the glass window covers up the entire width of Xaml app's window and is 
-acting over entire non-client area.
-
-When a `WM_NCHITTEST` request comes for the drag window, we take the pointer coordinates and match them against the 
-Xaml window. If the pointer is over any of the caption buttons, we return their respective hit test message: 
-`HTMAXBUTTON`, `HTMINBUTTON`, `HTCLOSE`. Snap flyout starts working this way.
+XAML renders through the child `DesktopChildSiteBridge`, not directly into the top-level HWND, so the XAML island does
+not provide top-level non-client hit testing. WinUI identifies caption rectangles through
+`InputNonClientPointerSource.SetRegionRects`. The Windows App SDK handles the underlying non-client input and coordinates
+it with AppWindow caption controls, including maximize-button Snap Layouts behavior.
 
 ![Snap flyout example](./images/customtitlebar-snapflyout.png)
-
-We do the same thing with mouse move for hover and click. If mouse move or pointer down coordinates occur on the 
-drag window exactly above the caption buttons in the Xaml window, we send the appropriate response to the Xaml 
-window to do hover or click on that respective button. The appropriate Xaml functions are called to change the visual 
-state of the buttons. The appropriate mouse leave events are also handled so all these events get cancelled on mouse 
-leave.
 
 ![Minimize button Mouse over example](./images/customtitlebar-minimize-mouse-over.png)
 
@@ -99,11 +137,16 @@ leave.
 
 ### Files
 
-The custom title bar feature is internally a control named **`WindowChrome`** and files are named accordingly.
-The drag regions are provided by calling `Microsoft.UI.Input.InputNonClientPointerSource` apis which handle the
-heavy lifting of creating glass windows, caption button windows and handling and responding to `NCHITTEST` messages by the OS.
+The WinUI side of the custom title-bar feature is internally represented by a control named **`WindowChrome`**.
+Drag regions are registered through `Microsoft.UI.Input.InputNonClientPointerSource`; AppWindow and the Windows App SDK
+own the underlying non-client input and caption-control implementation.
 
 * `WindowChrome` Control:
   * Dxaml layer: [`dxaml/xcp/dxaml/lib/WindowChrome_Partial.cpp`](../../dxaml/xcp/dxaml/lib/WindowChrome_Partial.cpp)
   * Core layer: [`dxaml/xcp/components/WindowChrome/CWindowChrome.cpp`](../../dxaml/xcp/components/WindowChrome/CWindowChrome.cpp)
-* InputNonClientPointerSource: See the Windows App SDK documentation for this API.
+* Top-level HWND and window messages:
+  [`dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp`](../../dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp)
+* InputNonClientPointerSource:
+  [Windows App SDK API documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource)
+* AppWindowTitleBar:
+  [Windows App SDK API documentation](https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar)

--- a/dxaml/test/infra/client/lib/WindowHelper.cpp
+++ b/dxaml/test/infra/client/lib/WindowHelper.cpp
@@ -2108,6 +2108,10 @@ std::vector<std::pair<xaml_settings::XamlChangeId, bool>> GetXamlOptionalChanges
             {
                 changeId = xaml_settings::XamlChangeId_DeferContextFlyoutInit;
             }
+            else if (_wcsicmp(name.c_str(), L"AlignExtendsContentIntoTitleBarBehavior") == 0)
+            {
+                changeId = xaml_settings::XamlChangeId_AlignExtendsContentIntoTitleBarBehavior;
+            }
 
             if (changeId == xaml_settings::XamlChangeId__Reserved)
             {
@@ -2188,6 +2192,7 @@ void WindowHelper::InitializeXamlCore(_In_ xaml_markup::IXamlMetadataProvider* c
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_OptimizeApplyStyles, &mutated);
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_DefaultStyleOptimizations, &mutated);
         optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_DeferContextFlyoutInit, &mutated);
+        optionalChangesStatics->EnableChange(xaml_settings::XamlChangeId_AlignExtendsContentIntoTitleBarBehavior, &mutated);
 
         // Apply per-test overrides from XamlOptionalChanges test data.
         for (const auto& [changeId, enabled] : changeOverrides)

--- a/dxaml/test/native/external/controls/window/WindowIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/window/WindowIntegrationTests.cpp
@@ -23,6 +23,44 @@ using namespace test_infra;
 
 namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespace Controls { namespace Window {
 
+namespace
+{
+    HWND FindDesktopChildSiteBridge(HWND parentWindow)
+    {
+        HWND bridgeWindow = nullptr;
+        ::EnumChildWindows(
+            parentWindow,
+            [](HWND childWindow, LPARAM result) -> BOOL
+            {
+                wchar_t className[128]{};
+                if (::GetClassNameW(childWindow, className, ARRAYSIZE(className)) > 0 &&
+                    wcscmp(className, L"Microsoft.UI.Content.DesktopChildSiteBridge") == 0)
+                {
+                    *reinterpret_cast<HWND*>(result) = childWindow;
+                    return FALSE;
+                }
+
+                return TRUE;
+            },
+            reinterpret_cast<LPARAM>(&bridgeWindow));
+
+        return bridgeWindow;
+    }
+
+    int GetDesktopChildSiteBridgeTopOffset(HWND parentWindow)
+    {
+        const HWND bridgeWindow = FindDesktopChildSiteBridge(parentWindow);
+        VERIFY_IS_TRUE(bridgeWindow != nullptr, L"The Window should host XAML in a DesktopChildSiteBridge.");
+
+        POINT clientOrigin{};
+        VERIFY_IS_TRUE(!!::ClientToScreen(parentWindow, &clientOrigin));
+
+        RECT bridgeRect{};
+        VERIFY_IS_TRUE(!!::GetWindowRect(bridgeWindow, &bridgeRect));
+        return bridgeRect.top - clientOrigin.y;
+    }
+}
+
     void LogWindowGeometry(const wchar_t* label, HWND windowHandle, xaml::Window^ window)
     {
         RECT outerRect{};
@@ -271,6 +309,75 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             auto systemBackdropBrush = compositionSupportsSystemBackdrop->SystemBackdrop;
             VERIFY_IS_NOT_NULL(systemBackdropBrush);
         });
+    }
+
+    void WindowIntegrationTests::ECITBEntryPointsReserveTopBorder()
+    {
+        VerifyECITBEntryPointOffsets(true);
+    }
+
+    void WindowIntegrationTests::ECITBEntryPointsPreserveCompatBehavior()
+    {
+        VerifyECITBEntryPointOffsets(false);
+    }
+
+    void WindowIntegrationTests::VerifyECITBEntryPointOffsets(bool expectedChangeEnabled)
+    {
+        TestCleanupWrapper cleanup;
+        const bool isChangeEnabled = xaml_settings::XamlOptionalChanges::IsChangeEnabled(
+            xaml_settings::XamlChangeId::AlignExtendsContentIntoTitleBarBehavior);
+        VERIFY_ARE_EQUAL(expectedChangeEnabled, isChangeEnabled);
+
+        auto createWindow = [&](WindowAutoCloser& window, HWND& windowHandle)
+        {
+            RunOnUIThread([&]()
+            {
+                window.Attach(safe_cast<xaml::Window^>(xaml_markup::XamlReader::Load(
+                    L"<Window xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' "
+                    L"xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+                    L"  <Grid Background='Magenta'/>"
+                    L"</Window>")));
+                window->Activate();
+
+                IWindowNative* windowNative = nullptr;
+                VERIFY_SUCCEEDED(reinterpret_cast<IUnknown*>(window.get())->QueryInterface(
+                    __uuidof(IWindowNative), reinterpret_cast<void**>(&windowNative)));
+                VERIFY_SUCCEEDED(windowNative->get_WindowHandle(&windowHandle));
+                windowNative->Release();
+            });
+            TestServices::WindowHelper->WaitForIdle();
+        };
+        auto verifyTopOffset = [](HWND windowHandle, int expectedOffset, const wchar_t* message)
+        {
+            const int actualOffset = GetDesktopChildSiteBridgeTopOffset(windowHandle);
+            LOG_OUTPUT(L"%s Expected offset=%d, actual offset=%d", message, expectedOffset, actualOffset);
+            VERIFY_ARE_EQUAL(expectedOffset, actualOffset, message);
+        };
+
+        WindowAutoCloser windowEntryPoint;
+        HWND windowEntryPointHandle = nullptr;
+        createWindow(windowEntryPoint, windowEntryPointHandle);
+        verifyTopOffset(windowEntryPointHandle, 0, L"Window ECITB off should place XAML at the client origin.");
+        RunOnUIThread([&]() { windowEntryPoint->ExtendsContentIntoTitleBar = true; });
+        TestServices::WindowHelper->WaitForIdle();
+        verifyTopOffset(windowEntryPointHandle, 1, L"Window ECITB on should reserve the top border.");
+        RunOnUIThread([&]() { windowEntryPoint->ExtendsContentIntoTitleBar = false; });
+        TestServices::WindowHelper->WaitForIdle();
+        verifyTopOffset(windowEntryPointHandle, 0, L"Window ECITB off should remove the top border.");
+
+        WindowAutoCloser appWindowEntryPoint;
+        HWND appWindowEntryPointHandle = nullptr;
+        createWindow(appWindowEntryPoint, appWindowEntryPointHandle);
+        verifyTopOffset(appWindowEntryPointHandle, 0, L"AppWindow ECITB off should place XAML at the client origin.");
+        RunOnUIThread([&]() { appWindowEntryPoint->AppWindow->TitleBar->ExtendsContentIntoTitleBar = true; });
+        TestServices::WindowHelper->WaitForIdle();
+        verifyTopOffset(
+            appWindowEntryPointHandle,
+            isChangeEnabled ? 1 : 0,
+            L"Direct AppWindow ECITB should use the optional-change geometry.");
+        RunOnUIThread([&]() { appWindowEntryPoint->AppWindow->TitleBar->ExtendsContentIntoTitleBar = false; });
+        TestServices::WindowHelper->WaitForIdle();
+        verifyTopOffset(appWindowEntryPointHandle, 0, L"AppWindow ECITB off should remove the top border.");
     }
 
 #ifdef MUX_PRERELEASE

--- a/dxaml/test/native/external/controls/window/WindowIntegrationTests.h
+++ b/dxaml/test/native/external/controls/window/WindowIntegrationTests.h
@@ -56,6 +56,17 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
         END_TEST_METHOD()
 
+        BEGIN_TEST_METHOD(ECITBEntryPointsReserveTopBorder)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates the one-pixel top border reserved by both ECITB entry points.")
+            TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
+        END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(ECITBEntryPointsPreserveCompatBehavior)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates legacy ECITB geometry when the optional change is disabled.")
+            TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
+            TEST_METHOD_PROPERTY(L"Data:XamlOptionalChanges", L"{AlignExtendsContentIntoTitleBarBehavior:false}")
+        END_TEST_METHOD()
+
 #ifdef MUX_PRERELEASE
         // Experimental Width/Height properties on Window are only present in prerelease builds.
         BEGIN_TEST_METHOD(CanGetSetWindowWidthHeight)
@@ -194,6 +205,9 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             TEST_METHOD_PROPERTY(L"Description", L"Validates that the markup-loaded Window content tree is released (not held for the Window's lifetime) once Window.Content is cleared.")
             TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
         END_TEST_METHOD()
+
+    private:
+        void VerifyECITBEntryPointOffsets(bool expectedChangeEnabled);
 
     };
 

--- a/dxaml/xcp/components/WindowChrome/CWindowChrome.cpp
+++ b/dxaml/xcp/components/WindowChrome/CWindowChrome.cpp
@@ -23,6 +23,7 @@
 #include "microsoft.ui.input.h"
 #include "XamlRoot.g.h"
 #include "Value.h"
+#include <OptionalChangeState.h>
 
 using WindowChrome = DirectUI::WindowChrome;
 using VisualTreeHelper = DirectUI::VisualTreeHelper;
@@ -168,8 +169,13 @@ LRESULT CWindowChrome::OnCreate()
 //   and returns it. If the border is disabled, then this method will return 0.
 // Return Value:
 // - the height of the border above the title bar or 0 if it's disabled
-int CWindowChrome::GetTopBorderHeight() const noexcept
+int CWindowChrome::GetTopBorderHeight()
 {
+    if (OptionalChangeState::ShouldAlignExtendsContentIntoTitleBarBehavior())
+    {
+        return GetAlignedTopBorderHeight();
+    }
+
     // No border when maximized, or when the titlebar is invisible (by being in
     // fullscreen or focus mode).
     if (!IsTitlebarVisible() || IsMaximized(m_topLevelWindow))
@@ -190,6 +196,78 @@ int CWindowChrome::GetTopBorderHeight() const noexcept
 bool CWindowChrome::IsTitlebarVisible() const
 {
     return IsChromeActive();
+}
+
+int CWindowChrome::GetAlignedTopBorderHeight()
+{
+    ASSERT(OptionalChangeState::ShouldAlignExtendsContentIntoTitleBarBehavior());
+
+    // Match the existing Window.ExtendsContentIntoTitleBar geometry, but use
+    // AppWindow as the source so a direct AppWindow assignment is understood.
+    if (!IsAppWindowTitleBarExtended() || IsMaximized(m_topLevelWindow))
+    {
+        return 0;
+    }
+
+    return topBorderVisibleHeight;
+}
+
+bool CWindowChrome::IsAppWindowTitleBarExtended()
+{
+    bool extendsContentIntoTitleBar = false;
+    IFCFAILFAST(GetPeer()->GetIsAppWindowTitleBarExtended(&extendsContentIntoTitleBar));
+    return extendsContentIntoTitleBar;
+}
+
+_Check_return_ HRESULT CWindowChrome::UpdateDwmFrameMargins(int topBorderHeight)
+{
+    ASSERT(WindowHelpers::ShouldApplyDwmTopBorderWorkaround(m_topLevelWindow));
+
+    int topFrameMargin = 0;
+    if (topBorderHeight > 0)
+    {
+        RECT frame = {};
+        const UINT dpi = ::GetDpiForWindow(m_topLevelWindow);
+        const DWORD style = static_cast<DWORD>(::GetWindowLongPtrW(m_topLevelWindow, GWL_STYLE));
+        const DWORD exStyle = static_cast<DWORD>(::GetWindowLongPtrW(m_topLevelWindow, GWL_EXSTYLE));
+
+        IFCW32_RETURN(::AdjustWindowRectExForDpi(
+            &frame,
+            style,
+            ::GetMenu(m_topLevelWindow) != nullptr,
+            exStyle,
+            dpi));
+
+        // Windows 10 needs the complete top frame extended into the client area.
+        // Extending only the uncovered row gives incorrect inactive-window colors.
+        topFrameMargin = static_cast<int>(std::max<LONG>(-frame.top, topBorderVisibleHeight));
+    }
+
+    if ((!m_appliedDwmTopFrameMargin && topFrameMargin == 0) ||
+        (m_appliedDwmTopFrameMargin && *m_appliedDwmTopFrameMargin == topFrameMargin))
+    {
+        // WinUI has not changed the margins for this window, or the WinUI-owned
+        // value is already current. Do not issue an unnecessary all-margin write.
+        return S_OK;
+    }
+
+    // DwmExtendFrameIntoClientArea writes all four margins and has no getter.
+    // Once WinUI reserves this row, it owns the complete margin set for the
+    // window. A zero value clears that WinUI-owned set when the row is removed.
+    MARGINS margins = {};
+    margins.cyTopHeight = topFrameMargin;
+    IFC_RETURN(::DwmExtendFrameIntoClientArea(m_topLevelWindow, &margins));
+
+    if (topFrameMargin > 0)
+    {
+        m_appliedDwmTopFrameMargin = topFrameMargin;
+    }
+    else
+    {
+        m_appliedDwmTopFrameMargin.reset();
+    }
+
+    return S_OK;
 }
 
 void CWindowChrome::UpdateContainerSize(WPARAM wParam, LPARAM lParam)
@@ -223,6 +301,12 @@ void CWindowChrome::UpdateBridgeWindowSizePosition()
     const auto windowWidth = RectHelpers::rectWidth(clientRect);
     const auto windowHeight = RectHelpers::rectHeight(clientRect);
     const auto topBorderHeight = WindowHelpers::ClampToShortMax(GetTopBorderHeight(), 0);
+
+    if (WindowHelpers::ShouldApplyDwmTopBorderWorkaround(m_topLevelWindow))
+    {
+        TRACE_HR_NORETURN(UpdateDwmFrameMargins(topBorderHeight));
+    }
+
     const COORD newIslandPos = { 0, topBorderHeight };
     
 

--- a/dxaml/xcp/components/WindowChrome/WindowHelpers.cpp
+++ b/dxaml/xcp/components/WindowChrome/WindowHelpers.cpp
@@ -6,6 +6,8 @@
 #include "uielement.h"
 #include "contentroot.h"
 #include "VisualTree.h"
+#include <OptionalChangeState.h>
+#include <dwmapi.h>
 
 SIZE WindowHelpers::GetPhysicalSize(HWND hwnd) noexcept
 {
@@ -107,6 +109,31 @@ short WindowHelpers::ClampToShortMax(const long value, const short min) noexcept
     return static_cast<short>(std::clamp(value,
         static_cast<long>(min),
         static_cast<long>(SHRT_MAX)));
+}
+
+bool WindowHelpers::ShouldApplyDwmTopBorderWorkaround(HWND hwnd) noexcept
+{
+    if (!OptionalChangeState::ShouldAlignExtendsContentIntoTitleBarBehavior())
+    {
+        return false;
+    }
+
+    // This documented getter is available when DWM owns the visible frame
+    // border behavior introduced in Windows 11. Support is process-wide, so
+    // query it once using the first top-level HWND. Older DWM versions return
+    // E_INVALIDARG and need the extended-frame workaround.
+    static const bool shouldApplyWorkaround = [hwnd]()
+    {
+        UINT borderThickness = 0;
+        const HRESULT result = ::DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
+            &borderThickness,
+            sizeof(borderThickness));
+        return result == E_INVALIDARG;
+    }();
+
+    return shouldApplyWorkaround;
 }
 
 // gets client logical rect for a given ui element

--- a/dxaml/xcp/components/WindowChrome/inc/CWindowChrome.h
+++ b/dxaml/xcp/components/WindowChrome/inc/CWindowChrome.h
@@ -63,9 +63,8 @@ public:
     ctl::ComPtr<DirectUI::WindowChrome> GetPeer();
     _Check_return_ HRESULT SetIsChromeActive(bool isActive);
     bool IsChromeActive() const  { return m_bIsActive; }
-
     bool IsTitlebarVisible() const;
-    int GetTopBorderHeight() const noexcept;
+    int GetTopBorderHeight();
     _Check_return_ HRESULT ConfigureWindowChrome();
     _Check_return_ HRESULT ApplyStyling();
     _Check_return_ HRESULT SetFocusIfNeeded();
@@ -85,6 +84,11 @@ private:
     // as the custom titlebar's glass window would otherwise intercept input to it and make it inoperable
     HRESULT RefreshToolbarOffset();
     
+    int GetAlignedTopBorderHeight();
+    bool IsAppWindowTitleBarExtended();
+    _Check_return_ HRESULT UpdateDwmFrameMargins(int topBorderHeight);
+
+    // Tracks Window.ExtendsContentIntoTitleBar.
     bool m_bIsActive = false;
     HWND m_topLevelWindow = NULL;
     bool m_enabledDrag = true;
@@ -92,5 +96,6 @@ private:
     RECT m_dragRegionCached{};
     wgr::RectInt32 m_scaledDragRegionCached{};
     bool m_isDefaultCaptionButtonStyleSet = false; // do it only the first time window chrome is created
+    std::optional<int> m_appliedDwmTopFrameMargin;
     
 };

--- a/dxaml/xcp/components/WindowChrome/inc/WindowHelpers.h
+++ b/dxaml/xcp/components/WindowChrome/inc/WindowHelpers.h
@@ -42,6 +42,7 @@ namespace WindowHelpers
     wf::Point ClientPhysicaltoLogicalPoint(HWND targetWindow,  wf::Point physicalPt) noexcept;
     wf::Point ScreenPhysicaltoClientLogicalPoint(HWND targetWindow,  wf::Point physicalPt) noexcept;
     short ClampToShortMax(const long value, const short min) noexcept;
+    bool ShouldApplyDwmTopBorderWorkaround(HWND hwnd) noexcept;
 
     RECT GetClientAreaLogicalRectForUIElement(_In_ CUIElement* uiElement) noexcept;
     RECT GetClientAreaPhysicalRectForUIElement(_In_ CUIElement* uiElement, float scale) noexcept;

--- a/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
+++ b/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
@@ -2212,6 +2212,7 @@ namespace DirectUI
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        AlignExtendsContentIntoTitleBarBehavior = 8948,
     };
     DEFINE_ENUM_FLAG_OPERATORS(XamlChangeId);
 

--- a/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
@@ -28,6 +28,7 @@ namespace OptionalChangeState
     constexpr int BitIndex_OptimizeApplyStyles = 1;
     constexpr int BitIndex_DefaultStyleOptimizations = 2;
     constexpr int BitIndex_DeferContextFlyoutInit = 3;
+    constexpr int BitIndex_AlignExtendsContentIntoTitleBarBehavior = 4;
 
     inline bool IsOptionalChangeEnabled(int bitIndex)
     {
@@ -53,5 +54,10 @@ namespace OptionalChangeState
     inline bool IsDeferContextFlyoutInitEnabled()
     {
         return IsOptionalChangeEnabled(BitIndex_DeferContextFlyoutInit) || IsPerfOptInEnabled();
+    }
+
+    inline bool ShouldAlignExtendsContentIntoTitleBarBehavior()
+    {
+        return IsOptionalChangeEnabled(BitIndex_AlignExtendsContentIntoTitleBarBehavior);
     }
 }

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
@@ -520,6 +520,7 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        AlignExtendsContentIntoTitleBarBehavior = 8948,
     };
 }
 

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
@@ -21,10 +21,12 @@
 #include "XamlTelemetry.h"
 #include <Theme.h>
 #include <dwmapi.h>
+#include <uxtheme.h>
 #include <windowing.h>
 #include "Microsoft.UI.Windowing.h"
 #include <FrameworkUdk/Theming.h>
 #include <Microsoft.UI.Interop.h>
+#include <OptionalChangeState.h>
 
 #pragma warning(disable:4267) //'var' : conversion from 'size_t' to 'type', possible loss of data
 
@@ -164,6 +166,14 @@ DesktopWindowImpl::~DesktopWindowImpl()
         VERIFYHR(m_dxamlWindowInstance->SetTitleBar(nullptr));
         VERIFYHR(m_dxamlWindowInstance->put_Content(nullptr));
         Shutdown();
+    }
+
+    // This balances the initialization used only by the redirected-GDI ECITB border
+    // path below. If the top-level HWND stops using a GDI redirection bitmap, remove
+    // this teardown together with that path.
+    if (m_isBufferedPaintInitialized)
+    {
+        VERIFYHR(::BufferedPaintUnInit());
     }
 }
 
@@ -1203,6 +1213,84 @@ LRESULT LResultFromHResult(HRESULT hr)
     return 0;
 }
 
+bool DesktopWindowImpl::TryEraseBackgroundForWindowTopBorder(HDC hdc, COLORREF backgroundColor)
+{
+    ASSERT(WindowHelpers::ShouldApplyDwmTopBorderWorkaround(m_hwnd.get()));
+
+    const int topBorderHeight = m_windowChrome ? m_windowChrome->GetTopBorderHeight() : 0;
+    const RECT rc = WindowHelpers::GetClientWindowCoordinates(m_hwnd.get());
+
+    if (topBorderHeight <= 0 ||
+        (rc.top + topBorderHeight) > rc.bottom ||
+        (::GetWindowLongPtrW(m_hwnd.get(), GWL_EXSTYLE) & WS_EX_NOREDIRECTIONBITMAP) != 0)
+    {
+        return false;
+    }
+
+    // The redirected surface must be opaque under the composition island and
+    // alpha zero in the row reserved for the DWM frame. A composition-only host
+    // has no redirected surface, so the style check above skips this path.
+    if (!m_isBufferedPaintInitialized)
+    {
+        const HRESULT initializeResult = ::BufferedPaintInit();
+        if (FAILED(initializeResult))
+        {
+            TRACE_HR_NORETURN(initializeResult);
+            return false;
+        }
+
+        m_isBufferedPaintInitialized = true;
+    }
+
+    HDC bufferedHdc = nullptr;
+    const auto paintBuffer = ::BeginBufferedPaint(
+        hdc,
+        &rc,
+        BPBF_TOPDOWNDIB,
+        nullptr,
+        &bufferedHdc);
+    if (!paintBuffer)
+    {
+        TRACE_HR_NORETURN(E_FAIL);
+        return false;
+    }
+
+    auto discardPaintBuffer = wil::scope_exit([paintBuffer]()
+    {
+        TRACE_HR_NORETURN(::EndBufferedPaint(paintBuffer, FALSE));
+    });
+
+    auto oldColor = ::SetBkColor(bufferedHdc, backgroundColor);
+    ASSERT(oldColor != CLR_INVALID);
+    ::ExtTextOut(bufferedHdc, 0, 0, ETO_OPAQUE, &rc, NULL, 0, NULL);
+
+    RECT borderRect = rc;
+    borderRect.bottom = rc.top + topBorderHeight;
+    ::SetBkColor(bufferedHdc, RGB(0, 0, 0));
+    ::ExtTextOut(bufferedHdc, 0, 0, ETO_OPAQUE, &borderRect, NULL, 0, NULL);
+    ::SetBkColor(bufferedHdc, oldColor);
+
+    const HRESULT opaqueResult = ::BufferedPaintSetAlpha(paintBuffer, &rc, 255);
+    const HRESULT transparentResult = SUCCEEDED(opaqueResult)
+        ? ::BufferedPaintSetAlpha(paintBuffer, &borderRect, 0)
+        : opaqueResult;
+    if (FAILED(opaqueResult) || FAILED(transparentResult))
+    {
+        TRACE_HR_NORETURN(FAILED(opaqueResult) ? opaqueResult : transparentResult);
+        return false;
+    }
+
+    discardPaintBuffer.release();
+    const HRESULT endResult = ::EndBufferedPaint(paintBuffer, TRUE);
+    if (FAILED(endResult))
+    {
+        TRACE_HR_NORETURN(endResult);
+        return false;
+    }
+
+    return true;
+}
+
 LRESULT DesktopWindowImpl::OnMessage(
     UINT uMsg,
     WPARAM wParam,
@@ -1270,6 +1358,14 @@ LRESULT DesktopWindowImpl::OnMessage(
 
             auto hdc = (HDC)wParam;
             auto color = ColorUtils::GetWUColor(dxamlCore->GetHandle()->GetFrameworkTheming()->GetHwndBackground(appTheme));
+            if (WindowHelpers::ShouldApplyDwmTopBorderWorkaround(m_hwnd.get()))
+            {
+                if (TryEraseBackgroundForWindowTopBorder(hdc, RGB(color.R, color.G, color.B)))
+                {
+                    return 1;
+                }
+            }
+
             RECT rc = WindowHelpers::GetClientWindowCoordinates(m_hwnd.get());
             auto oldColor  = ::SetBkColor(hdc, RGB(color.R, color.G, color.B));
             ASSERT(oldColor != CLR_INVALID);

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.h
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.h
@@ -140,6 +140,7 @@ namespace DirectUI
         void OpenSystemMenu(const int cursorX, const int cursorY) const noexcept;
         _Check_return_ HRESULT OnNonClientRegionButtonUp(WPARAM wParam, const int cursorX, const int cursorY);
         _Check_return_ HRESULT OnClosed();
+        bool TryEraseBackgroundForWindowTopBorder(HDC hdc, COLORREF backgroundColor);
 
         void OnSetFocus();
         void RegisterDesktopWindowClass();
@@ -305,5 +306,7 @@ namespace DirectUI
         ctl::ComPtr<xaml::IAtlasRequestCallback> m_atlasRequestCallback;
         ctl::ComPtr<DirectUI::WindowChrome> m_windowChrome;
         ctl::ComPtr<DirectUI::DesktopWindowXamlSource> m_desktopWindowXamlSource;
+        // Only needed while the top-level HWND uses its GDI redirection bitmap.
+        bool m_isBufferedPaintInitialized = false;
     };
 }

--- a/dxaml/xcp/dxaml/lib/WindowChrome_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/WindowChrome_Partial.cpp
@@ -201,6 +201,33 @@ ctl::ComPtr<ixp::IAppWindow> WindowChrome::GetAppWindow() const
     return appWindow;
 }
 
+_Check_return_ HRESULT WindowChrome::GetIsAppWindowTitleBarExtended(_Out_ bool* value) const
+{
+    *value = false;
+
+    // Window messages can reenter while the Window is being created or torn
+    // down. A missing DesktopWindow or AppWindow means ECITB is not active.
+    if (!m_desktopWindow)
+    {
+        return S_OK;
+    }
+
+    ctl::ComPtr<ixp::IAppWindow> appWindow;
+    IFC_RETURN(m_desktopWindow->get_AppWindowImpl(&appWindow));
+    if (!appWindow)
+    {
+        return S_OK;
+    }
+
+    ctl::ComPtr<ixp::IAppWindowTitleBar> appWindowTitleBar;
+    IFC_RETURN(appWindow->get_TitleBar(&appWindowTitleBar));
+
+    boolean extendsContentIntoTitleBar = false;
+    IFC_RETURN(appWindowTitleBar->get_ExtendsContentIntoTitleBar(&extendsContentIntoTitleBar));
+    *value = !!extendsContentIntoTitleBar;
+    return S_OK;
+}
+
 bool WindowChrome::CanDrag() const
 {
     CWindowChrome* coreWindowChrome = static_cast<CWindowChrome*>(GetHandle());
@@ -209,6 +236,12 @@ bool WindowChrome::CanDrag() const
         return coreWindowChrome->CanDrag();
     }
     return false;
+}
+
+int WindowChrome::GetTopBorderHeight()
+{
+    const auto chrome = static_cast<CWindowChrome*>(GetHandle());
+    return chrome ? chrome->GetTopBorderHeight() : 0;
 }
 
 void WindowChrome::UpdateCanDragStatus(bool enabled)

--- a/dxaml/xcp/dxaml/lib/WindowChrome_Partial.h
+++ b/dxaml/xcp/dxaml/lib/WindowChrome_Partial.h
@@ -27,7 +27,9 @@ namespace DirectUI
         DesktopWindowImpl* GetDesktopWindowNoRef() const { return m_desktopWindow; }
         HWND GetPositioningBridgeWindowHandle() const;
         ctl::ComPtr<ixp::IAppWindow> GetAppWindow() const;
+        _Check_return_ HRESULT GetIsAppWindowTitleBarExtended(_Out_ bool* value) const;
         bool CanDrag() const;
+        int GetTopBorderHeight();
         void UpdateCanDragStatus(bool enabled);
 
         template <typename T>

--- a/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
@@ -44,6 +44,8 @@ static int GetBitIndex(xaml_settings::XamlChangeId id)
         return OptionalChangeState::BitIndex_DefaultStyleOptimizations;
     case xaml_settings::XamlChangeId_DeferContextFlyoutInit:
         return OptionalChangeState::BitIndex_DeferContextFlyoutInit;
+    case xaml_settings::XamlChangeId_AlignExtendsContentIntoTitleBarBehavior:
+        return OptionalChangeState::BitIndex_AlignExtendsContentIntoTitleBarBehavior;
     default:
         return -1;
     }

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
@@ -20,6 +20,7 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        AlignExtendsContentIntoTitleBarBehavior = 8948,
     }
 
     // Provides static methods to opt in to or out of individual breaking or


### PR DESCRIPTION
*This content was largely generated by AI.  AI makes mistakes.*

## Fixes

Fixes #8948

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

### Current Behavior

On Windows 10, extending content into the title bar can leave the native top
window border missing or covered:

- `Window.ExtendsContentIntoTitleBar = true` reserves one physical pixel above
  the XAML child window, but `WM_ERASEBKGND` paints that row opaque.
- `AppWindow.TitleBar.ExtendsContentIntoTitleBar = true` does not update
  WinUI's local `WindowChrome` state, so the XAML child window starts at the
  client origin and covers the row completely.

The two public entry points therefore produce different geometry on every OS.
On Windows 10, neither path shows the correct DWM-composited top border.

### New Behavior

The default-off `AlignExtendsContentIntoTitleBarBehavior` optional change has
two isolated parts:

- **API alignment:** when calculating the existing one-pixel top-border
  geometry, read `AppWindow.TitleBar.ExtendsContentIntoTitleBar` so a direct
  AppWindow assignment is understood.
- **Legacy DWM rendering alignment:** when DWM does not support querying
  `DWMWA_VISIBLE_FRAME_BORDER_THICKNESS`, extend the complete top DWM frame into
  the client area and use a 32-bit buffered erase surface. Normal client pixels
  remain opaque while the reserved row has alpha zero.

On the legacy path, the buffered erase is skipped for a window created with
`WS_EX_NOREDIRECTIONBITMAP`, which has no redirected surface to modify.

The existing behavior remains unchanged when the optional change is disabled.
The new behaviors are isolated behind small helpers and simple `if` statements
so they can be contained independently later.

## Customer Impact

- `Window` and `AppWindow` use the same established one-pixel geometry when the
  optional change is enabled.
- Windows 10 exposes that row to DWM instead of showing an opaque app-colored
  stripe.
- Windows 11 keeps its existing DWM rendering path, including when square
  corners are requested.

### Compatibility

- The optional change is disabled by default.
- The geometry change follows the existing
  `Window.ExtendsContentIntoTitleBar` rules rather than introducing new
  presenter behavior.
- On the legacy path, buffered-paint failures fall back to the existing opaque
  erase path rather than terminating the process.
- A window that never reserves the row keeps app-owned DWM margins untouched.

`DwmExtendFrameIntoClientArea` sets all four margins and does not expose a
getter. On the legacy path, once this opt-in reserves the row on a window,
WinUI owns that window's complete frame-margin set, sets the non-top margins to
zero, and clears all four margins when the row is removed.

### Out of Scope

[Issue #8948 also reports a missing border in Windows 11 High Contrast](https://github.com/microsoft/microsoft-ui-xaml/issues/8948#issuecomment-1748069008).
This change does not alter Windows 11 DWM rendering and does not attempt to fix
that separate High Contrast behavior. Testing reproduces the missing border:
with this PR and the change enabled, the AppWindow content geometry is aligned
but the Windows 11 High Contrast top-border rendering remains unchanged.

## Regression Potential

- [ ] Low risk - isolated change, limited scope
- [x] Medium risk - touches shared components or public APIs
- [ ] High risk - architectural or breaking API change

The behavior is default-off and the compatibility path remains visible and
unchanged beneath the new gates.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

### Automated

- x64chk product and test build succeeded.
- The `*ECITB*` selection passed 6/6 on Windows 10 1809 and 6/6 on
  Windows 11 build 26683 using the same x64chk payload.
- The geometry tests use separate windows for the `Window` and `AppWindow`
  entry points and verify both optional-change states.

### DWM Capability

The rendering gate queries `DWMWA_VISIBLE_FRAME_BORDER_THICKNESS` on a real
WinUI HWND:

| Environment | Result |
|---|---|
| Windows 10 1809, build 17763 | `E_INVALIDARG`; use the legacy DWM workaround |
| Windows 11, build 26657, VM with square corners | `S_OK`, thickness `1`; keep the existing DWM path |

`DWMWA_WINDOW_CORNER_PREFERENCE` was set to `DWMWCP_DONOTROUND` successfully on
build 26657 and read back as preference `1`. That readback reports the requested
preference, not the effective rendered shape; the VM is also square-cornered by
DWM policy. The visible-frame capability remained available, so the gate does
not depend on whether corners are rounded.

### Visual

- On Windows 10 1809, the exact built DLL passed the full matrix: both API
  entry points and active and inactive states. With the change enabled, both
  APIs show a DWM-rendered top border above the first XAML row.
- On Windows 11 build 26683, the `Window` path remains visually unchanged.
  The aligned `AppWindow` geometry preserves the first XAML row while leaving
  the OS-rendered border unchanged.

### High Contrast

A dedicated repro makes the first XAML row bright green and the remaining
content magenta. This makes both the border row and a content row hidden by DWM
visible in screenshots and measurable by exact pixel color.

| Environment | Current behavior | With this PR (change enabled) |
|---|---|---|
| Windows 10 1809, `Window` API | Black opaque row, then the green XAML row | White top-border row, then the green XAML row |
| Windows 10 1809, `AppWindow` API | No border row; green begins at the window edge | White top-border row, then the green XAML row |
| Windows 11 build 26683, `Window` API | Black/missing top-border row, then the green XAML row | Unchanged |
| Windows 11 build 26683, `AppWindow` API | Black/missing top-border row covers the green XAML row | Geometry alignment preserves the green XAML row; top border remains unchanged |

Both VMs were restored to their original non-High-Contrast state after capture.

## Screenshots

### Root Causes

<!-- PR_MEDIA:media/root-causes.png -->
![Diagram showing the two independent root causes and their fixes](https://github.com/user-attachments/assets/d66adb18-7871-401e-a143-2d6a9c28279f)

### Normal Contrast

Each panel below is cropped from a fresh full-desktop screen capture, not from
a window-only capture. The 100-by-100 source-pixel crop begins 10 pixels above
and left of the outer window. It is scaled 4x with nearest-neighbor sampling.
Black is the controlled backdrop. The green band is exactly one physical pixel
and marks the first row of XAML content.

<!-- PR_MEDIA:media/all-scenarios.png -->
![Normal contrast complete outer-corner close-ups for both APIs on Windows 10 and Windows 11](https://github.com/user-attachments/assets/51731c45-73f0-495f-a813-983118fcb9e6)

On Windows 10, current `Window` behavior shows a white
`WM_ERASEBKGND` app-background row that does not match the gray native
left frame. That white row is present in both active and inactive states.
Current `AppWindow` behavior has no top row at all. With this PR, both APIs show
a top frame line that matches the left frame above the green XAML row. Against
the black backdrop, the change-enabled top and inner left frame pixels are both
`RGB(43, 43, 43)`. The second matrix confirms the result in both activation
states.

<!-- PR_MEDIA:media/before-after-active-inactive.png -->
![Windows 10 normal contrast top-left close-ups in active and inactive states](https://github.com/user-attachments/assets/f5b3de57-04e0-475b-bdff-9ffc7f05bd5b)

### High Contrast

<!-- PR_MEDIA:media/high-contrast-matrix.png -->
![High Contrast complete outer-corner close-ups for both APIs on Windows 10 and Windows 11](https://github.com/user-attachments/assets/e883f796-cf46-4e09-8225-01a37f3fdb37)

The Windows 10 change-enabled path shows the white High Contrast border above
the green XAML row for both APIs, joined to the white left frame. On Windows 11,
the `AppWindow` path preserves the green row, while the separately reported
missing High Contrast border remains unchanged.

<!-- PR_MEDIA:media/high-contrast-top-row-zoom.png -->
![Windows 10 High Contrast top-left close-ups in active and inactive states](https://github.com/user-attachments/assets/c2ff6e8b-8f11-413c-86ed-2695137a4948)

## Reviewer Note

`XamlChangeId.AlignExtendsContentIntoTitleBarBehavior` currently uses `8948`,
the GitHub issue number. Existing optional changes use internal tracking IDs, so
this value should be confirmed before the API is finalized.