### PR TITLE
Skip static test stage in GitHub PR validation

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunStaticTests-Stage.yml
@@ -2,12 +2,13 @@
 # Licensed under the MIT License.
 parameters:
   MUXFinalRelease: false
+  condition: true
 
 stages:
 - stage: RunStaticTests
   displayName: Run Static Tests Stage
   dependsOn: Build
-  condition: not(failed())
+  condition: and(not(failed()), ${{ parameters.condition }})
   jobs:
   - template: WinUI-RunStaticTests-Job.yml
     parameters:

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -176,9 +176,10 @@ extends:
           failOnTestFailure: false
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml
         parameters:
           MUXFinalRelease: ${{ parameters.MUXFinalRelease }}
+          condition: false
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
       - template: build\AzurePipelinesTemplates\WinUI-RunScenarioTests-Stage.yml@WinUIInternal


### PR DESCRIPTION
## Description

Keeps the `RunStaticTests` stage in the WinUI GitHub PR pipeline while marking it as skipped. Static-test behavior in other pipelines remains unchanged.

## Validation

- Confirmed the updated pipeline YAML parses successfully.