### PR TITLE
InkCanvas: custom drying (app-rendered dry ink via InkPresenter.Activ…

### DIFF
--- a/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml
+++ b/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml
@@ -24,7 +24,14 @@
             </Grid.RowDefinitions>
             <controls:InkToolbar x:Name="Toolbar" Grid.Row="0" Margin="0,0,0,6" />
             <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" Background="White">
-                <controls:InkCanvas x:Name="InkSurface" />
+                <Grid>
+                    <controls:InkCanvas x:Name="InkSurface" />
+                    <!-- App-owned dry-ink layer. While custom drying is active the app draws the dried
+                         strokes here (red polylines) via InkSynchronizer.BeginDry. A plain Canvas (not a
+                         second InkCanvas) avoids a second compositor splice. IsHitTestVisible=False lets pen
+                         input pass through to InkSurface below. -->
+                    <Canvas x:Name="DryOverlay" IsHitTestVisible="False" SizeChanged="OnDryOverlaySizeChanged" />
+                </Grid>
             </Border>
         </Grid>
 
@@ -88,6 +95,16 @@
                            Text="draw / erase to see events..." />
                 <TextBlock x:Name="EventLogText" TextWrapping="Wrap" IsTextSelectionEnabled="True"
                            FontFamily="Consolas" FontSize="11" />
+
+                <!-- Custom drying (WIP): the app takes over rendering of committed ink via InkSynchronizer.
+                     Activate, then draw: each StrokesCollected calls BeginDry() (the just-committed strokes)
+                     then EndDry(). If BeginDry returns 0 the OS capture-inside-notification did not land
+                     (the known gap this PR is for). -->
+                <TextBlock Text="Custom drying (WIP)" FontWeight="SemiBold" />
+                <ToggleSwitch x:Name="CustomDryToggle" Header="Activate custom drying"
+                              OnContent="Active" OffContent="Off" Toggled="OnCustomDryToggled" />
+                <TextBlock x:Name="CustomDryText" TextWrapping="Wrap" FontFamily="Consolas" FontSize="12"
+                           Text="off - activate, then draw a stroke" />
 
                 <TextBlock Text="Log" FontWeight="SemiBold" />
                 <TextBlock x:Name="LogText" TextWrapping="Wrap" IsTextSelectionEnabled="True"

--- a/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
+++ b/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
@@ -75,6 +75,10 @@ namespace ScratchPadApp
                     _inkSynchronizer = InkSurface.InkPresenter.ActivateCustomDrying();
                     _customDryActive = _inkSynchronizer != null;
                     App.Log("STARTUP ActivateCustomDrying -> " + (_customDryActive ? "OK (non-null)" : "returned null"));
+                    CustomDryToggle.IsOn = _customDryActive;
+                    CustomDryText.Text = _customDryActive
+                        ? "activated at startup - draw a stroke; BeginDry/EndDry run on each collection"
+                        : "ActivateCustomDrying returned null";
                 }
                 catch (Exception ex)
                 {

--- a/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
+++ b/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
@@ -290,14 +290,11 @@ namespace ScratchPadApp
                 }
 
                 _inkSynchronizer.EndDry();
-                // Verify the originals were actually removed from InkCanvas (not just covered by the red).
-                int surfaceLeft = InkSurface.InkPresenter.StrokeContainer.GetStrokes().Count;
                 CustomDryText.Text =
                     $"collection #{_customDryCollections}: app rendered {n} stroke(s) (tinted)" +
                     (n == 0 ? "  <- EMPTY" : "") +
-                    $"\ntotal dried = {_customDryStrokesTotal}" +
-                    $"\nInkCanvas now holds {surfaceLeft} (expect 0 = removed)";
-                App.Log($"CustomDry BeginDry={n}, app-rendered, EndDry ok; InkSurface container = {surfaceLeft}");
+                    $"\ntotal dried = {_customDryStrokesTotal}";
+                App.Log($"CustomDry BeginDry={n}, app-rendered, EndDry ok");
             }
             catch (Exception ex)
             {

--- a/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
+++ b/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
@@ -60,17 +60,15 @@ namespace ScratchPadApp
             // re-attaches it at runtime so we can compare without reinstalling.
             // (Toolbar.TargetInkCanvas is left null here; the toggle sets it.)
 
-            // Enable ALL input devices AFTER the toolbar wires up, and again once each is loaded, so a
-            // mouse/touch-only device (e.g. a VM with no pen) can ink.
+            // Enable ALL input devices once. The InkPresenter is a stable instance that caches this, so it
+            // does not need re-applying as the toolbar / canvas load.
             ApplyInputDeviceTypes();
             Toolbar.Loaded += (s, e) =>
             {
-                ApplyInputDeviceTypes();
                 App.Log("Toolbar.Loaded ActiveTool=" + (Toolbar.ActiveTool?.GetType().Name ?? "null"));
             };
             InkSurface.Loaded += (s, e) =>
             {
-                ApplyInputDeviceTypes();
                 App.Log($"InkSurface.Loaded size = {InkSurface.ActualWidth} x {InkSurface.ActualHeight}");
             };
             // Diagnostic: log raw pointer input reaching the canvas (handledEventsToo=true so we see it
@@ -120,6 +118,16 @@ namespace ScratchPadApp
         private void InkPresenter_StrokesCollected(Microsoft.UI.Xaml.Controls.InkPresenter sender, Microsoft.UI.Xaml.Controls.InkStrokesCollectedEventArgs args)
         {
             App.Log("StrokesCollected fired: " + (args?.Strokes?.Count ?? 0) + " strokes");
+
+            // Custom drying: bracket the app's own rendering of the just-committed strokes. BeginDry hands
+            // back the strokes the presenter committed (a real app renders them itself here); EndDry
+            // releases the wet-ink layer. A returned count of 0 means the OS BeginDry capture (only valid
+            // inside this notification) did not land - the known gap this PR is about.
+            if (_customDryActive && _inkSynchronizer != null)
+            {
+                CustomDryStep();
+            }
+
             if (args?.Strokes == null) return;
 
             StrokeSample last = null;
@@ -141,6 +149,15 @@ namespace ScratchPadApp
         private int _pointerPressedCount, _pointerMovedCount, _pointerReleasedCount, _pointerHoveredCount,
                     _pointerEnteredCount, _pointerExitedCount, _pointerLostCount;
         private readonly List<string> _eventLog = new List<string>();
+
+        // Custom drying (WIP): the synchronizer handed back by ActivateCustomDrying + running counters.
+        private Microsoft.UI.Xaml.Controls.InkSynchronizer _inkSynchronizer;
+        private bool _customDryActive;
+        private int _customDryCollections;
+        private int _customDryStrokesTotal;
+
+        // Constant tint the app paints dried strokes with; created once, not per collection.
+        private readonly SolidColorBrush _customDryTint = new SolidColorBrush(Windows.UI.Color.FromArgb(0xFF, 0xC0, 0x30, 0x30));
 
         // Subscribes to every event this PR adds. The high-frequency events (StrokeContinued,
         // PointerMoved, PointerHovered) are counted only; the rest are also written to a short log.
@@ -199,6 +216,94 @@ namespace ScratchPadApp
                     ? Microsoft.UI.Xaml.Controls.InkInputProcessingMode.None
                     : Microsoft.UI.Xaml.Controls.InkInputProcessingMode.Inking;
             App.Log("InputProcessingMode = " + InkSurface.InkPresenter.InputProcessingConfiguration.Mode);
+        }
+
+        // Activate custom drying: the app takes over rendering of committed ("dry") ink. Once active,
+        // each StrokesCollected brackets the app's rendering with InkSynchronizer.BeginDry()/EndDry().
+        private void OnCustomDryToggled(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CustomDryToggle.IsOn)
+                {
+                    _inkSynchronizer = InkSurface.InkPresenter.ActivateCustomDrying();
+                    _customDryActive = _inkSynchronizer != null;
+                    _customDryCollections = 0;
+                    _customDryStrokesTotal = 0;
+                    CustomDryText.Text = _customDryActive
+                        ? "activated - draw a stroke; BeginDry/EndDry run on each collection"
+                        : "ActivateCustomDrying returned null";
+                    App.Log("Custom drying activated: " + _customDryActive);
+                }
+                else
+                {
+                    _customDryActive = false;
+                    _inkSynchronizer = null;
+                    CustomDryText.Text = "off";
+                    App.Log("Custom drying deactivated");
+                }
+            }
+            catch (Exception ex)
+            {
+                _customDryActive = false;
+                CustomDryText.Text = "ActivateCustomDrying failed: " + ex.Message;
+                App.Log("Custom drying activate failed: " + ex.Message);
+            }
+        }
+
+        // Clip the dry-ink overlay to its own bounds so app-rendered strokes that leave the canvas (a
+        // stroke keeps drawing once the pointer is captured) do not paint across the neighboring panel.
+        private void OnDryOverlaySizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            DryOverlay.Clip = new RectangleGeometry
+            {
+                Rect = new Windows.Foundation.Rect(0, 0, e.NewSize.Width, e.NewSize.Height)
+            };
+        }
+
+        // Runs from StrokesCollected while custom drying is active: BeginDry returns the strokes the
+        // presenter just committed (a real app renders them itself), then EndDry releases the wet layer.
+        private void CustomDryStep()
+        {
+            try
+            {
+                var dryStrokes = _inkSynchronizer.BeginDry();
+                int n = dryStrokes?.Count ?? 0;
+                _customDryCollections++;
+                _customDryStrokesTotal += n;
+
+                // The app renders the dried strokes itself - the whole point of custom drying. Draw each as
+                // a red polyline on our own overlay Canvas, so it is visibly the app (not InkCanvas) drawing
+                // the committed ink.
+                if (n > 0)
+                {
+                    foreach (var stroke in dryStrokes)
+                    {
+                        var pts = stroke.GetInkPoints();
+                        if (pts == null || pts.Count < 2) { continue; }
+                        var poly = new Microsoft.UI.Xaml.Shapes.Polyline { Stroke = _customDryTint, StrokeThickness = System.Math.Max(1.5, stroke.DrawingAttributes.Size.Width) };
+                        var pc = new PointCollection();
+                        foreach (var ip in pts) { pc.Add(ip.Position); }
+                        poly.Points = pc;
+                        DryOverlay.Children.Add(poly);
+                    }
+                }
+
+                _inkSynchronizer.EndDry();
+                // Verify the originals were actually removed from InkCanvas (not just covered by the red).
+                int surfaceLeft = InkSurface.InkPresenter.StrokeContainer.GetStrokes().Count;
+                CustomDryText.Text =
+                    $"collection #{_customDryCollections}: app rendered {n} stroke(s) (tinted)" +
+                    (n == 0 ? "  <- EMPTY" : "") +
+                    $"\ntotal dried = {_customDryStrokesTotal}" +
+                    $"\nInkCanvas now holds {surfaceLeft} (expect 0 = removed)";
+                App.Log($"CustomDry BeginDry={n}, app-rendered, EndDry ok; InkSurface container = {surfaceLeft}");
+            }
+            catch (Exception ex)
+            {
+                CustomDryText.Text = "BeginDry/EndDry threw: " + ex.Message;
+                App.Log("CustomDry step failed: " + ex.Message);
+            }
         }
 
         private StrokeSample ProcessStroke(InkStroke stroke)

--- a/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
+++ b/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
@@ -63,6 +63,25 @@ namespace ScratchPadApp
             // Enable ALL input devices once. The InkPresenter is a stable instance that caches this, so it
             // does not need re-applying as the toolbar / canvas load.
             ApplyInputDeviceTypes();
+
+            // Deferred-start validation. The OS rejects _InitializeCustomDry with E_ILLEGAL_METHOD_CALL
+            // once input has been activated, and on desktop (DComp) input activates on the first
+            // non-zero SetSize. Calling here -- during construction, before the first layout pass --
+            // is the supported ordering. Set INK_CUSTOMDRY_AT_STARTUP=1 to exercise it.
+            if (Environment.GetEnvironmentVariable("INK_CUSTOMDRY_AT_STARTUP") == "1")
+            {
+                try
+                {
+                    _inkSynchronizer = InkSurface.InkPresenter.ActivateCustomDrying();
+                    _customDryActive = _inkSynchronizer != null;
+                    App.Log("STARTUP ActivateCustomDrying -> " + (_customDryActive ? "OK (non-null)" : "returned null"));
+                }
+                catch (Exception ex)
+                {
+                    App.Log("STARTUP ActivateCustomDrying THREW: " + ex.GetType().Name + ": " + ex.Message);
+                }
+            }
+
             Toolbar.Loaded += (s, e) =>
             {
                 App.Log("Toolbar.Loaded ActiveTool=" + (Toolbar.ActiveTool?.GetType().Name ?? "null"));

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -251,29 +251,6 @@ void InkCanvas::UpdateInkPresenterSize()
         return;
     }
 
