### PR TITLE
Load GitHub PR pipeline templates from the PR branch

### DIFF
--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -38,7 +38,7 @@ parameters:
 
 variables:
 - template: AzurePipelinesTemplates\WindowsAppSDK-Versions.yml@WindowsAppSDKVersionConfig
-- template: build\AzurePipelinesTemplates\WinUI-BuildVariables.yml@WinUIInternal
+- template: AzurePipelinesTemplates\WinUI-BuildVariables.yml
 - group: WinUI-Variable-Library
 - name: WindowsContainerImage
   value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest'
@@ -48,10 +48,6 @@ resources:
     - repository: templates
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
-      ref: refs/heads/main
-    - repository: WinUIInternal
-      type: git
-      name: WinUI/microsoft-ui-xaml-lift
       ref: refs/heads/main
     - repository: WindowsAppSDKConfig
       type: git
@@ -146,7 +142,7 @@ extends:
               Write-Host "GitHub PR context validation completed."
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml
         parameters:
           pipelineKind: GitHubPR
           buildScenarioApps: true
@@ -157,7 +153,7 @@ extends:
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if and(eq(parameters.runFullValidation, true), eq(parameters.MUXFinalRelease, false)) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml
         parameters:
           stageName: Build_MUXFinalRelease
           pipelineKind: PR-2
@@ -169,19 +165,19 @@ extends:
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunTests-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-RunTests-Stage.yml
         parameters:
           pipelineKind: PR
           # Test results are published but do not gate the pipeline yet.
           failOnTestFailure: false
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml
         parameters:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml
         parameters:
           pipelineKind: GitHubPR
           dependsOn: Build


### PR DESCRIPTION
## Description

Updates GitHub PR validation to load WinUI-owned pipeline templates from the same GitHub revision being validated. This lets pipeline-template changes validate themselves and removes the lag caused by resolving those templates from a separately pinned repository.

The governed pipeline and Windows App SDK configuration resources remain unchanged.

## Validation

- Parsed the updated pipeline YAML.
- Verified all 20 recursively referenced local templates resolve from the pipeline file.