### PR TITLE
Run GitHub PR builds when reuse output is unset

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-BuildWinUI-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildWinUI-Stage.yml
@@ -17,7 +17,7 @@ stages:
   # Skip the build job if we are reusing the output of a previous build.
   # useBuildOutputFromBuildId variable is set on the Pipeline at Queue time.
   condition:
-    and(succeeded(), eq(variables['useBuildOutputFromBuildId'],''))
+    and(succeeded(), eq(coalesce(variables['useBuildOutputFromBuildId'], ''), ''))
   dependsOn: ${{ parameters.dependsOn }}
   variables:
   - group: WinUI-InternalFeed

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -146,7 +146,7 @@ extends:
               Write-Host "GitHub PR context validation completed."
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml
         parameters:
           pipelineKind: GitHubPR
           buildScenarioApps: true
@@ -157,7 +157,7 @@ extends:
           dependsOn: ValidateGitHubPrContext
 
     - ${{ if and(eq(parameters.runFullValidation, true), eq(parameters.MUXFinalRelease, false)) }}:
-      - template: build\AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml@WinUIInternal
+      - template: AzurePipelinesTemplates\WinUI-BuildWinUI-Stage.yml
         parameters:
           stageName: Build_MUXFinalRelease
           pipelineKind: PR-2


### PR DESCRIPTION
## Description

Ensures GitHub-backed WinUI PR validation runs the build stages when no previous build output was requested.

Only the build-stage template is resolved from the GitHub revision so this condition can validate itself. Build variables, tests, static tests, and scenario tests continue to use `WinUIInternal`.

Queue-time build-output reuse remains unchanged.

## Validation

- Confirmed the focused YAML diff contains only the two build-stage template references and the missing-value condition.