-    // The OS activates ink input on the first non-zero SetSize, and InkPresenter.ActivateCustomDrying
-    // is only legal before input is activated. Defer that first push one dispatcher turn so an app
-    // configuring the presenter from its Loaded handler runs first. Normal priority, not Low: Low is
-    // starved during startup and cost ~272ms before ink input went live, versus ~22ms here.
-    if (!m_initialSizePushed)
-    {
-        if (m_initialSizeDeferred)
-        {
-            return;
-        }
-        m_initialSizeDeferred = true;
-
-        auto strongThis = get_strong();
-        DispatcherQueue().TryEnqueue(
-            winrt::Microsoft::UI::Dispatching::DispatcherQueuePriority::Normal,
-            [strongThis]()
-            {
-                strongThis->m_initialSizePushed = true;
-                strongThis->UpdateInkPresenterSize();
-            });
-        return;
-    }
-
     winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem(
         [width = rect.Width, height = rect.Height](inking::InkPresenter const& presenter)
         {

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -237,15 +237,14 @@ void InkCanvas::UpdateInkPresenterSize()
         return;
     }
 
-    // Transform the width/height based on Xaml scaling
+    // Transform the layout size into root coordinates so a RenderTransform (e.g. ScaleTransform) on
+    // the canvas is reflected in the ink area. The OS presenter sizes in DIPs, so no rasterization
+    // scale is applied here.
     auto transformer = TransformToVisual(nullptr);
     winrt::Rect rect{ 0, 0, static_cast<float>(ActualWidth()), static_cast<float>(ActualHeight())};
     rect = transformer.TransformBounds(rect);
 
-    // Get the system scale
-    auto rootScale = xamlRoot.RasterizationScale();
-
-    // Push the new physical-pixel size onto the OS presenter (on the ink thread) through the proxy.
+    // Push the new size onto the OS presenter (on the ink thread) through the proxy.
     // The proxy's queue no-ops if the OS presenter has not been created yet.
     if (!m_inkPresenterProxy)
     {
@@ -253,8 +252,9 @@ void InkCanvas::UpdateInkPresenterSize()
     }
 
     // The OS activates ink input on the first non-zero SetSize, and InkPresenter.ActivateCustomDrying
-    // is only legal before input is activated. Defer that first push to a low-priority callback so an
-    // app configuring the presenter (in its constructor or Loaded handler) runs first.
+    // is only legal before input is activated. Defer that first push one dispatcher turn so an app
+    // configuring the presenter from its Loaded handler runs first. Normal priority, not Low: Low is
+    // starved during startup and cost ~272ms before ink input went live, versus ~22ms here.
     if (!m_initialSizePushed)
     {
         if (m_initialSizeDeferred)
@@ -265,7 +265,7 @@ void InkCanvas::UpdateInkPresenterSize()
 
         auto strongThis = get_strong();
         DispatcherQueue().TryEnqueue(
-            winrt::Microsoft::UI::Dispatching::DispatcherQueuePriority::Low,
+            winrt::Microsoft::UI::Dispatching::DispatcherQueuePriority::Normal,
             [strongThis]()
             {
                 strongThis->m_initialSizePushed = true;
@@ -275,9 +275,9 @@ void InkCanvas::UpdateInkPresenterSize()
     }
 
     winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem(
-        [width = ActualWidth() * rootScale, height = ActualHeight() * rootScale](inking::InkPresenter const& presenter)
+        [width = rect.Width, height = rect.Height](inking::InkPresenter const& presenter)
         {
-            presenter.as<IInkPresenterDesktop>()->SetSize(static_cast<float>(width), static_cast<float>(height));
+            presenter.as<IInkPresenterDesktop>()->SetSize(width, height);
         });
 }
 
@@ -369,7 +369,7 @@ void InkCanvas::AttachInkVisualToPresenter()
     // transition (normal drying, and custom-dry EndDry) so the removal + new content land in one frame.
     // The presenter holds a ref on the handler; it is replaced on re-attach and released at teardown.
     auto* presenterSelf = winrt::get_self<::InkPresenter>(m_inkPresenterProxy);
-    presenterSelf->QueueInkPresenterWorkItem([presenterSelf, rootVisual = m_inkRootVisual, compositionDevice = m_threadData->m_compositionDevice](inking::InkPresenter const& presenter)
+    presenterSelf->QueueInkPresenterWorkItem([rootVisual = m_inkRootVisual, compositionDevice = m_threadData->m_compositionDevice](inking::InkPresenter const& presenter)
         {
             auto desktopPresenter = presenter.as<IInkPresenterDesktop>();
             // Pass the composition device (not nullptr): custom drying needs it for the wet->dry
@@ -378,16 +378,13 @@ void InkCanvas::AttachInkVisualToPresenter()
             auto commitHandler = winrt::make_self<InkCommitRequestHandler>(compositionDevice);
             winrt::check_hresult(desktopPresenter->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
             winrt::check_hresult(compositionDevice->Commit());
-            presenterSelf->SetInkRootVisualForCustomDry(rootVisual);
         });
 }
 
-// Roots the ink visual under the given target and hands the shared composition device to the presenter
-// (used to present the wet-container clear while custom drying). Shared by both compositor paths.
+// Roots the ink visual under the given target. Shared by both compositor paths.
 void InkCanvas::SetInkRootVisual(IDCompositionTarget* target)
 {
     winrt::check_hresult(target->SetRoot(m_inkRootVisual.get()));
-    winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->SetCompositionDevice(m_threadData->m_compositionDevice);
 }
 
 // System compositor path: splices the ink visual directly under a lifted MUC visual via
@@ -472,12 +469,6 @@ void InkCanvas::DetachFromVisualLink()
     m_isDetached.store(true, std::memory_order_release);
 
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, nullptr);
-
-    // Drop the composition device reference on the ink thread before teardown.
-    if (m_inkPresenterProxy)
-    {
-        winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->ReleaseCompositionDevice();
-    }
 
     m_systemDCompTarget = nullptr;
     m_systemVisualLink = nullptr;

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -77,28 +77,9 @@ struct ThreadData
     wil::unique_hmodule m_hmodDComp;
 };
 
-//
-// IInkCommitRequestHandler implementation.
-// InkPresenter calls OnCommitRequested() when ink transitions from wet to dry
-// and needs the app to commit the DComposition device.
-//
-struct InkCommitRequestHandler : winrt::implements<InkCommitRequestHandler, IInkCommitRequestHandler>
-{
-    InkCommitRequestHandler(winrt::com_ptr<IDCompositionDevice> device)
-        : m_device(device) {}
-
-    IFACEMETHODIMP OnCommitRequested() override
-    {
-        if (m_device)
-        {
-            return m_device->Commit();
-        }
-        return S_OK;
-    }
-
-private:
-    winrt::com_ptr<IDCompositionDevice> m_device;
-};
+// InkCommitRequestHandler (the IInkCommitRequestHandler the presenter calls on every wet->dry
+// transition to commit the shared DComposition device) now lives in InkPresenter.h, so the InkPresenter
+// proxy can re-create it when it re-creates the OS presenter to activate custom drying at runtime.
 
 //
 //  InkCanvas
@@ -359,15 +340,28 @@ void InkCanvas::AttachInkVisualToPresenter()
     // Clear the detach flag BEFORE queuing so the ink thread doesn't drop the SetRootVisual work.
     m_isDetached.store(false, std::memory_order_release);
 
-    // Bind the visual to the presenter on the ink thread. SetRootVisual drives both rendering and
-    // input routing. XAML positions/clips the ink visual for both compositor paths, so commit here.
-    // No commit-request handler (conflicts with InkSynchronizer).
-    winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem([rootVisual = m_inkRootVisual, compositionDevice = m_threadData->m_compositionDevice](inking::InkPresenter const& presenter)
+    // Bind the visual to the presenter on the ink thread. SetRootVisual(rootVisual, device) roots the
+    // ink; SetCommitRequestHandler wires the DComp commit the presenter requests on every wet->dry
+    // transition (normal drying, and custom-dry EndDry) so the removal + new content land in one frame.
+    // The presenter holds a ref on the handler; it is replaced on re-attach and released at teardown.
+    auto* presenterSelf = winrt::get_self<::InkPresenter>(m_inkPresenterProxy);
+    presenterSelf->QueueInkPresenterWorkItem([presenterSelf, rootVisual = m_inkRootVisual, compositionDevice = m_threadData->m_compositionDevice](inking::InkPresenter const& presenter)
         {
             auto desktopPresenter = presenter.as<IInkPresenterDesktop>();
             winrt::check_hresult(desktopPresenter->SetRootVisual(rootVisual.get(), nullptr));
+            auto commitHandler = winrt::make_self<InkCommitRequestHandler>(compositionDevice);
+            winrt::check_hresult(desktopPresenter->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
             winrt::check_hresult(compositionDevice->Commit());
+            presenterSelf->SetInkRootVisualForCustomDry(rootVisual);
         });
+}
+
+// Roots the ink visual under the given target and hands the shared composition device to the presenter
+// (used to present the wet-container clear while custom drying). Shared by both compositor paths.
+void InkCanvas::RootInkVisual(IDCompositionTarget* target)
+{
+    winrt::check_hresult(target->SetRoot(m_inkRootVisual.get()));
+    winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->SetCompositionDevice(m_threadData->m_compositionDevice);
 }
 
 // System compositor path: splices the ink visual directly under a lifted MUC visual via
@@ -404,7 +398,8 @@ void InkCanvas::AttachToSystemCompositor()
 #endif
         desktopDevice.get(),
         m_systemDCompTarget.put()));
-    winrt::check_hresult(m_systemDCompTarget->SetRoot(m_inkRootVisual.get()));
+    RootInkVisual(m_systemDCompTarget.get());
+    winrt::check_hresult(m_threadData->m_compositionDevice->Commit());
 
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, mucRootVisual);
 }
@@ -436,7 +431,7 @@ void InkCanvas::AttachToLiftedCompositor()
     m_systemVisualLink.IsAboveContent(true);
 
     winrt::com_ptr<IDCompositionTarget> target = m_systemVisualLink.DCompTarget();
-    winrt::check_hresult(target->SetRoot(m_inkRootVisual.get()));
+    RootInkVisual(target.get());
 
     winrt::check_hresult(m_threadData->m_compositionDevice->Commit());
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, m_systemVisualLink.PlacementVisual());
@@ -451,6 +446,12 @@ void InkCanvas::DetachFromVisualLink()
     m_isDetached.store(true, std::memory_order_release);
 
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, nullptr);
+
+    // Drop the composition device reference on the ink thread before teardown.
+    if (m_inkPresenterProxy)
+    {
+        winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->ReleaseCompositionDevice();
+    }
 
     m_systemDCompTarget = nullptr;
     m_systemVisualLink = nullptr;

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -358,7 +358,7 @@ void InkCanvas::AttachInkVisualToPresenter()
 
 // Roots the ink visual under the given target and hands the shared composition device to the presenter
 // (used to present the wet-container clear while custom drying). Shared by both compositor paths.
-void InkCanvas::RootInkVisual(IDCompositionTarget* target)
+void InkCanvas::SetInkRootVisual(IDCompositionTarget* target)
 {
     winrt::check_hresult(target->SetRoot(m_inkRootVisual.get()));
     winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->SetCompositionDevice(m_threadData->m_compositionDevice);
@@ -398,7 +398,7 @@ void InkCanvas::AttachToSystemCompositor()
 #endif
         desktopDevice.get(),
         m_systemDCompTarget.put()));
-    RootInkVisual(m_systemDCompTarget.get());
+    SetInkRootVisual(m_systemDCompTarget.get());
     winrt::check_hresult(m_threadData->m_compositionDevice->Commit());
 
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, mucRootVisual);
@@ -431,7 +431,7 @@ void InkCanvas::AttachToLiftedCompositor()
     m_systemVisualLink.IsAboveContent(true);
 
     winrt::com_ptr<IDCompositionTarget> target = m_systemVisualLink.DCompTarget();
-    RootInkVisual(target.get());
+    SetInkRootVisual(target.get());
 
     winrt::check_hresult(m_threadData->m_compositionDevice->Commit());
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, m_systemVisualLink.PlacementVisual());

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -247,14 +247,38 @@ void InkCanvas::UpdateInkPresenterSize()
 
     // Push the new physical-pixel size onto the OS presenter (on the ink thread) through the proxy.
     // The proxy's queue no-ops if the OS presenter has not been created yet.
-    if (m_inkPresenterProxy)
+    if (!m_inkPresenterProxy)
     {
-        winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem(
-            [width = ActualWidth() * rootScale, height = ActualHeight() * rootScale](inking::InkPresenter const& presenter)
-            {
-                presenter.as<IInkPresenterDesktop>()->SetSize(static_cast<float>(width), static_cast<float>(height));
-            });
+        return;
     }
+
+    // The OS activates ink input on the first non-zero SetSize, and InkPresenter.ActivateCustomDrying
+    // is only legal before input is activated. Defer that first push to a low-priority callback so an
+    // app configuring the presenter (in its constructor or Loaded handler) runs first.
+    if (!m_initialSizePushed)
+    {
+        if (m_initialSizeDeferred)
+        {
+            return;
+        }
+        m_initialSizeDeferred = true;
+
+        auto strongThis = get_strong();
+        DispatcherQueue().TryEnqueue(
+            winrt::Microsoft::UI::Dispatching::DispatcherQueuePriority::Low,
+            [strongThis]()
+            {
+                strongThis->m_initialSizePushed = true;
+                strongThis->UpdateInkPresenterSize();
+            });
+        return;
+    }
+
+    winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem(
+        [width = ActualWidth() * rootScale, height = ActualHeight() * rootScale](inking::InkPresenter const& presenter)
+        {
+            presenter.as<IInkPresenterDesktop>()->SetSize(static_cast<float>(width), static_cast<float>(height));
+        });
 }
 
 void InkCanvas::AttachToVisualLink()
@@ -348,7 +372,9 @@ void InkCanvas::AttachInkVisualToPresenter()
     presenterSelf->QueueInkPresenterWorkItem([presenterSelf, rootVisual = m_inkRootVisual, compositionDevice = m_threadData->m_compositionDevice](inking::InkPresenter const& presenter)
         {
             auto desktopPresenter = presenter.as<IInkPresenterDesktop>();
-            winrt::check_hresult(desktopPresenter->SetRootVisual(rootVisual.get(), nullptr));
+            // Pass the composition device (not nullptr): custom drying needs it for the wet->dry
+            // handoff. The OS only uses the resulting commit provider in custom-dry mode.
+            winrt::check_hresult(desktopPresenter->SetRootVisual(rootVisual.get(), compositionDevice.get()));
             auto commitHandler = winrt::make_self<InkCommitRequestHandler>(compositionDevice);
             winrt::check_hresult(desktopPresenter->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
             winrt::check_hresult(compositionDevice->Commit());

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -63,7 +63,7 @@ private:
     void PositionInkVisual();
     // Roots the ink visual under the given target and hands the composition device to the presenter.
     // Shared by both compositor paths.
-    void RootInkVisual(IDCompositionTarget* target);
+    void SetInkRootVisual(IDCompositionTarget* target);
 
     std::shared_ptr<ThreadData> m_threadData;
  

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -98,4 +98,9 @@ private:
     // this. AttachToVisualLink clears it for the rapid Loaded/Unloaded re-attach case.
     std::atomic<bool> m_isDetached{ false };
 
+    // The OS activates ink input on the first non-zero SetSize, and ActivateCustomDrying is only
+    // legal before that. Hold the presenter at 0x0 until app configuration has had a chance to run.
+    bool m_initialSizeDeferred{ false };
+    bool m_initialSizePushed{ false };
+
 };

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -98,9 +98,4 @@ private:
     // this. AttachToVisualLink clears it for the rapid Loaded/Unloaded re-attach case.
     std::atomic<bool> m_isDetached{ false };
 
-    // The OS activates ink input on the first non-zero SetSize, and ActivateCustomDrying is only
-    // legal before that. Hold the presenter at 0x0 until app configuration has had a chance to run.
-    bool m_initialSizeDeferred{ false };
-    bool m_initialSizePushed{ false };
-
 };

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -61,6 +61,9 @@ private:
     void AttachInkVisualToPresenter();
     // Sizes the lifted PlacementVisual to the control's physical-pixel bounds (lifted path only).
     void PositionInkVisual();
+    // Roots the ink visual under the given target and hands the composition device to the presenter.
+    // Shared by both compositor paths.
+    void RootInkVisual(IDCompositionTarget* target);
 
     std::shared_ptr<ThreadData> m_threadData;
  

--- a/controls/dev/InkCanvas/InkCanvas.idl
+++ b/controls/dev/InkCanvas/InkCanvas.idl
@@ -123,6 +123,18 @@
         InkPresenter GetInkPresenter();
     }
 
