### PR TITLE
Temporarily skip RS5 test execution

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-RunScenarioTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunScenarioTests-Stage.yml
@@ -30,6 +30,7 @@ stages:
       buildConfiguration: chk
       testOS: Win10-RS5
       testPayloadArtifactName: 'ScenarioTestPayload'
+      skipTests: true
 
   - template: WinUI-RunTestPassOnPipeline-Job.yml
     parameters:

--- a/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
@@ -11,6 +11,7 @@ parameters:
   rerunPassesRequiredToAvoidFailure: 5
   testPayloadArtifactName: 'TestPayload'
   failOnTestFailure: true
+  skipTests: false
 # We run the bulk of our tests in Helix. But this Job runs tests directly on the Pipeline agents.
 # These Pipeline agents are running on a ni_release build of Windows which is not available in Helix.
 # This approach allows us to run tests on prerelease builds of Windows.
@@ -18,7 +19,7 @@ parameters:
 jobs:
 - job: ${{ parameters.runTestJobName }} #${{ parameters.testOS }}${{ parameters.buildPlatform }}${{ parameters.buildConfiguration }}
   dependsOn: ${{ parameters.dependsOn }}
-  condition: not(failed())
+  condition: and(not(failed()), eq(${{ parameters.skipTests }}, false))
   pool:
     type: windows
     isCustom: true

--- a/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
@@ -40,5 +40,5 @@ stages:
         dependsOn: CreateTestPayload
         testOS: 'Win10-RS5'
         testPayloadArtifactName: 'TestPayload'
-        failOnTestFailure: ${{ parameters.failOnTestFailure }}
         skipTests: true
+        failOnTestFailure: ${{ parameters.failOnTestFailure }}

--- a/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
@@ -41,3 +41,4 @@ stages:
         testOS: 'Win10-RS5'
         testPayloadArtifactName: 'TestPayload'
         failOnTestFailure: ${{ parameters.failOnTestFailure }}
+        skipTests: true

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -169,7 +169,7 @@ extends:
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml@WinUIInternal
+      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml
         parameters:
           pipelineKind: PR
           # Test results are published but do not gate the pipeline yet.
@@ -181,7 +181,7 @@ extends:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal
+      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml
         parameters:
           pipelineKind: GitHubPR
           dependsOn: Build

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -169,7 +169,7 @@ extends:
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml
+      - template: AzurePipelinesTemplates\WinUI-RunTests-Stage.yml
         parameters:
           pipelineKind: PR
           # Test results are published but do not gate the pipeline yet.
@@ -181,7 +181,7 @@ extends:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml
+      - template: AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml
         parameters:
           pipelineKind: GitHubPR
           dependsOn: Build


### PR DESCRIPTION
## Description

Temporarily skips RS5 test execution while that validation environment is unavailable. The 23H2 and 25H2 test passes remain unchanged.

This adds a reusable `skipTests` parameter that defaults to `false`, opts out only the two RS5 execution callers, and resolves the dynamic test-stage templates from the GitHub branch so the mitigation is carried by the public validation definition.

## Validation

- Confirmed only `RunTestsRS5` and `RunAppTestsRS5` set `skipTests: true`.
- Confirmed payload generation, build stages, static tests, and non-RS5 execution remain unchanged.