### PR TITLE
TextCommandBarFlyout: close an empty flyout before it renders

### DIFF
--- a/controls/dev/CommandBarFlyout/CommandBarFlyout.cpp
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyout.cpp
@@ -159,6 +159,8 @@ CommandBarFlyout::CommandBarFlyout()
     Opening({
         [this](auto const&, auto const&)
         {
+            m_isClosingWithoutShowing = false;
+
             // The CommandBarFlyout is shown in standard mode in the case
             // where it's being opened as a context menu, rather than as a selection flyout.
             // In that circumstance, we want to have the flyout be open from the start.
@@ -182,6 +184,13 @@ CommandBarFlyout::CommandBarFlyout()
                 SharedHelpers::QueueCallbackForCompositionRendering(
                     [strongThis = get_strong(), commandBar]
                     {
+                        // This runs after Opened, so the flyout may have closed itself again in the
+                        // meantime because it had nothing to show.
+                        if (strongThis->m_isClosingWithoutShowing)
+                        {
+                            return;
+                        }
+
                         if (auto const commandBarFlyoutCommandBar = winrt::get_self<CommandBarFlyoutCommandBar>(commandBar))
                         {
                             auto const scopeGuard = gsl::finally([commandBarFlyoutCommandBar]()
@@ -210,6 +219,17 @@ CommandBarFlyout::CommandBarFlyout()
     Opened({
         [this](auto const&, auto const&)
         {
+            if (ShouldCloseWithoutShowing())
+            {
+                // Opened is raised after layout but before the frame is rendered, so closing now
+                // means the flyout is never actually drawn. The Closing handler below skips the
+                // close animation for this case, which would otherwise keep an empty flyout on
+                // screen for the duration of the animation.
+                m_isClosingWithoutShowing = true;
+                Hide();
+                return;
+            }
+
             if (auto commandBar = winrt::get_self<CommandBarFlyoutCommandBar>(m_commandBar.get()))
             {
                 if (commandBar->HasOpenAnimation())
@@ -235,7 +255,7 @@ CommandBarFlyout::CommandBarFlyout()
                 // So we need to remove it in all cases.
                 RemoveDropShadow();
 
-                if (!m_isClosingAfterCloseAnimation && commandBar->HasCloseAnimation())
+                if (!m_isClosingAfterCloseAnimation && !m_isClosingWithoutShowing && commandBar->HasCloseAnimation())
                 {
                     args.Cancel(true);
 

--- a/controls/dev/CommandBarFlyout/CommandBarFlyout.h
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyout.h
@@ -27,6 +27,11 @@ public:
     tracker_ref<winrt::FlyoutPresenter> GetPresenter();
 
 protected:
+    // Gives a derived flyout the last word on whether it has any UI worth showing. This is checked
+    // once the flyout has opened but before anything has been rendered, so returning true closes it
+    // again without the user ever seeing it.
+    virtual bool ShouldCloseWithoutShowing() { return false; }
+
     tracker_ref<winrt::CommandBarFlyoutCommandBar> m_commandBar{ this };
 
 private:
@@ -66,5 +71,6 @@ private:
     tracker_ref<winrt::FlyoutPresenter> m_presenter{ this };
 
     bool m_isClosingAfterCloseAnimation{ false };
+    bool m_isClosingWithoutShowing{ false };
 }; 
 

--- a/controls/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
+++ b/controls/dev/CommandBarFlyout/InteractionTests/TextCommandBarFlyoutTests.cs
@@ -524,18 +524,39 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
         [TestProperty("TestSuite", "C")]
         public void ValidateRightClickOnEmptyTextBoxDoesNotShowFlyout()
         {
-            using (var setup = new TestSetupHelper(new[] { "CommandBarFlyout Tests", "Extra CommandBarFlyout Tests" }))
+            // The test app disables the CommandBarFlyout open/close animations by default, but the flicker
+            // this test guards against only used to be visible while the close animation played.
+            Log.Comment("Re-enable animations for this test.");
+            new CheckBox(FindElement.ById("LongAnimationsDisabled")).Uncheck();
+
+            try
             {
-                Log.Comment("Clear the clipboard.");
-                FindElement.ById<Button>("ClearClipboardContentsButton").InvokeAndWait();
+                using (var setup = new TestSetupHelper(new[] { "CommandBarFlyout Tests", "Extra CommandBarFlyout Tests" }))
+                {
+                    Log.Comment("Clear the clipboard.");
+                    FindElement.ById<Button>("ClearClipboardContentsButton").InvokeAndWait();
 
-                Log.Comment("Right-click on the text box.");
-                InputHelper.RightClick(FindElement.ById("TextBox"));
+                    Log.Comment("Right-click inside the text box - a right-click on its very corner never reaches the text.");
+                    var textBox = FindElement.ById("TextBox");
+                    InputHelper.RightClick(textBox, 10, textBox.BoundingRectangle.Height / 2);
 
-                Log.Comment("Count the number of open popups.");
-                FindElement.ById<Button>("CountPopupsButton").InvokeAndWait();
+                    Log.Comment("Count the number of open popups.");
+                    FindElement.ById<Button>("CountPopupsButton").InvokeAndWait();
 
-                Verify.AreEqual("0", FindElement.ById<Edit>("PopupCountTextBox").Value);
+                    Verify.AreEqual("0", FindElement.ById<Edit>("PopupCountTextBox").Value);
+
+                    Log.Comment("The flyout should never have been rendered either - it used to flicker on screen before closing itself.");
+                    Verify.AreEqual("0", FindElement.ById<Edit>("FlyoutVisibleFrameCountTextBox").Value);
+                }
+            }
+            finally
+            {
+                var animationsDisabledCheckBox = TryFindElement.ById("LongAnimationsDisabled");
+
+                if (animationsDisabledCheckBox != null)
+                {
+                    new CheckBox(animationsDisabledCheckBox).Check();
+                }
             }
         }
 

--- a/controls/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml
+++ b/controls/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml
@@ -65,6 +65,7 @@
             <Button AutomationProperties.AutomationId="CountPopupsButton" Content="Count popups" Click="OnCountPopupsClicked" Margin="0,0,8,0"/>
             <TextBox x:Name="PopupCountTextBox" AutomationProperties.AutomationId="PopupCountTextBox" IsReadOnly="True" />
             <TextBox x:Name="CustomButtonsOpenCount" AutomationProperties.AutomationId="CustomButtonsOpenCount" IsReadOnly="True" />
+            <TextBox x:Name="FlyoutVisibleFrameCountTextBox" AutomationProperties.AutomationId="FlyoutVisibleFrameCountTextBox" IsReadOnly="True" Margin="8,0,0,0" />
         </StackPanel>
     </StackPanel>
 </local:TestPage>

--- a/controls/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml.cs
+++ b/controls/dev/CommandBarFlyout/TestUI/ExtraCommandBarFlyoutPage.xaml.cs
@@ -23,6 +23,8 @@ namespace MUXControlsTestApp
     public sealed partial class ExtraCommandBarFlyoutPage : TestPage
     {
         private int customButtonsFlyoutOpenCount = 0;
+        private int flyoutVisibleFrameCount = 0;
+        private bool isCountingFlyoutFrames = false;
 
         public ExtraCommandBarFlyoutPage()
         {
@@ -34,6 +36,49 @@ namespace MUXControlsTestApp
             RichTextBlock1.ContextFlyout = TextCommandBarContextFlyout;
             TextBox1.SelectionFlyout = TextCommandBarSelectionFlyout;
             RichTextBlock1.SelectionFlyout = TextCommandBarSelectionFlyout;
+
+            TextCommandBarContextFlyout.Opening += OnContextFlyoutOpening;
+            TextCommandBarContextFlyout.Closed += OnContextFlyoutClosed;
+        }
+
+        private void OnContextFlyoutOpening(object sender, object args)
+        {
+            flyoutVisibleFrameCount = 0;
+            CountFlyoutFrames(true);
+        }
+
+        private void OnContextFlyoutClosed(object sender, object args)
+        {
+            CountFlyoutFrames(false);
+        }
+
+        private void CountFlyoutFrames(bool count)
+        {
+            if (count == isCountingFlyoutFrames)
+            {
+                return;
+            }
+
+            isCountingFlyoutFrames = count;
+
+            if (count)
+            {
+                CompositionTarget.Rendering += OnRendering;
+            }
+            else
+            {
+                CompositionTarget.Rendering -= OnRendering;
+            }
+        }
+
+        // Rendering is raised right before the frame is drawn, so an open popup at this point is a
+        // popup the user is about to see.
+        private void OnRendering(object sender, object args)
+        {
+            if (VisualTreeHelper.GetOpenPopupsForXamlRoot(XamlRoot).Count > 0)
+            {
+                flyoutVisibleFrameCount++;
+            }
         }
 
         private void OnClearClipboardContentsClicked(object sender, object args)
@@ -45,6 +90,7 @@ namespace MUXControlsTestApp
         {
             PopupCountTextBox.Text = VisualTreeHelper.GetOpenPopupsForXamlRoot(XamlRoot).Count.ToString();
             CustomButtonsOpenCount.Text = customButtonsFlyoutOpenCount.ToString();
+            FlyoutVisibleFrameCountTextBox.Text = flyoutVisibleFrameCount.ToString();
         }
 
         private void tbloaded(object sender, RoutedEventArgs e)

--- a/controls/dev/CommandBarFlyout/TextCommandBarFlyout.cpp
+++ b/controls/dev/CommandBarFlyout/TextCommandBarFlyout.cpp
@@ -20,23 +20,17 @@ TextCommandBarFlyout::TextCommandBarFlyout()
             UpdateButtons();
         }
     });
+}
 
-    Opened({
-        [this](auto const&, auto const&)
-        {
-            // If there aren't any primary commands and we aren't opening expanded,
-            // or if there are just no commands at all, then we'll have literally no UI to show. 
-            // We'll just close the flyout in that case - nothing should be opening us
-            // in this state anyway, but this makes sure we don't have a light-dismiss layer
-            // with nothing visible to light dismiss.
-
-            if (PrimaryCommands().Size() == 0 &&
-                (SecondaryCommands().Size() == 0 || (!m_commandBar.get().IsOpen() && ShowMode() != winrt::FlyoutShowMode::Standard)))
-            {
-                Hide();
-            }
-        }
-    });
+bool TextCommandBarFlyout::ShouldCloseWithoutShowing()
+{
+    // If there aren't any primary commands and we aren't opening expanded,
+    // or if there are just no commands at all, then we'll have literally no UI to show.
+    // We'll just close the flyout in that case - nothing should be opening us
+    // in this state anyway, but this makes sure we don't have a light-dismiss layer
+    // with nothing visible to light dismiss.
+    return PrimaryCommands().Size() == 0 &&
+        (SecondaryCommands().Size() == 0 || (!m_commandBar.get().IsOpen() && ShowMode() != winrt::FlyoutShowMode::Standard));
 }
 
 void TextCommandBarFlyout::InitializeButtonWithUICommand(

--- a/controls/dev/CommandBarFlyout/TextCommandBarFlyout.h
+++ b/controls/dev/CommandBarFlyout/TextCommandBarFlyout.h
@@ -30,6 +30,9 @@ public:
 
     TextCommandBarFlyout();
 
+protected:
+    bool ShouldCloseWithoutShowing() override;
+
 private:
     void UpdateButtons();
 


### PR DESCRIPTION
## Fixes

Fixes #10994

## PR Type

- [x] Bugfix

## Description

Right-clicking an empty, editable `TextBox` with an empty clipboard leaves `TextCommandBarFlyout` with no commands at all, so it closed itself from its `Opened` handler. But `CommandBarFlyout`'s `Closing` handler cancels *every* close in order to play `ClosingOpacityStoryboard` first — so instead of never appearing, the empty flyout was drawn and then faded out over ~140 ms. The composition-rendering callback queued from `Opening` runs after `Opened`, so it also expanded the command bar, opening the overflow popup on the way out.

`Opened` is raised after layout but *before* the frame is rendered, so closing there is early enough — it just must not animate.

`CommandBarFlyout` now asks a new protected virtual `ShouldCloseWithoutShowing()` before starting the open animation or raising `MenuOpened`, and remembers that decision (`m_isClosingWithoutShowing`) so that:

- the `Closing` handler skips the close animation, and
- the queued composition-rendering callback stops expanding a flyout that has already given up.

`TextCommandBarFlyout`'s existing "no UI to show" condition moves into that override unchanged, which keeps the check at `Opened` — where apps that add commands from their own `Opening` handler have already run.

### Current Behavior

The empty flyout is rendered and visibly flickers for the duration of the close animation, briefly expanding as it goes.

### New Behavior

The empty flyout is never rendered at all. No popup, no flicker.

## Customer Impact

User-facing. Fixes the visual glitch reported in #10994 (reproducible in WinUI Gallery's `TextBox` sample): right-clicking an empty `TextBox` with an empty clipboard no longer flashes a context menu.

## Regression Potential

- [x] Low risk — isolated change, limited scope

`ShouldCloseWithoutShowing()` defaults to `false`, so every `CommandBarFlyout` other than `TextCommandBarFlyout` behaves exactly as before. For `TextCommandBarFlyout` the condition itself is unchanged and still evaluated at the same point in the lifecycle — only the *way* the flyout closes changes (no animation, and the pending expand callback is skipped).

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

The existing `ValidateRightClickOnEmptyTextBoxDoesNotShowFlyout` interaction test could not catch this bug for three reasons, all fixed in the second commit:

1. **It only counted popups after everything had settled** — which is `0` whether or not the flyout flickered on the way. `ExtraCommandBarFlyoutPage` now counts the frames the flyout was actually on screen for: it subscribes to `CompositionTarget.Rendering` while the flyout is alive and increments when a popup is open. `Rendering` is raised right before the frame is drawn, so an open popup there is one the user is about to see.
2. **It never opened the flyout in the first place** — `InputHelper.RightClick` defaults to offset `(0,0)`, the element's top-left corner rather than its centre; on a `TextBox` that lands on the border and no context menu is requested. It now right-clicks inside the text.
3. **The test app disables long animations at startup**, which swaps in a `CommandBarFlyoutCommandBar` style with the storyboards stripped — and the flicker only existed while the close animation played. The test re-enables animations and restores the setting in a `finally`.

Verified red/green against the same test binary with only the product DLL swapped: **13 rendered frames without the fix, 0 with it.**