+    // Ink-thread-marshaled mirror of Windows.UI.Input.Inking.InkSynchronizer. Returned by
+    // InkPresenter.ActivateCustomDrying; lets the app take over rendering of "dry" (committed) ink.
+    // BeginDry/EndDry bracket the app's own rendering of the strokes the presenter just committed, so
+    // the presenter does not also draw them. The OS synchronizer is thread-affine to the ink thread,
+    // so both calls marshal there through the owning InkPresenter.
+    [MUX_PREVIEW]
+    runtimeclass InkSynchronizer
+    {
+        Windows.Foundation.Collections.IVectorView<Windows.UI.Input.Inking.InkStroke> BeginDry();
+        void EndDry();
+    }
+
     // Ink-thread-marshaled subset of Windows.UI.Input.Inking.InkPresenter.
     [MUX_PREVIEW]
     runtimeclass InkPresenter
@@ -145,6 +157,11 @@
         InkInputConfiguration InputConfiguration{ get; };
         InkStrokeInput StrokeInput{ get; };
         InkUnprocessedInput UnprocessedInput{ get; };
+
+        // Switches the presenter into custom-drying mode and returns the InkSynchronizer used to
+        // bracket the app's own rendering of committed strokes (parity with UWP
+        // InkPresenter.ActivateCustomDrying). Call before the first stroke is collected.
+        InkSynchronizer ActivateCustomDrying();
 
         event Windows.Foundation.TypedEventHandler<InkPresenter, InkStrokesCollectedEventArgs> StrokesCollected;
         event Windows.Foundation.TypedEventHandler<InkPresenter, InkStrokesErasedEventArgs> StrokesErased;

--- a/controls/dev/InkCanvas/InkCanvas.idl
+++ b/controls/dev/InkCanvas/InkCanvas.idl
@@ -160,7 +160,8 @@
 
         // Switches the presenter into custom-drying mode and returns the InkSynchronizer used to
         // bracket the app's own rendering of committed strokes (parity with UWP
-        // InkPresenter.ActivateCustomDrying). Call before the first stroke is collected.
+        // InkPresenter.ActivateCustomDrying). Must be called before the canvas begins receiving
+        // input, i.e. during page construction or Loaded, before the first layout pass sizes it.
         InkSynchronizer ActivateCustomDrying();
 
         event Windows.Foundation.TypedEventHandler<InkPresenter, InkStrokesCollectedEventArgs> StrokesCollected;

--- a/controls/dev/InkCanvas/InkCanvas.idl
+++ b/controls/dev/InkCanvas/InkCanvas.idl
@@ -93,13 +93,8 @@
         event Windows.Foundation.TypedEventHandler<InkStrokeInput, Windows.UI.Core.PointerEventArgs> StrokeCanceled;
 
         // Back-pointer to the owning presenter (parity with UWP InkStrokeInput.InkPresenter). Returns
-        // our mirror InkPresenter, not the OS one, consistent with the wrapping model. Exposed as a
-        // method, NOT a property: a property here generates a XAML metadata thunk, and because
-        // InkPresenter.StrokeInput is itself a property thunk pointing back to InkStrokeInput, the two
-        // thunks form a cycle the metadata provider walks recursively (stack overflow at first use).
-        // A method carries no metadata thunk, breaking the cycle (same reasoning as
-        // InkPresenter.GetHighContrastAdjustment below). UWP's get_InkPresenter is a method at the ABI.
-        InkPresenter GetInkPresenter();
+        // our mirror InkPresenter, not the OS one, consistent with the wrapping model.
+        InkPresenter InkPresenter{ get; };
     }
 
     // Ink-thread-marshaled mirror of Windows.UI.Input.Inking.InkUnprocessedInput. Fires the raw
@@ -117,10 +112,8 @@
         event Windows.Foundation.TypedEventHandler<InkUnprocessedInput, Windows.UI.Core.PointerEventArgs> PointerLost;
 
         // Back-pointer to the owning presenter (parity with UWP InkUnprocessedInput.InkPresenter).
-        // Returns our mirror InkPresenter, not the OS one, consistent with the wrapping model. Exposed
-        // as a method, NOT a property, to avoid the recursive XAML metadata thunk cycle with
-        // InkPresenter.UnprocessedInput (see InkStrokeInput.GetInkPresenter above).
-        InkPresenter GetInkPresenter();
+        // Returns our mirror InkPresenter, not the OS one, consistent with the wrapping model.
+        InkPresenter InkPresenter{ get; };
     }
 
     // Ink-thread-marshaled mirror of Windows.UI.Input.Inking.InkSynchronizer. Returned by
@@ -145,12 +138,7 @@
         Windows.UI.Input.Inking.InkDrawingAttributes CopyDefaultDrawingAttributes();
         void SetPredefinedConfiguration(Windows.UI.Input.Inking.InkPresenterPredefinedConfiguration configuration);
 
-        // High-contrast rendering adjustment. Exposed as get/set methods rather than a property:
-        // our InkPresenter runtimeclass name-collides with Windows.UI.Input.Inking.InkPresenter, so
-        // the generated XAML metadata property thunk would bind to the OS presenter (whose enum type
-        // differs). Methods carry no XAML metadata thunk, so the mirror enum flows correctly.
-        InkHighContrastAdjustment GetHighContrastAdjustment();
-        void SetHighContrastAdjustment(InkHighContrastAdjustment value);
+        InkHighContrastAdjustment HighContrastAdjustment;
 
         InkStrokeContainer StrokeContainer{ get; };
         InkInputProcessingConfiguration InputProcessingConfiguration{ get; };

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -674,98 +674,89 @@ muxc::InkUnprocessedInput InkPresenter::UnprocessedInput()
 
 muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
 {
-    // Snapshot the app-set input configuration on the UI thread (where these mirrors live) so the rebuilt
-    // presenter can restore it - the rebuild otherwise starts from OS defaults. Reading here avoids a
-    // cross-thread read inside the ink-thread work item.
+    // Snapshot the app-set input configuration on the UI thread (avoids a cross-thread read inside the
+    // ink-thread work item); the rebuilt presenter restores it.
     auto mode = m_inputProcessingConfiguration ? m_inputProcessingConfiguration.Mode() : muxc::InkInputProcessingMode::Inking;
     auto rightDrag = m_inputProcessingConfiguration ? m_inputProcessingConfiguration.RightDragAction() : muxc::InkInputRightDragAction::LeaveUnprocessed;
     bool barrelButton = m_inputConfiguration ? m_inputConfiguration.IsPrimaryBarrelButtonInputEnabled() : true;
     bool eraserInput = m_inputConfiguration ? m_inputConfiguration.IsEraserInputEnabled() : true;
 
-    // Ensure the stable mirror exists (UWP parity: repeated calls return the same identity) BEFORE the
-    // synchronous work item, so the work item can adopt the OS synchronizer into it on the ink thread.
-    if (!m_customDryMirror)
+    // Create the projected synchronizer on the UI (calling) thread, where the app invokes it - a proxy
+    // created on the ink thread crashes when called cross-apartment. Stable across repeated calls.
+    if (!m_customDrySynchronizer)
     {
-        m_customDryMirror = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
+        m_customDrySynchronizer = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
     }
 
-    // The OS only allows ActivateCustomDrying before the presenter has started processing input. The
-    // lifted InkCanvas roots + sizes the presenter on load, which starts it, so a runtime activation on
-    // that same presenter is "too late" (E_ILLEGAL_METHOD_CALL) - and starting is irreversible, so
-    // detaching the root visual / zeroing the size does NOT undo it (verified). To honor a runtime
-    // activation we therefore build a FRESH OS presenter and wire it in the exact order the OS custom-
-    // dry contract requires - create -> SetRootVisual(device) -> SetCommitRequestHandler ->
-    // ActivateCustomDrying -> configure/subscribe -> SetSize - then swap it in for the started one.
+    // Idempotent (UWP parity): the first call rebuilds + activates on the ink thread; repeated calls
+    // return the same synchronizer.
     RunInkPresenterWorkItemSync(
-        [this, mode, rightDrag, barrelButton, eraserInput](inking::InkPresenter const& oldPresenter)
+        [this, mode, rightDrag, barrelButton, eraserInput](inking::InkPresenter const& startedPresenter)
         {
-            // Idempotent (UWP parity): repeated calls return the same synchronizer with no side effects,
-            // so do not rebuild the presenter if custom drying is already active.
-            if (m_customDryActive)
+            if (!m_customDryActive)
             {
-                return;
-            }
-
-            // Carry the current physical size across to the replacement, then stop the started presenter
-            // from presenting into the shared ink visual before the new one takes it over.
-            float width = 0, height = 0;
-            oldPresenter.as<IInkPresenterDesktop>()->GetSize(&width, &height);
-            oldPresenter.as<IInkPresenterDesktop>()->SetRootVisual(nullptr, nullptr);
-
-            // Fresh presenter, then bind the render target together with the composition DEVICE via
-            // SetRootVisual - device = m_compositionDevice, NOT nullptr. The normal-inking path passes
-            // nullptr (it relies only on the commit handler); custom drying needs the real device to wire
-            // up the wet->dry handoff - with a null device BeginDry fails with E_UNEXPECTED. Size is still
-            // 0 so the presenter has not "started" (activation is still allowed).
-            auto newDesktop = winrt::capture<IInkPresenterDesktop>(m_inkHost, &IInkDesktopHost::CreateInkPresenter);
-            auto newPresenter = newDesktop.as<inking::InkPresenter>();
-
-            if (m_rootVisual)
-            {
-                winrt::check_hresult(newDesktop->SetRootVisual(m_rootVisual.get(), m_compositionDevice.get()));
-            }
-            if (m_compositionDevice)
-            {
-                auto commitHandler = winrt::make_self<InkCommitRequestHandler>(m_compositionDevice);
-                winrt::check_hresult(newDesktop->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
-            }
-            // Adopt the OS InkSynchronizer into the mirror, which owns it and the dry-transaction state;
-            // this proxy keeps only the projected mirror, never the raw OS synchronizer. m_customDrySync
-            // lets the in-context StrokesCollected callback drive the mirror's ink-thread BeginDry.
-            auto syncImpl = winrt::get_self<::InkSynchronizer>(m_customDryMirror);
-            syncImpl->AdoptOsSynchronizer(newPresenter.ActivateCustomDrying());
-            m_customDrySync = syncImpl;
-            m_customDryActive = true;
-
-            // Adopt the new presenter (wires stroke/input forwarding) and restore the configuration the
-            // app had applied to the replaced one.
-            InitializeOsPresenter(newPresenter);
-            newPresenter.InputDeviceTypes(m_inputDeviceTypes);
-            newPresenter.IsInputEnabled(m_isInputEnabled);
-            if (m_defaultDrawingAttributes)
-            {
-                newPresenter.UpdateDefaultDrawingAttributes(m_defaultDrawingAttributes);
-            }
-            newPresenter.HighContrastAdjustment(
-                static_cast<inking::InkHighContrastAdjustment>(static_cast<int32_t>(m_highContrastAdjustment)));
-            newPresenter.InputProcessingConfiguration().Mode(
-                static_cast<inking::InkInputProcessingMode>(static_cast<int32_t>(mode)));
-            newPresenter.InputProcessingConfiguration().RightDragAction(
-                static_cast<inking::InkInputRightDragAction>(static_cast<int32_t>(rightDrag)));
-            newPresenter.InputConfiguration().IsPrimaryBarrelButtonInputEnabled(barrelButton);
-            newPresenter.InputConfiguration().IsEraserInputEnabled(eraserInput);
-
-            // Start it (input begins) now that custom-dry is engaged with the render target set.
-            winrt::check_hresult(newDesktop->SetSize(width, height));
-            if (m_compositionDevice)
-            {
-                winrt::check_hresult(m_compositionDevice->Commit());
+                RebuildOsPresenterForCustomDrying(startedPresenter, mode, rightDrag, barrelButton, eraserInput);
+                m_customDryActive = true;
             }
         },
         /* propagateException */ true,
         /* pumpMessages */ false);
 
-    return m_customDryMirror;
+    return m_customDrySynchronizer;
+}
+
+void InkPresenter::RebuildOsPresenterForCustomDrying(inking::InkPresenter const& startedPresenter,
+    muxc::InkInputProcessingMode mode, muxc::InkInputRightDragAction rightDrag, bool barrelButton, bool eraserInput)
+{
+    // Carry the size across, then stop the started presenter from presenting into the shared ink visual.
+    float width = 0;
+    float height = 0;
+    startedPresenter.as<IInkPresenterDesktop>()->GetSize(&width, &height);
+    startedPresenter.as<IInkPresenterDesktop>()->SetRootVisual(nullptr, nullptr);
+
+    // SetRootVisual gets the composition DEVICE (not nullptr): custom drying needs it for the wet->dry
+    // handoff; a null device makes BeginDry fail with E_UNEXPECTED. Size is still 0, so activation is legal.
+    auto customDryDesktop = winrt::capture<IInkPresenterDesktop>(m_inkHost, &IInkDesktopHost::CreateInkPresenter);
+    auto customDryPresenter = customDryDesktop.as<inking::InkPresenter>();
+    if (m_rootVisual)
+    {
+        winrt::check_hresult(customDryDesktop->SetRootVisual(m_rootVisual.get(), m_compositionDevice.get()));
+    }
+    if (m_compositionDevice)
+    {
+        auto commitHandler = winrt::make_self<InkCommitRequestHandler>(m_compositionDevice);
+        winrt::check_hresult(customDryDesktop->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
+    }
+
+    // Inject the OS synchronizer (from ActivateCustomDrying) into the UI-thread-created proxy.
+    // m_customDrySync lets the in-context StrokesCollected callback drive its ink-thread BeginDry.
+    auto syncImpl = winrt::get_self<::InkSynchronizer>(m_customDrySynchronizer);
+    syncImpl->AdoptOsSynchronizer(customDryPresenter.ActivateCustomDrying());
+    m_customDrySync = syncImpl;
+
+    // Adopt the fresh presenter and restore the config the app had set (a fresh presenter = OS defaults).
+    InitializeOsPresenter(customDryPresenter);
+    customDryPresenter.InputDeviceTypes(m_inputDeviceTypes);
+    customDryPresenter.IsInputEnabled(m_isInputEnabled);
+    if (m_defaultDrawingAttributes)
+    {
+        customDryPresenter.UpdateDefaultDrawingAttributes(m_defaultDrawingAttributes);
+    }
+    customDryPresenter.HighContrastAdjustment(
+        static_cast<inking::InkHighContrastAdjustment>(static_cast<int32_t>(m_highContrastAdjustment)));
+    customDryPresenter.InputProcessingConfiguration().Mode(
+        static_cast<inking::InkInputProcessingMode>(static_cast<int32_t>(mode)));
+    customDryPresenter.InputProcessingConfiguration().RightDragAction(
+        static_cast<inking::InkInputRightDragAction>(static_cast<int32_t>(rightDrag)));
+    customDryPresenter.InputConfiguration().IsPrimaryBarrelButtonInputEnabled(barrelButton);
+    customDryPresenter.InputConfiguration().IsEraserInputEnabled(eraserInput);
+
+    // Start it (input begins) now that custom drying is engaged.
+    winrt::check_hresult(customDryDesktop->SetSize(width, height));
+    if (m_compositionDevice)
+    {
+        winrt::check_hresult(m_compositionDevice->Commit());
+    }
 }
 
 void InkPresenter::SetCompositionDevice(winrt::com_ptr<IDCompositionDevice> const& device)

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -695,18 +695,6 @@ muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
     return m_customDrySynchronizer;
 }
 
-void InkPresenter::SetCompositionDevice(winrt::com_ptr<IDCompositionDevice> const& device)
-{
-    // Store the shared composition device on the ink thread; the custom-drying path commits it after
-    // clearing the wet container so the removed strokes leave the screen.
-    QueueInkPresenterWorkItem([this, device](inking::InkPresenter const&) { m_compositionDevice = device; });
-}
-
-void InkPresenter::ReleaseCompositionDevice()
-{
-    QueueInkPresenterWorkItem([this](inking::InkPresenter const&) { m_compositionDevice = nullptr; });
-}
-
 // -- InkSynchronizer mirror -----------------------------------------------------------------------
 // Owns the OS InkSynchronizer (adopted on the ink thread from the presenter's OS ActivateCustomDrying)
 // and marshals its BeginDry/EndDry onto the ink thread through the owning InkPresenter proxy's work

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -672,6 +672,201 @@ muxc::InkUnprocessedInput InkPresenter::UnprocessedInput()
     return m_unprocessedInput;
 }
 
+muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
+{
+    // Snapshot the app-set input configuration on the UI thread (where these mirrors live) so the rebuilt
+    // presenter can restore it - the rebuild otherwise starts from OS defaults. Reading here avoids a
+    // cross-thread read inside the ink-thread work item.
+    auto mode = m_inputProcessingConfiguration ? m_inputProcessingConfiguration.Mode() : muxc::InkInputProcessingMode::Inking;
+    auto rightDrag = m_inputProcessingConfiguration ? m_inputProcessingConfiguration.RightDragAction() : muxc::InkInputRightDragAction::LeaveUnprocessed;
+    bool barrelButton = m_inputConfiguration ? m_inputConfiguration.IsPrimaryBarrelButtonInputEnabled() : true;
+    bool eraserInput = m_inputConfiguration ? m_inputConfiguration.IsEraserInputEnabled() : true;
+
+    // Ensure the stable mirror exists (UWP parity: repeated calls return the same identity) BEFORE the
+    // synchronous work item, so the work item can adopt the OS synchronizer into it on the ink thread.
+    if (!m_customDryMirror)
+    {
+        m_customDryMirror = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
+    }
+
+    // The OS only allows ActivateCustomDrying before the presenter has started processing input. The
+    // lifted InkCanvas roots + sizes the presenter on load, which starts it, so a runtime activation on
+    // that same presenter is "too late" (E_ILLEGAL_METHOD_CALL) - and starting is irreversible, so
+    // detaching the root visual / zeroing the size does NOT undo it (verified). To honor a runtime
+    // activation we therefore build a FRESH OS presenter and wire it in the exact order the OS custom-
+    // dry contract requires - create -> SetRootVisual(device) -> SetCommitRequestHandler ->
+    // ActivateCustomDrying -> configure/subscribe -> SetSize - then swap it in for the started one.
+    RunInkPresenterWorkItemSync(
+        [this, mode, rightDrag, barrelButton, eraserInput](inking::InkPresenter const& oldPresenter)
+        {
+            // Idempotent (UWP parity): repeated calls return the same synchronizer with no side effects,
+            // so do not rebuild the presenter if custom drying is already active.
+            if (m_customDryActive)
+            {
+                return;
+            }
+
+            // Carry the current physical size across to the replacement, then stop the started presenter
+            // from presenting into the shared ink visual before the new one takes it over.
+            float width = 0, height = 0;
+            oldPresenter.as<IInkPresenterDesktop>()->GetSize(&width, &height);
+            oldPresenter.as<IInkPresenterDesktop>()->SetRootVisual(nullptr, nullptr);
+
+            // Fresh presenter, then bind the render target together with the composition DEVICE via
+            // SetRootVisual - device = m_compositionDevice, NOT nullptr. The normal-inking path passes
+            // nullptr (it relies only on the commit handler); custom drying needs the real device to wire
+            // up the wet->dry handoff - with a null device BeginDry fails with E_UNEXPECTED. Size is still
+            // 0 so the presenter has not "started" (activation is still allowed).
+            auto newDesktop = winrt::capture<IInkPresenterDesktop>(m_inkHost, &IInkDesktopHost::CreateInkPresenter);
+            auto newPresenter = newDesktop.as<inking::InkPresenter>();
+
+            if (m_rootVisual)
+            {
+                winrt::check_hresult(newDesktop->SetRootVisual(m_rootVisual.get(), m_compositionDevice.get()));
+            }
+            if (m_compositionDevice)
+            {
+                auto commitHandler = winrt::make_self<InkCommitRequestHandler>(m_compositionDevice);
+                winrt::check_hresult(newDesktop->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
+            }
+            // Adopt the OS InkSynchronizer into the mirror, which owns it and the dry-transaction state;
+            // this proxy keeps only the projected mirror, never the raw OS synchronizer. m_customDrySync
+            // lets the in-context StrokesCollected callback drive the mirror's ink-thread BeginDry.
+            auto syncImpl = winrt::get_self<::InkSynchronizer>(m_customDryMirror);
+            syncImpl->AdoptOsSynchronizer(newPresenter.ActivateCustomDrying());
+            m_customDrySync = syncImpl;
+            m_customDryActive = true;
+
+            // Adopt the new presenter (wires stroke/input forwarding) and restore the configuration the
+            // app had applied to the replaced one.
+            InitializeOsPresenter(newPresenter);
+            newPresenter.InputDeviceTypes(m_inputDeviceTypes);
+            newPresenter.IsInputEnabled(m_isInputEnabled);
+            if (m_defaultDrawingAttributes)
+            {
+                newPresenter.UpdateDefaultDrawingAttributes(m_defaultDrawingAttributes);
+            }
+            newPresenter.HighContrastAdjustment(
+                static_cast<inking::InkHighContrastAdjustment>(static_cast<int32_t>(m_highContrastAdjustment)));
+            newPresenter.InputProcessingConfiguration().Mode(
+                static_cast<inking::InkInputProcessingMode>(static_cast<int32_t>(mode)));
+            newPresenter.InputProcessingConfiguration().RightDragAction(
+                static_cast<inking::InkInputRightDragAction>(static_cast<int32_t>(rightDrag)));
+            newPresenter.InputConfiguration().IsPrimaryBarrelButtonInputEnabled(barrelButton);
+            newPresenter.InputConfiguration().IsEraserInputEnabled(eraserInput);
+
+            // Start it (input begins) now that custom-dry is engaged with the render target set.
+            winrt::check_hresult(newDesktop->SetSize(width, height));
+            if (m_compositionDevice)
+            {
+                winrt::check_hresult(m_compositionDevice->Commit());
+            }
+        },
+        /* propagateException */ true,
+        /* pumpMessages */ false);
+
+    return m_customDryMirror;
+}
+
+void InkPresenter::SetCompositionDevice(winrt::com_ptr<IDCompositionDevice> const& device)
+{
+    // Store the shared composition device on the ink thread; the custom-drying path commits it after
+    // clearing the wet container so the removed strokes leave the screen.
+    QueueInkPresenterWorkItem([this, device](inking::InkPresenter const&) { m_compositionDevice = device; });
+}
+
+void InkPresenter::ReleaseCompositionDevice()
+{
+    QueueInkPresenterWorkItem([this](inking::InkPresenter const&) { m_compositionDevice = nullptr; });
+}
+
+// -- InkSynchronizer mirror -----------------------------------------------------------------------
+// Owns the OS InkSynchronizer (adopted on the ink thread from the presenter's OS ActivateCustomDrying)
+// and the dry-transaction state, and marshals its BeginDry/EndDry onto the ink thread through the owning
+// InkPresenter proxy's work queue. Returns empty / no-ops once the owner has been torn down.
+
+void InkSynchronizer::BeginDryInContext()
+{
+    // Runs on the ink thread inside the OS StrokesCollected callback - the only point BeginDry is valid.
+    // A rapid burst can outrun the app's EndDry, and BeginDry is invalid while a dry is still open, so
+    // close any still-open one first. Then BeginDry hands back the just-committed strokes and we HOLD the
+    // wet layer up (no EndDry here) so the stroke stays on screen until the app has painted its dry ink
+    // and calls EndDry. Append (don't overwrite) so a burst that outruns the app's BeginDry is not lost.
+    // Capture any failure so it surfaces at the app's BeginDry rather than being swallowed.
+    if (!m_osSynchronizer)
+    {
+        return;
+    }
+    m_lastDryHr = S_OK;
+    try
+    {
+        if (m_dryInProgress)
+        {
+            m_osSynchronizer.EndDry();
+            m_dryInProgress = false;
+        }
+        auto dry = m_osSynchronizer.BeginDry();
+        m_dryInProgress = true;
+        if (dry && dry.Size())
+        {
+            std::vector<inking::InkStroke> drySnapshot(dry.Size(), nullptr);
+            dry.GetMany(0, drySnapshot);
+            m_pendingDryStrokes.insert(m_pendingDryStrokes.end(), drySnapshot.begin(), drySnapshot.end());
+        }
+    }
+    catch (winrt::hresult_error const& e)
+    {
+        m_lastDryHr = e.code();
+    }
+    catch (...)
+    {
+        m_lastDryHr = E_FAIL;
+    }
+}
+
+winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> InkSynchronizer::BeginDry()
+{
+    // The in-context BeginDry already ran on the ink thread (inside the OS StrokesCollected callback) and
+    // the wet layer is being held up. Drain the strokes it captured on the ink thread, then hand them
+    // back; the app paints them as dry ink and then calls EndDry to release the wet layer.
+    std::vector<inking::InkStroke> drained;
+    RunOnInkHostThreadSync(m_owner,
+        [this, &drained](inking::InkPresenter const&)
+        {
+            // Propagate a genuine in-context BeginDry failure to the app's BeginDry (UWP parity) rather
+            // than returning an empty result that hides it.
+            if (FAILED(m_lastDryHr))
+            {
+                winrt::throw_hresult(m_lastDryHr);
+            }
+            drained = std::move(m_pendingDryStrokes);
+            m_pendingDryStrokes.clear();
+        },
+        /* propagateException */ true,
+        /* pumpMessages */ false);
+    // Build the returned collection on the calling (UI) thread - matching the StrokesCollected path and
+    // avoiding an ink-thread-affine object being handed to the app.
+    return winrt::single_threaded_vector<inking::InkStroke>(std::move(drained)).GetView();
+}
+
+void InkSynchronizer::EndDry()
+{
+    // Release the held wet layer now that the app has painted its dry ink; the commit-request handler
+    // presents that removal. The wet was held since the in-context BeginDry, so the stroke stayed
+    // continuously visible. No-op if a rapid burst already closed this dry in the StrokesCollected handler.
+    RunOnInkHostThreadSync(m_owner,
+        [this](inking::InkPresenter const&)
+        {
+            if (m_dryInProgress && m_osSynchronizer)
+            {
+                m_osSynchronizer.EndDry();
+                m_dryInProgress = false;
+            }
+        },
+        /* propagateException */ true,
+        /* pumpMessages */ false);
+}
+
 winrt::event_token InkPresenter::StrokesCollected(winrt::Windows::Foundation::TypedEventHandler<muxc::InkPresenter, muxc::InkStrokesCollectedEventArgs> const& handler)
 {
     return m_strokesCollectedEvent.add(handler);
@@ -692,9 +887,11 @@ void InkPresenter::StrokesErased(winrt::event_token const& token)
     m_strokesErasedEvent.remove(token);
 }
 
-// Runs ONCE on the ink thread (from Start's work item) as soon as the OS presenter is created. The
-// proxy takes ownership of the OS presenter and owns everything about it from here on: initial
-// configuration and the stroke-event forwarding path.
+// Runs on the ink thread as soon as an OS presenter is created: once from Start's work item, and again
+// from ActivateCustomDrying when it swaps in a freshly-created presenter to activate custom drying. The
+// proxy adopts the given OS presenter and (re)establishes everything about it from here on: initial
+// configuration and the stroke-event forwarding path. Safe to run more than once - it always targets
+// the passed-in presenter, and the previously-adopted one is released when m_osPresenter is reassigned.
 void InkPresenter::InitializeOsPresenter(inking::InkPresenter const& osPresenter)
 {
     m_osPresenter = osPresenter;
@@ -733,11 +930,24 @@ void InkPresenter::InitializeOsPresenter(inking::InkPresenter const& osPresenter
     // snapshot the strokes here, marshal to the UI thread, and re-raise our own events there.
     // Handlers are attached eagerly and are harmless when the app never subscribes to our events.
     osPresenter.StrokesCollected(
-        [marshalToUi](inking::InkPresenter const&, inking::InkStrokesCollectedEventArgs const& args)
+        [marshalToUi, weakSelf](inking::InkPresenter const&, inking::InkStrokesCollectedEventArgs const& args)
         {
             auto strokes = args.Strokes();
             std::vector<inking::InkStroke> snapshot(strokes.Size(), nullptr);
             strokes.GetMany(0, snapshot);
+
+            // Custom drying: BeginDry is only valid synchronously inside THIS OS callback, on the ink
+            // thread (the app's StrokesCollected handler runs later on the UI thread - too late). Drive it
+            // through the InkSynchronizer mirror, which owns the OS synchronizer and the dry-transaction
+            // state: it holds the wet layer up and captures the strokes for the app's BeginDry to drain.
+            if (auto strong = weakSelf.get())
+            {
+                auto self = winrt::get_self<::InkPresenter>(strong);
+                if (self->m_customDrySync)
+                {
+                    self->m_customDrySync->BeginDryInContext();
+                }
+            }
 
             marshalToUi([snapshot = std::move(snapshot)](::InkPresenter* self) mutable
                 {

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -673,8 +673,8 @@ muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
     // crashes when called cross-apartment.
     auto customDrySynchronizer = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
 
-    // The OS only permits this before input is activated, which is why InkCanvas holds the presenter
-    // at 0x0 until app configuration has run (see InkCanvas::UpdateInkPresenterSize).
+    // UWP parity: the OS rejects this with E_ILLEGAL_METHOD_CALL once ink input has activated (first
+    // non-zero SetSize), and the app owns that ordering - activate before the first layout pass.
     bool activated = false;
     RunInkPresenterWorkItemSync(
         [&](inking::InkPresenter const& osPresenter)

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -53,11 +53,11 @@ void RunOnInkHostThread(winrt::weak_ref<muxc::InkPresenter> const& presenter, st
     }
 }
 
-void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages)
+void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages)
 {
     if (auto strong = presenter.get())
     {
-        winrt::get_self<::InkPresenter>(strong)->RunInkPresenterWorkItemSync(std::move(workItem), propagateException, pumpMessages);
+        winrt::get_self<::InkPresenter>(strong)->RunInkPresenterWorkItemSync(std::move(workItem), pumpMessages);
     }
 }
 
@@ -95,7 +95,7 @@ winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> InkStrok
                 snapshot.push_back(stroke);
             }
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 
     return winrt::single_threaded_vector<inking::InkStroke>(std::move(snapshot)).GetView();
 }
@@ -141,7 +141,7 @@ winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::SaveAsync(winrt::Wi
             // Run the OS async to completion on the ink thread that owns the container.
             presenter.StrokeContainer().SaveAsync(outputStream).get();
         },
-        /* propagateException */ true, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 }
 
 winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::SaveAsync(winrt::Windows::Storage::Streams::IOutputStream outputStream, inking::InkPersistenceFormat inkPersistenceFormat)
@@ -157,7 +157,7 @@ winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::SaveAsync(winrt::Wi
             // Run the OS async to completion on the ink thread that owns the container.
             presenter.StrokeContainer().SaveAsync(outputStream, inkPersistenceFormat).get();
         },
-        /* propagateException */ true, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 }
 
 winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::LoadAsync(winrt::Windows::Storage::Streams::IInputStream inputStream)
@@ -171,7 +171,7 @@ winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::LoadAsync(winrt::Wi
         {
             presenter.StrokeContainer().LoadAsync(inputStream).get();
         },
-        /* propagateException */ true, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 }
 
 // Selection / query members. Each marshals a single call to the OS container on the ink
@@ -187,7 +187,7 @@ inking::InkStroke InkStrokeContainer::GetStrokeById(uint32_t id)
         {
             result = presenter.StrokeContainer().GetStrokeById(id);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -199,7 +199,7 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::DeleteSelected()
         {
             result = presenter.StrokeContainer().DeleteSelected();
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -211,7 +211,7 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::MoveSelected(winrt::Windows
         {
             result = presenter.StrokeContainer().MoveSelected(translation);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -223,7 +223,7 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::SelectWithLine(winrt::Windo
         {
             result = presenter.StrokeContainer().SelectWithLine(from, to);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -245,7 +245,7 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::SelectWithPolyLine(winrt::W
             for (auto const& p : snapshot) { vec.Append(p); }
             result = presenter.StrokeContainer().SelectWithPolyLine(vec);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -258,14 +258,14 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::BoundingRect()
         {
             result = presenter.StrokeContainer().BoundingRect();
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
 // Clipboard members. The OS container is thread-affine, so these run on the ink thread like
-// the other container operations. Copy/Paste propagate failures so the app sees the HRESULT
-// (e.g. an empty selection on copy, or an incompatible clipboard payload on paste) instead of
-// a silent no-op; the returned Rect from paste is the invalidated region.
+// the other container operations. Failures surface to the app as an HRESULT (e.g. an empty
+// selection on copy, or an incompatible clipboard payload on paste); the returned Rect from
+// paste is the invalidated region.
 void InkStrokeContainer::CopySelectedToClipboard()
 {
     RunOnInkHostThreadSync(m_owner,
@@ -273,7 +273,7 @@ void InkStrokeContainer::CopySelectedToClipboard()
         {
             presenter.StrokeContainer().CopySelectedToClipboard();
         },
-        /* propagateException */ true, /* pumpMessages */ true);
+        /* pumpMessages */ true);
 }
 
 winrt::Windows::Foundation::Rect InkStrokeContainer::PasteFromClipboard(winrt::Windows::Foundation::Point const& position)
@@ -284,20 +284,19 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::PasteFromClipboard(winrt::W
         {
             result = presenter.StrokeContainer().PasteFromClipboard(position);
         },
-        /* propagateException */ true, /* pumpMessages */ true);
+        /* pumpMessages */ true);
     return result;
 }
 
 bool InkStrokeContainer::CanPasteFromClipboard()
 {
-    // Query: best-effort, so a failure just reports "cannot paste" rather than throwing.
     bool result = false;
     RunOnInkHostThreadSync(m_owner,
         [&result](inking::InkPresenter const& presenter)
         {
             result = presenter.StrokeContainer().CanPasteFromClipboard();
         },
-        /* propagateException */ false, /* pumpMessages */ true);
+        /* pumpMessages */ true);
     return result;
 }
 
@@ -428,7 +427,7 @@ void InkPresenter::QueueInkPresenterWorkItem(std::function<void(inking::InkPrese
 // deadlock. INVARIANT: a work item posted here must not synchronously call back to the UI thread
 // (the wait is non-pumping); anything needing UI/app objects uses the async path (SaveAsync /
 // LoadAsync resume_background() first, so the UI thread is never the one blocked).
-void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages)
+void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages)
 {
     if (!m_inkHost)
     {
@@ -437,19 +436,9 @@ void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPre
 
     if (::GetCurrentThreadId() == m_inkThreadId)
     {
-        try
+        if (m_osPresenter)
         {
-            if (m_osPresenter)
-            {
-                workItem(m_osPresenter);
-            }
-        }
-        catch (...)
-        {
-            if (propagateException)
-            {
-                throw;
-            }
+            workItem(m_osPresenter);
         }
         return;
     }
@@ -472,8 +461,8 @@ void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPre
             }
             catch (...)
             {
-                // Capture rather than swallow: SaveAsync/LoadAsync opt into re-propagation so a
-                // failed save/load is reported to the app. Best-effort getters ignore this.
+                // Captured here and rethrown on the calling thread below: the ink thread has no way
+                // to raise it at the caller.
                 workError = std::current_exception();
             }
             ::SetEvent(doneEvent.get());
@@ -499,7 +488,7 @@ void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPre
         ::WaitForSingleObject(doneEvent.get(), INFINITE);
     }
 
-    if (propagateException && workError)
+    if (workError)
     {
         std::rethrow_exception(workError);
     }
@@ -595,7 +584,7 @@ winrt::InkDrawingAttributes InkPresenter::CopyDefaultDrawingAttributes()
         {
             result = presenter.CopyDefaultDrawingAttributes();
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 
     if (!result)
     {
@@ -674,29 +663,35 @@ muxc::InkUnprocessedInput InkPresenter::UnprocessedInput()
 
 muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
 {
-    // Create the projected synchronizer on the UI (calling) thread, where the app invokes it - a proxy
-    // created on the ink thread crashes when called cross-apartment. Stable across repeated calls.
-    if (!m_customDrySynchronizer)
+    // Idempotent (UWP parity): activate once; repeated calls return the same synchronizer.
+    if (m_customDrySynchronizer)
     {
-        m_customDrySynchronizer = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
+        return m_customDrySynchronizer;
     }
 
-    // Idempotent (UWP parity): activate once on the ink thread; repeated calls return the same
-    // synchronizer. The OS only permits this before input is activated, which is why InkCanvas holds
-    // the presenter at 0x0 until app configuration has run (see InkCanvas::UpdateInkPresenterSize).
+    // Created on the UI (calling) thread, where the app invokes it - a proxy created on the ink thread
+    // crashes when called cross-apartment.
+    auto customDrySynchronizer = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
+
+    // The OS only permits this before input is activated, which is why InkCanvas holds the presenter
+    // at 0x0 until app configuration has run (see InkCanvas::UpdateInkPresenterSize).
+    bool activated = false;
     RunInkPresenterWorkItemSync(
-        [this](inking::InkPresenter const& osPresenter)
+        [&](inking::InkPresenter const& osPresenter)
         {
-            if (!m_customDryActive)
-            {
-                winrt::get_self<::InkSynchronizer>(m_customDrySynchronizer)
-                    ->AdoptOsSynchronizer(osPresenter.ActivateCustomDrying());
-                m_customDryActive = true;
-            }
+            winrt::get_self<::InkSynchronizer>(customDrySynchronizer)->Initialize(osPresenter.ActivateCustomDrying());
+            activated = true;
         },
-        /* propagateException */ true,
         /* pumpMessages */ false);
 
+    // The work item never ran: no ink host, or the OS presenter has not been created yet. Report it
+    // rather than handing back a synchronizer whose BeginDry would silently do nothing.
+    if (!activated)
+    {
+        throw winrt::hresult_error(E_ILLEGAL_METHOD_CALL, L"InkPresenter is not ready for custom drying.");
+    }
+
+    m_customDrySynchronizer = customDrySynchronizer;
     return m_customDrySynchronizer;
 }
 
@@ -736,7 +731,6 @@ winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> InkSynch
                 dry.GetMany(0, strokes);
             }
         },
-        /* propagateException */ true,
         /* pumpMessages */ false);
     // Build the returned collection on the calling (UI) thread so the app is never handed an
     // ink-thread-affine object.
@@ -753,7 +747,6 @@ void InkSynchronizer::EndDry()
                 m_osSynchronizer.EndDry();
             }
         },
-        /* propagateException */ true,
         /* pumpMessages */ false);
 }
 

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -689,9 +689,8 @@ muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
         {
             if (!m_customDryActive)
             {
-                auto syncImpl = winrt::get_self<::InkSynchronizer>(m_customDrySynchronizer);
-                syncImpl->AdoptOsSynchronizer(osPresenter.ActivateCustomDrying());
-                m_customDrySync = syncImpl;
+                winrt::get_self<::InkSynchronizer>(m_customDrySynchronizer)
+                    ->AdoptOsSynchronizer(osPresenter.ActivateCustomDrying());
                 m_customDryActive = true;
             }
         },
@@ -715,85 +714,43 @@ void InkPresenter::ReleaseCompositionDevice()
 
 // -- InkSynchronizer mirror -----------------------------------------------------------------------
 // Owns the OS InkSynchronizer (adopted on the ink thread from the presenter's OS ActivateCustomDrying)
-// and the dry-transaction state, and marshals its BeginDry/EndDry onto the ink thread through the owning
-// InkPresenter proxy's work queue. Returns empty / no-ops once the owner has been torn down.
-
-void InkSynchronizer::BeginDryInContext()
-{
-    // Runs on the ink thread inside the OS StrokesCollected callback - the only point BeginDry is valid.
-    // A rapid burst can outrun the app's EndDry, and BeginDry is invalid while a dry is still open, so
-    // close any still-open one first. Then BeginDry hands back the just-committed strokes and we HOLD the
-    // wet layer up (no EndDry here) so the stroke stays on screen until the app has painted its dry ink
-    // and calls EndDry. Append (don't overwrite) so a burst that outruns the app's BeginDry is not lost.
-    // Capture any failure so it surfaces at the app's BeginDry rather than being swallowed.
-    if (!m_osSynchronizer)
-    {
-        return;
-    }
-    m_lastDryHr = S_OK;
-    try
-    {
-        if (m_dryInProgress)
-        {
-            m_osSynchronizer.EndDry();
-            m_dryInProgress = false;
-        }
-        auto dry = m_osSynchronizer.BeginDry();
-        m_dryInProgress = true;
-        if (dry && dry.Size())
-        {
-            std::vector<inking::InkStroke> drySnapshot(dry.Size(), nullptr);
-            dry.GetMany(0, drySnapshot);
-            m_pendingDryStrokes.insert(m_pendingDryStrokes.end(), drySnapshot.begin(), drySnapshot.end());
-        }
-    }
-    catch (winrt::hresult_error const& e)
-    {
-        m_lastDryHr = e.code();
-    }
-    catch (...)
-    {
-        m_lastDryHr = E_FAIL;
-    }
-}
+// and marshals its BeginDry/EndDry onto the ink thread through the owning InkPresenter proxy's work
+// queue. UWP hands the app the OS object directly; this proxy exists only because that object is
+// ink-thread affine, so it forwards both calls and keeps no dry-transaction state of its own.
+// No-ops once the owner has been torn down.
 
 winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> InkSynchronizer::BeginDry()
 {
-    // The in-context BeginDry already ran on the ink thread (inside the OS StrokesCollected callback) and
-    // the wet layer is being held up. Drain the strokes it captured on the ink thread, then hand them
-    // back; the app paints them as dry ink and then calls EndDry to release the wet layer.
-    std::vector<inking::InkStroke> drained;
+    std::vector<inking::InkStroke> strokes;
     RunOnInkHostThreadSync(m_owner,
-        [this, &drained](inking::InkPresenter const&)
+        [this, &strokes](inking::InkPresenter const&)
         {
-            // Propagate a genuine in-context BeginDry failure to the app's BeginDry (UWP parity) rather
-            // than returning an empty result that hides it.
-            if (FAILED(m_lastDryHr))
+            if (!m_osSynchronizer)
             {
-                winrt::throw_hresult(m_lastDryHr);
+                return;
             }
-            drained = std::move(m_pendingDryStrokes);
-            m_pendingDryStrokes.clear();
+            auto dry = m_osSynchronizer.BeginDry();
+            if (dry && dry.Size())
+            {
+                strokes.resize(dry.Size(), nullptr);
+                dry.GetMany(0, strokes);
+            }
         },
         /* propagateException */ true,
         /* pumpMessages */ false);
-    // Build the returned collection on the calling (UI) thread - matching the StrokesCollected path and
-    // avoiding an ink-thread-affine object being handed to the app.
-    return winrt::single_threaded_vector<inking::InkStroke>(std::move(drained)).GetView();
+    // Build the returned collection on the calling (UI) thread so the app is never handed an
+    // ink-thread-affine object.
+    return winrt::single_threaded_vector<inking::InkStroke>(std::move(strokes)).GetView();
 }
 
 void InkSynchronizer::EndDry()
 {
-    // Release the held wet layer now that the app has painted its dry ink; the commit-request handler
-    // presents that removal. The wet was held since the in-context BeginDry, so the stroke stayed
-    // continuously visible. No-op if a rapid burst already closed this dry in the StrokesCollected handler.
     RunOnInkHostThreadSync(m_owner,
         [this](inking::InkPresenter const&)
         {
-            if (m_dryInProgress && m_osSynchronizer)
+            if (m_osSynchronizer)
             {
                 m_osSynchronizer.EndDry();
-                m_dryInProgress = false;
             }
         },
         /* propagateException */ true,
@@ -868,19 +825,6 @@ void InkPresenter::InitializeOsPresenter(inking::InkPresenter const& osPresenter
             auto strokes = args.Strokes();
             std::vector<inking::InkStroke> snapshot(strokes.Size(), nullptr);
             strokes.GetMany(0, snapshot);
-
-            // Custom drying: BeginDry is only valid synchronously inside THIS OS callback, on the ink
-            // thread (the app's StrokesCollected handler runs later on the UI thread - too late). Drive it
-            // through the InkSynchronizer mirror, which owns the OS synchronizer and the dry-transaction
-            // state: it holds the wet layer up and captures the strokes for the app's BeginDry to drain.
-            if (auto strong = weakSelf.get())
-            {
-                auto self = winrt::get_self<::InkPresenter>(strong);
-                if (self->m_customDrySync)
-                {
-                    self->m_customDrySync->BeginDryInContext();
-                }
-            }
 
             marshalToUi([snapshot = std::move(snapshot)](::InkPresenter* self) mutable
                 {

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -674,13 +674,6 @@ muxc::InkUnprocessedInput InkPresenter::UnprocessedInput()
 
 muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
 {
-    // Snapshot the app-set input configuration on the UI thread (avoids a cross-thread read inside the
-    // ink-thread work item); the rebuilt presenter restores it.
-    auto mode = m_inputProcessingConfiguration ? m_inputProcessingConfiguration.Mode() : muxc::InkInputProcessingMode::Inking;
-    auto rightDrag = m_inputProcessingConfiguration ? m_inputProcessingConfiguration.RightDragAction() : muxc::InkInputRightDragAction::LeaveUnprocessed;
-    bool barrelButton = m_inputConfiguration ? m_inputConfiguration.IsPrimaryBarrelButtonInputEnabled() : true;
-    bool eraserInput = m_inputConfiguration ? m_inputConfiguration.IsEraserInputEnabled() : true;
-
     // Create the projected synchronizer on the UI (calling) thread, where the app invokes it - a proxy
     // created on the ink thread crashes when called cross-apartment. Stable across repeated calls.
     if (!m_customDrySynchronizer)
@@ -688,14 +681,17 @@ muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
         m_customDrySynchronizer = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
     }
 
-    // Idempotent (UWP parity): the first call rebuilds + activates on the ink thread; repeated calls
-    // return the same synchronizer.
+    // Idempotent (UWP parity): activate once on the ink thread; repeated calls return the same
+    // synchronizer. The OS only permits this before input is activated, which is why InkCanvas holds
+    // the presenter at 0x0 until app configuration has run (see InkCanvas::UpdateInkPresenterSize).
     RunInkPresenterWorkItemSync(
-        [this, mode, rightDrag, barrelButton, eraserInput](inking::InkPresenter const& startedPresenter)
+        [this](inking::InkPresenter const& osPresenter)
         {
             if (!m_customDryActive)
             {
-                RebuildOsPresenterForCustomDrying(startedPresenter, mode, rightDrag, barrelButton, eraserInput);
+                auto syncImpl = winrt::get_self<::InkSynchronizer>(m_customDrySynchronizer);
+                syncImpl->AdoptOsSynchronizer(osPresenter.ActivateCustomDrying());
+                m_customDrySync = syncImpl;
                 m_customDryActive = true;
             }
         },
@@ -703,60 +699,6 @@ muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
         /* pumpMessages */ false);
 
     return m_customDrySynchronizer;
-}
-
-void InkPresenter::RebuildOsPresenterForCustomDrying(inking::InkPresenter const& startedPresenter,
-    muxc::InkInputProcessingMode mode, muxc::InkInputRightDragAction rightDrag, bool barrelButton, bool eraserInput)
-{
-    // Carry the size across, then stop the started presenter from presenting into the shared ink visual.
-    float width = 0;
-    float height = 0;
-    startedPresenter.as<IInkPresenterDesktop>()->GetSize(&width, &height);
-    startedPresenter.as<IInkPresenterDesktop>()->SetRootVisual(nullptr, nullptr);
-
-    // SetRootVisual gets the composition DEVICE (not nullptr): custom drying needs it for the wet->dry
-    // handoff; a null device makes BeginDry fail with E_UNEXPECTED. Size is still 0, so activation is legal.
-    auto customDryDesktop = winrt::capture<IInkPresenterDesktop>(m_inkHost, &IInkDesktopHost::CreateInkPresenter);
-    auto customDryPresenter = customDryDesktop.as<inking::InkPresenter>();
-    if (m_rootVisual)
-    {
-        winrt::check_hresult(customDryDesktop->SetRootVisual(m_rootVisual.get(), m_compositionDevice.get()));
-    }
-    if (m_compositionDevice)
-    {
-        auto commitHandler = winrt::make_self<InkCommitRequestHandler>(m_compositionDevice);
-        winrt::check_hresult(customDryDesktop->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
-    }
-
-    // Inject the OS synchronizer (from ActivateCustomDrying) into the UI-thread-created proxy.
-    // m_customDrySync lets the in-context StrokesCollected callback drive its ink-thread BeginDry.
-    auto syncImpl = winrt::get_self<::InkSynchronizer>(m_customDrySynchronizer);
-    syncImpl->AdoptOsSynchronizer(customDryPresenter.ActivateCustomDrying());
-    m_customDrySync = syncImpl;
-
-    // Adopt the fresh presenter and restore the config the app had set (a fresh presenter = OS defaults).
-    InitializeOsPresenter(customDryPresenter);
-    customDryPresenter.InputDeviceTypes(m_inputDeviceTypes);
-    customDryPresenter.IsInputEnabled(m_isInputEnabled);
-    if (m_defaultDrawingAttributes)
-    {
-        customDryPresenter.UpdateDefaultDrawingAttributes(m_defaultDrawingAttributes);
-    }
-    customDryPresenter.HighContrastAdjustment(
-        static_cast<inking::InkHighContrastAdjustment>(static_cast<int32_t>(m_highContrastAdjustment)));
-    customDryPresenter.InputProcessingConfiguration().Mode(
-        static_cast<inking::InkInputProcessingMode>(static_cast<int32_t>(mode)));
-    customDryPresenter.InputProcessingConfiguration().RightDragAction(
-        static_cast<inking::InkInputRightDragAction>(static_cast<int32_t>(rightDrag)));
-    customDryPresenter.InputConfiguration().IsPrimaryBarrelButtonInputEnabled(barrelButton);
-    customDryPresenter.InputConfiguration().IsEraserInputEnabled(eraserInput);
-
-    // Start it (input begins) now that custom drying is engaged.
-    winrt::check_hresult(customDryDesktop->SetSize(width, height));
-    if (m_compositionDevice)
-    {
-        winrt::check_hresult(m_compositionDevice->Commit());
-    }
 }
 
 void InkPresenter::SetCompositionDevice(winrt::com_ptr<IDCompositionDevice> const& device)

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -603,12 +603,12 @@ void InkPresenter::SetPredefinedConfiguration(inking::InkPresenterPredefinedConf
         });
 }
 
-muxc::InkHighContrastAdjustment InkPresenter::GetHighContrastAdjustment() const noexcept
+muxc::InkHighContrastAdjustment InkPresenter::HighContrastAdjustment() const noexcept
 {
     return m_highContrastAdjustment;
 }
 
-void InkPresenter::SetHighContrastAdjustment(muxc::InkHighContrastAdjustment const& value)
+void InkPresenter::HighContrastAdjustment(muxc::InkHighContrastAdjustment const& value)
 {
     m_highContrastAdjustment = value;
 

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -12,9 +12,11 @@
 #include "InkInputConfiguration.g.h"
 #include "InkStrokeInput.g.h"
 #include "InkUnprocessedInput.g.h"
+#include "InkSynchronizer.g.h"
 #include "InkPresenter.g.h"
 #include <windows.ui.input.inking.h>
 #include <inkpresenterdesktop.h>
+#include <dcomp.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.UI.Core.h>
@@ -28,6 +30,28 @@
 // unambiguous: 'inking' for the OS types, 'muxc' for our projected types.
 namespace inking = winrt::Windows::UI::Input::Inking;
 namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
+
+// The IInkCommitRequestHandler the OS presenter calls (OnCommitRequested) on every wet->dry transition
+// - normal drying and custom-dry EndDry - so the host commits the shared DComposition device and the
+// change is presented. Defined here (rather than privately in InkCanvas.cpp) so the InkPresenter proxy
+// can re-create it when it re-creates the OS presenter to activate custom drying at runtime.
+struct InkCommitRequestHandler : winrt::implements<InkCommitRequestHandler, IInkCommitRequestHandler>
+{
+    InkCommitRequestHandler(winrt::com_ptr<IDCompositionDevice> device)
+        : m_device(device) {}
+
+    IFACEMETHODIMP OnCommitRequested() override
+    {
+        if (m_device)
+        {
+            return m_device->Commit();
+        }
+        return S_OK;
+    }
+
+private:
+    winrt::com_ptr<IDCompositionDevice> m_device;
+};
 
 // Marshals a work item onto the ink host thread through the owning InkPresenter proxy, passing the
 // OS presenter to the lambda. No-op if the proxy has already been destroyed. The child proxies
@@ -230,6 +254,52 @@ private:
     winrt::event<Handler> m_pointerLost;
 };
 
+// Mirror of Windows.UI.Input.Inking.InkSynchronizer, returned by InkPresenter.ActivateCustomDrying.
+// Lets the app render committed ("dry") ink itself: BeginDry hands back the strokes the presenter just
+// committed and suppresses the presenter's own dry rendering; EndDry releases the wet-ink layer once
+// the app has drawn them. This mirror OWNS the OS InkSynchronizer (adopted on the ink thread from the
+// presenter's OS ActivateCustomDrying) and the dry-transaction state; the OS synchronizer is thread-
+// affine to the ink thread, so BeginDry/EndDry marshal onto it through the owning InkPresenter proxy's
+// work queue. The InkPresenter keeps this projected mirror, never the raw OS inking::InkSynchronizer.
+class InkSynchronizer :
+    public winrt::implementation::InkSynchronizerT<InkSynchronizer>
+{
+public:
+    InkSynchronizer(winrt::weak_ref<muxc::InkPresenter> const& owner) : m_owner(owner) {}
+
+    winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> BeginDry();
+    void EndDry();
+
+    // Internal (not on the winmd surface). Adopts the OS InkSynchronizer handed back by the owning
+    // presenter's OS ActivateCustomDrying. Called once on the ink thread when custom drying is activated.
+    void AdoptOsSynchronizer(inking::InkSynchronizer const& osSynchronizer) noexcept { m_osSynchronizer = osSynchronizer; }
+
+    // Internal (not on the winmd surface). Runs the OS BeginDry in-context on the ink thread, inside the
+    // OS StrokesCollected callback (the only point BeginDry is valid): holds the wet layer up and captures
+    // the just-committed strokes for the app's BeginDry to drain. Ink-thread only.
+    void BeginDryInContext();
+
+private:
+    winrt::weak_ref<muxc::InkPresenter> m_owner{ nullptr };
+
+    // The OS InkSynchronizer this mirror fronts (from OS ActivateCustomDrying). Thread-affine to the ink
+    // thread; only ever touched inside ink-thread work items. Null until custom drying is activated.
+    inking::InkSynchronizer m_osSynchronizer{ nullptr };
+
+    // Strokes captured by the in-context BeginDry (ink thread) and drained by the app's BeginDry (which
+    // marshals to the ink thread). Ink-thread only.
+    std::vector<inking::InkStroke> m_pendingDryStrokes;
+
+    // True between the in-context BeginDry and its matching EndDry (the app drives EndDry once it has
+    // painted its dry ink, so the wet layer stays up until then). Guards a second BeginDry while a dry is
+    // still open when a burst outruns EndDry. Ink-thread only.
+    bool m_dryInProgress{ false };
+
+    // HRESULT of the most recent in-context BeginDry; S_OK on success. The app's BeginDry re-throws it so
+    // a genuine failure surfaces there instead of being swallowed. Ink-thread only.
+    HRESULT m_lastDryHr{ S_OK };
+};
+
 // Manipulable subset of Windows.UI.Input.Inking.InkPresenter. The OS presenter can only be created
 // and called on the IInkDesktopHost ink thread, so this proxy is the single owner of it: it holds
 // the ink host reference (handed in at construction by the owning InkCanvas), creates the OS
@@ -262,6 +332,8 @@ public:
     muxc::InkStrokeInput StrokeInput();
     muxc::InkUnprocessedInput UnprocessedInput();
 
+    muxc::InkSynchronizer ActivateCustomDrying();
+
     winrt::event_token StrokesCollected(winrt::Windows::Foundation::TypedEventHandler<muxc::InkPresenter, muxc::InkStrokesCollectedEventArgs> const& handler);
     void StrokesCollected(winrt::event_token const& token);
     winrt::event_token StrokesErased(winrt::Windows::Foundation::TypedEventHandler<muxc::InkPresenter, muxc::InkStrokesErasedEventArgs> const& handler);
@@ -293,6 +365,17 @@ public:
     // snapshotted off the ink thread and marshaled back to the UI thread.
     void RaiseStrokesCollected(winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> const& strokes);
     void RaiseStrokesErased(winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> const& strokes);
+
+    // Internal. Stores the shared composition device (on the ink thread) so the custom-drying path can
+    // present the wet container Clear. Called by InkCanvas at attach; released via ReleaseCompositionDevice.
+    void SetCompositionDevice(winrt::com_ptr<IDCompositionDevice> const& device);
+
+    // Internal. Drops the composition device reference on the ink thread. Called by InkCanvas at detach.
+    void ReleaseCompositionDevice();
+
+    // Internal. Remembers the ink root visual so a runtime ActivateCustomDrying can detach/reattach it
+    // around the OS activation. Called on the ink thread by InkCanvas at attach.
+    void SetInkRootVisualForCustomDry(winrt::com_ptr<IDCompositionVisual> const& visual) noexcept { m_rootVisual = visual; }
 
 private:
     // Runs on the ink thread (from Start's work item) once the OS presenter has been created. Takes
@@ -335,6 +418,30 @@ private:
     muxc::InkInputConfiguration m_inputConfiguration{ nullptr };
     muxc::InkStrokeInput m_strokeInput{ nullptr };
     muxc::InkUnprocessedInput m_unprocessedInput{ nullptr };
+
+    // Custom-drying: the stable mirror handed back by ActivateCustomDrying (UI-thread cached; repeated
+    // calls return the same identity, UWP parity). It owns the OS InkSynchronizer and the dry-transaction
+    // state; this proxy keeps only the projected mirror, never the raw OS inking::InkSynchronizer.
+    muxc::InkSynchronizer m_customDryMirror{ nullptr };
+
+    // Non-owning pointer to m_customDryMirror's implementation, so the in-context StrokesCollected
+    // callback can drive its ink-thread BeginDry. Set on the ink thread when custom drying is activated;
+    // valid for this proxy's lifetime (m_customDryMirror owns the object). Ink-thread only.
+    InkSynchronizer* m_customDrySync{ nullptr };
+
+    // The shared DComp device, BORROWED from the InkCanvas/ThreadData that owns it (a per-UI-thread
+    // singleton shared by every InkCanvas on the thread). Held only to pass as the SetRootVisual device
+    // arg and to build the commit handler when a runtime ActivateCustomDrying rebuilds the OS presenter.
+    // Ink-thread only; released at detach via ReleaseCompositionDevice.
+    winrt::com_ptr<IDCompositionDevice> m_compositionDevice{ nullptr };
+
+    // Custom drying: true once the app has activated custom drying. Ink-thread only.
+    bool m_customDryActive{ false };
+
+    // The ink root visual handed to SetRootVisual. Held so a runtime ActivateCustomDrying can detach it
+    // (SetRootVisual(nullptr)) for the OS activation - which requires a pre-start presenter - and then
+    // reattach it. Ink-thread only; set by InkCanvas at attach.
+    winrt::com_ptr<IDCompositionVisual> m_rootVisual{ nullptr };
 
     // Ruler / protractor stencils bound to the OS presenter. Thread-affine to the ink
     // thread, so they are only ever constructed and touched inside serialized ink-thread

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -59,12 +59,12 @@ private:
 // of reaching into the proxy's work queue directly; the queue lives on the InkPresenter proxy, which
 // is the sole owner of the thread-affine OS presenter and the ink host reference.
 void RunOnInkHostThread(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem);
-// Synchronous marshal onto the ink host thread. propagateException rethrows a work-item failure on the
-// caller (false for best-effort getters). pumpMessages uses a COM-pumping wait (COWAIT_DISPATCH_CALLS)
-// instead of a plain blocking wait - required for OLE-clipboard work that can call back into the
-// UI-thread clipboard owner while this wait is in progress; a non-pumping wait would deadlock. Pass
-// false for ordinary getters.
-void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages);
+// Synchronous marshal onto the ink host thread. A work-item failure is rethrown on the calling thread,
+// so ink-thread errors reach the app rather than being reported as a default-constructed result.
+// pumpMessages uses a COM-pumping wait (COWAIT_DISPATCH_CALLS) instead of a plain blocking wait -
+// required for OLE-clipboard work that can call back into the UI-thread clipboard owner while this wait
+// is in progress; a non-pumping wait would deadlock. Pass false for ordinary getters.
+void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages);
 
 // Snapshot of the InkStroke objects handed to InkPresenter.StrokesCollected. InkStroke is
 // agile, so the strokes are copied on the ink thread and this args object is re-raised on
@@ -273,7 +273,7 @@ public:
     // Internal (not on the winmd surface). Injects the OS InkSynchronizer (from the presenter's OS
     // ActivateCustomDrying) into this UI-thread-created proxy. Called on the ink thread, where the OS
     // synchronizer is valid.
-    void AdoptOsSynchronizer(inking::InkSynchronizer const& osSynchronizer) noexcept { m_osSynchronizer = osSynchronizer; }
+    void Initialize(inking::InkSynchronizer const& osSynchronizer) noexcept { m_osSynchronizer = osSynchronizer; }
 
 private:
     winrt::weak_ref<muxc::InkPresenter> m_owner{ nullptr };
@@ -334,7 +334,7 @@ public:
     // SetRootVisual / SetSize).
     void QueueInkPresenterWorkItem(std::function<void(inking::InkPresenter const&)> workItem);
     // pumpMessages uses a COM-pumping wait (see the free RunOnInkHostThreadSync); pass false for ordinary getters.
-    void RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages);
+    void RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages);
 
     // Internal (not on the winmd surface). Shows/hides the ruler / protractor stencils on the OS
     // presenter. InkPresenterRuler / InkPresenterProtractor are thread-affine, so they are created
@@ -412,9 +412,6 @@ private:
     // arg and to build the commit handler when a runtime ActivateCustomDrying rebuilds the OS presenter.
     // Ink-thread only; released at detach via ReleaseCompositionDevice.
     winrt::com_ptr<IDCompositionDevice> m_compositionDevice{ nullptr };
-
-    // Custom drying: true once the app has activated custom drying. Ink-thread only.
-    bool m_customDryActive{ false };
 
     // The ink root visual handed to SetRootVisual. Held so a runtime ActivateCustomDrying can detach it
     // (SetRootVisual(nullptr)) for the OS activation - which requires a pre-start presenter - and then

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -349,17 +349,6 @@ public:
     void RaiseStrokesCollected(winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> const& strokes);
     void RaiseStrokesErased(winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> const& strokes);
 
-    // Internal. Stores the shared composition device (on the ink thread) so the custom-drying path can
-    // present the wet container Clear. Called by InkCanvas at attach; released via ReleaseCompositionDevice.
-    void SetCompositionDevice(winrt::com_ptr<IDCompositionDevice> const& device);
-
-    // Internal. Drops the composition device reference on the ink thread. Called by InkCanvas at detach.
-    void ReleaseCompositionDevice();
-
-    // Internal. Remembers the ink root visual so a runtime ActivateCustomDrying can detach/reattach it
-    // around the OS activation. Called on the ink thread by InkCanvas at attach.
-    void SetInkRootVisualForCustomDry(winrt::com_ptr<IDCompositionVisual> const& visual) noexcept { m_rootVisual = visual; }
-
 private:
     // Runs on the ink thread (from Start's work item) once the OS presenter has been created. Takes
     // ownership of it, applies initial configuration, and wires its StrokesCollected/StrokesErased
@@ -406,17 +395,6 @@ private:
     // calls return the same instance, UWP parity). It fronts the OS InkSynchronizer; this proxy keeps
     // only this projected wrapper, never the raw OS one.
     muxc::InkSynchronizer m_customDrySynchronizer{ nullptr };
-
-    // The shared DComp device, BORROWED from the InkCanvas/ThreadData that owns it (a per-UI-thread
-    // singleton shared by every InkCanvas on the thread). Held only to pass as the SetRootVisual device
-    // arg and to build the commit handler when a runtime ActivateCustomDrying rebuilds the OS presenter.
-    // Ink-thread only; released at detach via ReleaseCompositionDevice.
-    winrt::com_ptr<IDCompositionDevice> m_compositionDevice{ nullptr };
-
-    // The ink root visual handed to SetRootVisual. Held so a runtime ActivateCustomDrying can detach it
-    // (SetRootVisual(nullptr)) for the OS activation - which requires a pre-start presenter - and then
-    // reattach it. Ink-thread only; set by InkCanvas at attach.
-    winrt::com_ptr<IDCompositionVisual> m_rootVisual{ nullptr };
 
     // Ruler / protractor stencils bound to the OS presenter. Thread-affine to the ink
     // thread, so they are only ever constructed and touched inside serialized ink-thread

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -385,12 +385,6 @@ private:
     // via m_uiDispatcher -> raise our events).
     void InitializeOsPresenter(inking::InkPresenter const& osPresenter);
 
-    // Runs on the ink thread. The OS forbids ActivateCustomDrying after the presenter has started (our
-    // InkCanvas starts it on load), so we build a fresh presenter, activate it while unstarted, restore
-    // the app's configuration, and swap it in. Sets m_customDrySynchronizer / m_customDrySync.
-    void RebuildOsPresenterForCustomDrying(inking::InkPresenter const& startedPresenter,
-        muxc::InkInputProcessingMode mode, muxc::InkInputRightDragAction rightDrag, bool barrelButton, bool eraserInput);
-
     // The shared ink host (owns the ink thread), handed in by InkCanvas at construction. Used to
     // queue work items; the OS presenter is created and serviced on that thread.
     winrt::com_ptr<IInkDesktopHost> m_inkHost{ nullptr };

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -257,10 +257,10 @@ private:
 // Mirror of Windows.UI.Input.Inking.InkSynchronizer, returned by InkPresenter.ActivateCustomDrying.
 // Lets the app render committed ("dry") ink itself: BeginDry hands back the strokes the presenter just
 // committed and suppresses the presenter's own dry rendering; EndDry releases the wet-ink layer once
-// the app has drawn them. This mirror OWNS the OS InkSynchronizer (adopted on the ink thread from the
-// presenter's OS ActivateCustomDrying) and the dry-transaction state; the OS synchronizer is thread-
-// affine to the ink thread, so BeginDry/EndDry marshal onto it through the owning InkPresenter proxy's
-// work queue. The InkPresenter keeps this projected mirror, never the raw OS inking::InkSynchronizer.
+// the app has drawn them. UWP returns the OS InkSynchronizer directly; this mirror exists only because
+// that object is thread-affine to the ink thread, so it forwards BeginDry/EndDry through the owning
+// InkPresenter proxy's work queue and holds no dry-transaction state of its own. The InkPresenter keeps
+// this projected mirror, never the raw OS inking::InkSynchronizer.
 class InkSynchronizer :
     public winrt::implementation::InkSynchronizerT<InkSynchronizer>
 {
@@ -275,30 +275,12 @@ public:
     // synchronizer is valid.
     void AdoptOsSynchronizer(inking::InkSynchronizer const& osSynchronizer) noexcept { m_osSynchronizer = osSynchronizer; }
 
-    // Internal (not on the winmd surface). Runs the OS BeginDry in-context on the ink thread, inside the
-    // OS StrokesCollected callback (the only point BeginDry is valid): holds the wet layer up and captures
-    // the just-committed strokes for the app's BeginDry to drain. Ink-thread only.
-    void BeginDryInContext();
-
 private:
     winrt::weak_ref<muxc::InkPresenter> m_owner{ nullptr };
 
     // The OS InkSynchronizer this mirror fronts (from OS ActivateCustomDrying). Thread-affine to the ink
     // thread; only ever touched inside ink-thread work items. Null until custom drying is activated.
     inking::InkSynchronizer m_osSynchronizer{ nullptr };
-
-    // Strokes captured by the in-context BeginDry (ink thread) and drained by the app's BeginDry (which
-    // marshals to the ink thread). Ink-thread only.
-    std::vector<inking::InkStroke> m_pendingDryStrokes;
-
-    // True between the in-context BeginDry and its matching EndDry (the app drives EndDry once it has
-    // painted its dry ink, so the wet layer stays up until then). Guards a second BeginDry while a dry is
-    // still open when a burst outruns EndDry. Ink-thread only.
-    bool m_dryInProgress{ false };
-
-    // HRESULT of the most recent in-context BeginDry; S_OK on success. The app's BeginDry re-throws it so
-    // a genuine failure surfaces there instead of being swallowed. Ink-thread only.
-    HRESULT m_lastDryHr{ S_OK };
 };
 
 // Manipulable subset of Windows.UI.Input.Inking.InkPresenter. The OS presenter can only be created
@@ -421,14 +403,9 @@ private:
     muxc::InkUnprocessedInput m_unprocessedInput{ nullptr };
 
     // Custom drying: the synchronizer handed back by ActivateCustomDrying (UI-thread cached; repeated
-    // calls return the same instance, UWP parity). It wraps the OS InkSynchronizer and owns the
-    // dry-transaction state; this proxy keeps only this projected wrapper, never the raw OS one.
+    // calls return the same instance, UWP parity). It fronts the OS InkSynchronizer; this proxy keeps
+    // only this projected wrapper, never the raw OS one.
     muxc::InkSynchronizer m_customDrySynchronizer{ nullptr };
-
-    // Non-owning pointer to m_customDrySynchronizer's implementation, so the in-context StrokesCollected
-    // callback can drive its ink-thread BeginDry. Set on the ink thread when custom drying is activated;
-    // valid for this proxy's lifetime (m_customDrySynchronizer owns the object). Ink-thread only.
-    InkSynchronizer* m_customDrySync{ nullptr };
 
     // The shared DComp device, BORROWED from the InkCanvas/ThreadData that owns it (a per-UI-thread
     // singleton shared by every InkCanvas on the thread). Held only to pass as the SetRootVisual device

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -270,8 +270,9 @@ public:
     winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> BeginDry();
     void EndDry();
 
-    // Internal (not on the winmd surface). Adopts the OS InkSynchronizer handed back by the owning
-    // presenter's OS ActivateCustomDrying. Called once on the ink thread when custom drying is activated.
+    // Internal (not on the winmd surface). Injects the OS InkSynchronizer (from the presenter's OS
+    // ActivateCustomDrying) into this UI-thread-created proxy. Called on the ink thread, where the OS
+    // synchronizer is valid.
     void AdoptOsSynchronizer(inking::InkSynchronizer const& osSynchronizer) noexcept { m_osSynchronizer = osSynchronizer; }
 
     // Internal (not on the winmd surface). Runs the OS BeginDry in-context on the ink thread, inside the
@@ -384,6 +385,12 @@ private:
     // via m_uiDispatcher -> raise our events).
     void InitializeOsPresenter(inking::InkPresenter const& osPresenter);
 
+    // Runs on the ink thread. The OS forbids ActivateCustomDrying after the presenter has started (our
+    // InkCanvas starts it on load), so we build a fresh presenter, activate it while unstarted, restore
+    // the app's configuration, and swap it in. Sets m_customDrySynchronizer / m_customDrySync.
+    void RebuildOsPresenterForCustomDrying(inking::InkPresenter const& startedPresenter,
+        muxc::InkInputProcessingMode mode, muxc::InkInputRightDragAction rightDrag, bool barrelButton, bool eraserInput);
+
     // The shared ink host (owns the ink thread), handed in by InkCanvas at construction. Used to
     // queue work items; the OS presenter is created and serviced on that thread.
     winrt::com_ptr<IInkDesktopHost> m_inkHost{ nullptr };
@@ -419,14 +426,14 @@ private:
     muxc::InkStrokeInput m_strokeInput{ nullptr };
     muxc::InkUnprocessedInput m_unprocessedInput{ nullptr };
 
-    // Custom-drying: the stable mirror handed back by ActivateCustomDrying (UI-thread cached; repeated
-    // calls return the same identity, UWP parity). It owns the OS InkSynchronizer and the dry-transaction
-    // state; this proxy keeps only the projected mirror, never the raw OS inking::InkSynchronizer.
-    muxc::InkSynchronizer m_customDryMirror{ nullptr };
+    // Custom drying: the synchronizer handed back by ActivateCustomDrying (UI-thread cached; repeated
+    // calls return the same instance, UWP parity). It wraps the OS InkSynchronizer and owns the
+    // dry-transaction state; this proxy keeps only this projected wrapper, never the raw OS one.
+    muxc::InkSynchronizer m_customDrySynchronizer{ nullptr };
 
-    // Non-owning pointer to m_customDryMirror's implementation, so the in-context StrokesCollected
+    // Non-owning pointer to m_customDrySynchronizer's implementation, so the in-context StrokesCollected
     // callback can drive its ink-thread BeginDry. Set on the ink thread when custom drying is activated;
-    // valid for this proxy's lifetime (m_customDryMirror owns the object). Ink-thread only.
+    // valid for this proxy's lifetime (m_customDrySynchronizer owns the object). Ink-thread only.
     InkSynchronizer* m_customDrySync{ nullptr };
 
     // The shared DComp device, BORROWED from the InkCanvas/ThreadData that owns it (a per-UI-thread

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -194,8 +194,7 @@ public:
 
     // Back-pointer to the owning presenter mirror (UWP parity). Weak, so it never keeps the owner
     // alive; returns null once the owner is gone. Set by InkPresenter::Start (post-construction).
-    // Method (not property) to avoid a recursive XAML metadata thunk cycle - see the IDL comment.
-    muxc::InkPresenter GetInkPresenter() { return m_owner.get(); }
+    muxc::InkPresenter InkPresenter() { return m_owner.get(); }
     void SetOwner(winrt::weak_ref<muxc::InkPresenter> const& owner) { m_owner = owner; }
 
 private:
@@ -239,8 +238,7 @@ public:
 
     // Back-pointer to the owning presenter mirror (UWP parity). Weak, so it never keeps the owner
     // alive; returns null once the owner is gone. Set by InkPresenter::Start (post-construction).
-    // Method (not property) to avoid a recursive XAML metadata thunk cycle - see the IDL comment.
-    muxc::InkPresenter GetInkPresenter() { return m_owner.get(); }
+    muxc::InkPresenter InkPresenter() { return m_owner.get(); }
     void SetOwner(winrt::weak_ref<muxc::InkPresenter> const& owner) { m_owner = owner; }
 
 private:
@@ -306,8 +304,8 @@ public:
 
     void SetPredefinedConfiguration(inking::InkPresenterPredefinedConfiguration const& configuration);
 
-    muxc::InkHighContrastAdjustment GetHighContrastAdjustment() const noexcept;
-    void SetHighContrastAdjustment(muxc::InkHighContrastAdjustment const& value);
+    muxc::InkHighContrastAdjustment HighContrastAdjustment() const noexcept;
+    void HighContrastAdjustment(muxc::InkHighContrastAdjustment const& value);
 
     muxc::InkStrokeContainer StrokeContainer();
     muxc::InkInputProcessingConfiguration InputProcessingConfiguration();

--- a/controls/dev/InkToolbar/InkToolbar.cpp
+++ b/controls/dev/InkToolbar/InkToolbar.cpp
@@ -891,7 +891,7 @@ int32_t InkToolbar::GetHighContrastAdjustmentValue()
     {
         if (auto proxy = canvas.InkPresenter())
         {
-            return static_cast<int32_t>(proxy.GetHighContrastAdjustment());
+            return static_cast<int32_t>(proxy.HighContrastAdjustment());
         }
     }
     return 0; // UseSystemColorsWhenNecessary

--- a/controls/dev/dll/XamlMetadataProviderGenerated.h
+++ b/controls/dev/dll/XamlMetadataProviderGenerated.h
@@ -1717,6 +1717,26 @@ Entry c_typeEntries[] =
     },
     {
         /* Arg1 TypeName */ 
+        L"Microsoft.UI.Xaml.Controls.InkSynchronizer",
+        /* Arg2 CreateXamlTypeCallback */ 
+        []()
+        {
+            auto xamlType = winrt::make_self<XamlType>(
+                /* Arg 1 - TypeName */ 
+                (PCWSTR)L"Microsoft.UI.Xaml.Controls.InkSynchronizer",
+                /* Arg 2 - BaseTypeName */ 
+                (PCWSTR)L"Object",
+                /* Arg 3 - Activator func */ 
+                nullptr,
+                /* Arg 4 - Populate properties func */ 
+                nullptr
+            );
+
+            return static_cast<winrt::IXamlType>(*xamlType);
+        }
+    },
+    {
+        /* Arg1 TypeName */ 
         L"Microsoft.UI.Xaml.Controls.InkToolbar",
         /* Arg2 CreateXamlTypeCallback */ 
         []()

--- a/controls/dev/dll/XamlMetadataProviderGenerated.h
+++ b/controls/dev/dll/XamlMetadataProviderGenerated.h
@@ -1622,6 +1622,14 @@ Entry c_typeEntries[] =
                         false, /* isDependencyProperty */
                         false /* isAttachable */);
                     xamlType.AddMember(
+                        L"HighContrastAdjustment", /* propertyName */
+                        L"Microsoft.UI.Xaml.Controls.InkHighContrastAdjustment", /* propertyType */
+                        [](winrt::IInspectable instance) { return box_value<int>((int)instance.as<winrt::InkPresenter>().HighContrastAdjustment()); },
+                        [](winrt::IInspectable instance, winrt::IInspectable value) { instance.as<winrt::InkPresenter>().HighContrastAdjustment(unbox_value<winrt::InkHighContrastAdjustment>(value)); },
+                        false, /* isContent */
+                        false, /* isDependencyProperty */
+                        false /* isAttachable */);
+                    xamlType.AddMember(
                         L"InputConfiguration", /* propertyName */
                         L"Microsoft.UI.Xaml.Controls.InkInputConfiguration", /* propertyType */
                         [](winrt::IInspectable instance) { return instance.as<winrt::InkPresenter>().InputConfiguration(); },
@@ -1709,8 +1717,17 @@ Entry c_typeEntries[] =
                 /* Arg 3 - Activator func */ 
                 nullptr,
                 /* Arg 4 - Populate properties func */ 
-                nullptr
-            );
+                (std::function<void(XamlTypeBase&)>)[](XamlTypeBase& xamlType)
+                {
+                    xamlType.AddMember(
+                        L"InkPresenter", /* propertyName */
+                        L"Microsoft.UI.Xaml.Controls.InkPresenter", /* propertyType */
+                        [](winrt::IInspectable instance) { return instance.as<winrt::InkStrokeInput>().InkPresenter(); },
+                        nullptr, /* setter */
+                        false, /* isContent */
+                        false, /* isDependencyProperty */
+                        false /* isAttachable */);
+                });
 
             return static_cast<winrt::IXamlType>(*xamlType);
         }
@@ -2398,8 +2415,17 @@ Entry c_typeEntries[] =
                 /* Arg 3 - Activator func */ 
                 nullptr,
                 /* Arg 4 - Populate properties func */ 
-                nullptr
-            );
+                (std::function<void(XamlTypeBase&)>)[](XamlTypeBase& xamlType)
+                {
+                    xamlType.AddMember(
+                        L"InkPresenter", /* propertyName */
+                        L"Microsoft.UI.Xaml.Controls.InkPresenter", /* propertyType */
+                        [](winrt::IInspectable instance) { return instance.as<winrt::InkUnprocessedInput>().InkPresenter(); },
+                        nullptr, /* setter */
+                        false, /* isContent */
+                        false, /* isDependencyProperty */
+                        false /* isAttachable */);
+                });
 
             return static_cast<winrt::IXamlType>(*xamlType);
         }

--- a/controls/dev/inc/CppWinRTIncludes.h
+++ b/controls/dev/inc/CppWinRTIncludes.h
@@ -270,7 +270,8 @@ namespace winrt
 
     // using namespace ::winrt::Windows::UI::Input::Inking;
     using InkDrawingAttributes = ::winrt::Windows::UI::Input::Inking::InkDrawingAttributes;
-    using InkPresenter = ::winrt::Windows::UI::Input::Inking::InkPresenter;
+    // No InkPresenter alias: winrt::InkPresenter must resolve to the WinUI mirror
+    // (Microsoft.UI.Xaml.Controls.InkPresenter). Use the inking namespace alias for the OS type.
     using InkPresenterProtractor = ::winrt::Windows::UI::Input::Inking::InkPresenterProtractor;
     using InkPresenterRuler = ::winrt::Windows::UI::Input::Inking::InkPresenterRuler;
 


### PR DESCRIPTION
## Summary
Adds `Windows.UI.Input.Inking`-parity **custom drying** to the lifted `InkCanvas`.
`InkPresenter.ActivateCustomDrying()` returns an `InkSynchronizer` whose
`BeginDry()`/`EndDry()` let the app render committed ("dry") ink itself instead of the
OS drawing it.

## How it works
The OS DirectInk presenter runs off the UI thread (via `IInkDesktopHost`), so the proxy:
- Runs the real OS `BeginDry` **in-context** inside the ink-thread `StrokesCollected`
  callback (the only point it is valid), **holds the wet layer**, and hands the
  just-committed strokes to the app.
- The app paints them as dry ink and calls `EndDry`, which **releases the held wet
  layer and commits** — so the stroke stays continuously visible (no
  wet-removed-before-dry-painted gap).
- Rapid bursts are coalesced (the open dry is closed before the next `BeginDry`) and
  captured strokes are accumulated so none are lost before the app drains them.

## Key fix
When custom drying is activated the presenter is (re)created and its root visual is
bound with `SetRootVisual(rootVisual, device)` using the shared **DComposition
device** — not `nullptr`. That device wires the custom-dry wet→dry commit path; with a
null device `BeginDry` fails with `E_UNEXPECTED`. Activation happens while the
presenter is unsized (not yet "started"), then it is sized to begin input.

## Ownership
- The `muxc::InkSynchronizer` proxy owns the OS `InkSynchronizer` and the dry-transaction
  state; `InkPresenter` keeps only the projected mirror, never the raw OS type.
- The DComposition device is owned by the per-UI-thread `InkCanvas` data (shared by every
  `InkCanvas` on the thread); the presenter borrows a reference only for the custom-dry
  rebuild.
- All custom-dry state is ink-thread-affine and marshaled through the presenter's work
  queue (UI→ink synchronous, ink→UI async; weak refs break the cycle).

## Notes
- Custom drying is one-way (parity with UWP — the OS presenter has no "deactivate").
- Any residual visual difference at the wet→dry handoff is the app's own dry rendering
  (color/width/smoothing), not a timing gap.

## Demo / test
`ScratchPadApp` gains an "Activate custom drying" toggle that drives `BeginDry`/`EndDry`
from `StrokesCollected` and paints the dried strokes on the app's own overlay with a
live collection count.

## Testing
Built + deployed and verified by drawing with custom drying active: strokes are handed
to the app and rendered by it (the presenter's stroke container is emptied), and the
wet→dry transition is continuous.