### PR TITLE
NavigationView: show FooterMenuItems sub-items in a flyout

### DIFF
--- a/controls/dev/NavigationView/NavigationView.cpp
+++ b/controls/dev/NavigationView/NavigationView.cpp
@@ -360,19 +360,10 @@ void NavigationView::SelectandMoveOverflowItem(winrt::IInspectable const& select
 void NavigationView::CloseFlyoutIfRequired(const winrt::NavigationViewItem& selectedItem)
 {
     auto const selectedIndex = m_selectionModel.SelectedIndex();
-    const bool isInModeWithFlyout = [this]()
-    {
-        if (auto splitView = m_rootSplitView.get())
-        {
-            // Check if the pane is closed and if the splitview is in either compact mode.
-            const auto splitViewDisplayMode = splitView.DisplayMode();
-            return (!splitView.IsPaneOpen() && (splitViewDisplayMode == winrt::SplitViewDisplayMode::CompactOverlay || splitViewDisplayMode == winrt::SplitViewDisplayMode::CompactInline)) ||
-                    PaneDisplayMode() == winrt::NavigationViewPaneDisplayMode::Top;
-        }
-        return false;
-    }();
 
-    if (isInModeWithFlyout && selectedIndex && !DoesNavigationViewItemHaveChildren(selectedItem))
+    // Whether we are in a mode with a flyout is answered by the root item itself below, via
+    // ShouldRepeaterShowInFlyout.
+    if (selectedIndex && !DoesNavigationViewItemHaveChildren(selectedItem))
     {
         // Item selected is a leaf node, find top level parent and close flyout
         if (auto const rootItem = GetContainerForIndex(selectedIndex.GetAt(1), selectedIndex.GetAt(0) == c_footerMenuBlockIndex /* inFooter */))
@@ -1170,7 +1161,16 @@ winrt::IndexPath NavigationView::GetIndexPathForContainer(const winrt::Navigatio
         if (auto const nvi = m_lastItemExpandedIntoFlyout.get())
         {
             child = nvi;
-            parent = IsTopNavigationView() ? m_topNavRepeater.get() : m_leftNavRepeater.get();
+            // The expanded item can live in either the main menu or the footer, so ask for its actual repeater
+            // instead of assuming the main one.
+            if (auto const expandedItemParentIR = GetParentItemsRepeaterForContainer(nvi))
+            {
+                parent = expandedItemParentIR;
+            }
+            else
+            {
+                parent = IsTopNavigationView() ? m_topNavRepeater.get() : m_leftNavRepeater.get();
+            }
         }
     }
 
@@ -1256,7 +1256,10 @@ void NavigationView::OnRepeaterElementPrepared(const winrt::ItemsRepeater& ir, c
             // Propagate depth to children items if they exist
             const auto childDepth = [position, nvibImpl]()
             {
-                if (position == NavigationViewRepeaterPosition::TopPrimary)
+                // These positions show their children in a flyout, which starts back at depth 0.
+                if (position == NavigationViewRepeaterPosition::TopPrimary ||
+                    position == NavigationViewRepeaterPosition::TopFooter ||
+                    position == NavigationViewRepeaterPosition::LeftFooter)
                 {
                     return 0;
                 }

--- a/controls/dev/NavigationView/NavigationViewItem.cpp
+++ b/controls/dev/NavigationView/NavigationViewItem.cpp
@@ -771,6 +771,14 @@ bool NavigationViewItem::IsOnTopPrimary() const
     return Position() == NavigationViewRepeaterPosition::TopPrimary && isPaneDisplayModeTop;
 }
 
+// Only top-level footer items carry a footer position - children of a footer item are positioned
+// as regular nav items, so this is true exactly for the items directly in FooterMenuItems.
+bool NavigationViewItem::IsOnFooter() const
+{
+    auto const position = Position();
+    return position == NavigationViewRepeaterPosition::LeftFooter || position == NavigationViewRepeaterPosition::TopFooter;
+}
+
 winrt::UIElement const NavigationViewItem::GetPresenterOrItem() const
 {
     if (auto const presenter = m_navigationViewItemPresenter.get())
@@ -896,7 +904,9 @@ void NavigationViewItem::ReparentRepeater()
 
 bool NavigationViewItem::ShouldRepeaterShowInFlyout() const
 {
-    return (m_isClosedCompact && IsTopLevelItem()) || IsOnTopPrimary();
+    // Footer items always use the flyout. The footer only gets a slice of the pane's height, so
+    // expanding inline squashes the items below it and makes the footer scroll instead of growing.
+    return (m_isClosedCompact && IsTopLevelItem()) || IsOnTopPrimary() || IsOnFooter();
 }
 
 bool NavigationViewItem::IsRepeaterVisible() const

--- a/controls/dev/NavigationView/NavigationViewItem.h
+++ b/controls/dev/NavigationView/NavigationViewItem.h
@@ -110,6 +110,7 @@ private:
     bool ShouldEnableToolTip() const;
     bool IsOnLeftNav() const;
     bool IsOnTopPrimary() const;
+    bool IsOnFooter() const;
     bool IsOutOfControlBounds(const winrt::Point& point);
 
     void UpdateRepeaterItemsSource();

--- a/controls/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
+++ b/controls/dev/NavigationView/NavigationView_ApiTests/NavigationViewTests.cs
@@ -1656,6 +1656,83 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
             Verify.IsTrue(ItemHasSelectionIndicator(navView, "Menu Item 7"));
         }
 
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/5356
+        [TestMethod]
+        public void VerifyTopModeFooterItemShowsChildrenInFlyout()
+        {
+            VerifyFooterItemShowsChildrenInFlyout(NavigationViewPaneDisplayMode.Top);
+        }
+
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/5356
+        [TestMethod]
+        public void VerifyLeftModeFooterItemShowsChildrenInFlyout()
+        {
+            VerifyFooterItemShowsChildrenInFlyout(NavigationViewPaneDisplayMode.Left);
+        }
+
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/5356
+        [TestMethod]
+        public void VerifyLeftCompactFooterItemShowsChildrenInFlyout()
+        {
+            VerifyFooterItemShowsChildrenInFlyout(NavigationViewPaneDisplayMode.LeftCompact);
+        }
+
+        private void VerifyFooterItemShowsChildrenInFlyout(NavigationViewPaneDisplayMode paneDisplayMode)
+        {
+            NavigationView navView = null;
+            NavigationViewItem footerItem = null;
+            NavigationViewItem footerChild = null;
+            var loadedEvent = new ManualResetEvent(false);
+
+            RunOnUIThread.Execute(() =>
+            {
+                footerChild = new NavigationViewItem() { Content = "Footer Child" };
+                footerItem = new NavigationViewItem() { Content = "Footer Item", SelectsOnInvoked = false };
+                footerItem.MenuItems.Add(footerChild);
+
+                navView = new NavigationView() {
+                    PaneDisplayMode = paneDisplayMode,
+                    IsSettingsVisible = false
+                };
+                navView.MenuItems.Add(new NavigationViewItem() { Content = "Menu Item" });
+                navView.FooterMenuItems.Add(footerItem);
+
+                navView.Loaded += (sender, args) => loadedEvent.Set();
+                Content = navView;
+            });
+
+            loadedEvent.WaitOne();
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                footerItem.IsExpanded = true;
+            });
+
+            // Showing the flyout is deferred to a composition rendering callback.
+            IdleSynchronizer.Wait();
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.IsNotNull(GetVisualAncestorByName(footerChild, "FlyoutContentGrid"),
+                    "Children of a footer item should be hosted in the item's flyout, not inline inside the item.");
+            });
+        }
+
+        static FrameworkElement GetVisualAncestorByName(DependencyObject element, string name)
+        {
+            for (var current = VisualTreeHelper.GetParent(element); current != null; current = VisualTreeHelper.GetParent(current))
+            {
+                if (current is FrameworkElement frameworkElement && frameworkElement.Name == name)
+                {
+                    return frameworkElement;
+                }
+            }
+
+            return null;
+        }
+
         static ItemsRepeater GetRepeater(DependencyObject parent)
         {
             static ItemsRepeater GetNavigationViewRepeaterHelper(DependencyObject root)

--- a/controls/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
+++ b/controls/dev/NavigationView/NavigationView_InteractionTests/CommonTests.cs
@@ -1692,6 +1692,42 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTes
             }
         }
 
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/5356
+        [TestMethod]
+        [TestProperty("TestSuite", "D")]
+        public void VerifyFooterItemChildrenUseFlyoutInLeftMode()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "HierarchicalNavigationView FooterMenuItems Test" }))
+            {
+                Log.Comment("Set PaneDisplayMode to Left.");
+                var panelDisplayModeComboBox = new ComboBox(FindElement.ByName("PaneDisplayModeCombobox"));
+                panelDisplayModeComboBox.SelectItemByName("Left");
+                Wait.ForIdle();
+
+                UIObject footerItem1 = FindElement.ByName("Footer Item 1");
+                UIObject footerItem5 = FindElement.ByName("Footer Item 5");
+                var footerItem5Height = footerItem5.BoundingRectangle.Height;
+                Verify.IsTrue(footerItem5Height > 20, "Footer Item 5 should start at a normal height. Height: " + footerItem5Height);
+
+                Log.Comment("Expand Footer Item 1 using its chevron.");
+                InputHelper.LeftClick(footerItem1, footerItem1.BoundingRectangle.Width - 20, footerItem1.BoundingRectangle.Height / 2);
+                Wait.ForIdle();
+
+                Verify.IsNotNull(FindElement.ByName("Footer Item 4"), "Footer Item 4 should be visible after expanding Footer Item 1.");
+
+                Log.Comment("Verify the children went into the flyout instead of expanding inline.");
+                new Button(FindElement.ByName("GetFooterItem2ParentButton")).Invoke();
+                Wait.ForIdle();
+                Verify.AreEqual("Flyout", new TextBlock(FindElement.ByName("FooterItem2ParentLabel")).DocumentText);
+
+                Log.Comment("Verify the rest of the footer was not squashed to make room for the children.");
+                ElementCache.Refresh();
+                footerItem5 = FindElement.ByName("Footer Item 5");
+                Verify.AreEqual(footerItem5Height, footerItem5.BoundingRectangle.Height,
+                    "Footer Item 5 should keep its height when a sibling expands.");
+            }
+        }
+
         [TestMethod]
         [TestProperty("TestSuite", "D")]
         public void VerifyNoCrashWhenSwitchingPaneDisplayModeWithAutoWrappedElements()

--- a/controls/dev/NavigationView/NavigationView_InteractionTests/TopModeTests.cs
+++ b/controls/dev/NavigationView/NavigationView_InteractionTests/TopModeTests.cs
@@ -782,6 +782,70 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests.NavigationViewTes
             }
         }
 
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/5356
+        [TestMethod]
+        public void TopNavigationFooterItemShowsChildrenInFlyoutTest()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "HierarchicalNavigationView FooterMenuItems Test" }))
+            {
+                UIObject footerItem1 = FindElement.ByName("Footer Item 1");
+                Verify.IsNotNull(footerItem1, "Footer Item 1 should be visible.");
+                Verify.IsNull(FindElement.ByName("Footer Item 4"), "Footer Item 4 should not be visible.");
+
+                ClickOnNavigationViewItemChevron(footerItem1);
+
+                UIObject footerItem4 = FindElement.ByName("Footer Item 4");
+                Verify.IsNotNull(footerItem4, "Footer Item 4 should be visible after expanding Footer Item 1.");
+
+                Log.Comment("Verify that the children are hosted in the flyout and not inline in the top nav bar.");
+                new Button(FindElement.ByName("GetFooterItem2ParentButton")).Invoke();
+                Wait.ForIdle();
+                Verify.AreEqual("Flyout", new TextBlock(FindElement.ByName("FooterItem2ParentLabel")).DocumentText);
+
+                Verify.IsTrue(
+                    footerItem4.BoundingRectangle.Top >= footerItem1.BoundingRectangle.Bottom,
+                    "Children should be laid out below the footer item, not on top of it. Footer Item 1: "
+                        + footerItem1.BoundingRectangle + ", Footer Item 4: " + footerItem4.BoundingRectangle);
+
+                ClickOnNavigationViewItemChevron(footerItem1);
+                ElementCache.Refresh();
+                Verify.IsNull(FindElement.ByName("Footer Item 4"), "Footer Item 4 should not be visible after collapsing Footer Item 1.");
+            }
+        }
+
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/5356
+        [TestMethod]
+        public void TopNavigationCanSelectChildOfFooterItemTest()
+        {
+            using (var setup = new TestSetupHelper(new[] { "NavigationView Tests", "HierarchicalNavigationView FooterMenuItems Test" }))
+            {
+                TextBlock selectedItemLabel = new TextBlock(FindElement.ByName("SelectedItemLabel"));
+                Verify.AreEqual("uninitialized", selectedItemLabel.DocumentText);
+
+                UIObject footerItem1 = FindElement.ByName("Footer Item 1");
+                ClickOnNavigationViewItemChevron(footerItem1);
+
+                Log.Comment("Expand Footer Item 2 inside the flyout.");
+                UIObject footerItem2 = FindElement.ByName("Footer Item 2");
+                Verify.IsNotNull(footerItem2, "Footer Item 2 should be visible.");
+                InputHelper.LeftClick(footerItem2);
+                Wait.ForIdle();
+
+                Log.Comment("Select the grandchild, which should close the flyout.");
+                UIObject footerItem3 = FindElement.ByName("Footer Item 3");
+                Verify.IsNotNull(footerItem3, "Footer Item 3 should be visible after expanding Footer Item 2.");
+                InputHelper.LeftClick(footerItem3);
+                Wait.ForIdle();
+
+                new Button(FindElement.ByName("GetSelectedItemLabelButton")).Invoke();
+                Wait.ForIdle();
+                Verify.AreEqual("Footer Item 3", selectedItemLabel.DocumentText);
+
+                ElementCache.Refresh();
+                Verify.IsNull(FindElement.ById("ChildrenFlyout"), "Flyout should be closed after selecting a leaf item.");
+            }
+        }
+
         private void ClickOnNavigationViewItemChevron(UIObject nvi)
         {
             Log.Comment("Click On NavigationViewItem Chevron");

--- a/controls/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewFooterMenuItems.xaml
+++ b/controls/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewFooterMenuItems.xaml
@@ -1,0 +1,54 @@
+﻿<!-- Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License. See LICENSE in the project root for license information. -->
+<Page
+    x:Class="MUXControlsTestApp.HierarchicalNavigationViewFooterMenuItems"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:MUXControlsTestApp"
+    xmlns:muxcontrols="using:Microsoft.UI.Xaml.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <muxcontrols:NavigationView
+            x:Name="navview"
+            PaneDisplayMode="Top"
+            IsSettingsVisible="False">
+            <muxcontrols:NavigationView.MenuItems>
+                <muxcontrols:NavigationViewItem Content="Menu Item 1" x:Name="MI1" />
+                <muxcontrols:NavigationViewItem Content="Menu Item 2" x:Name="MI2" />
+            </muxcontrols:NavigationView.MenuItems>
+            <muxcontrols:NavigationView.FooterMenuItems>
+                <muxcontrols:NavigationViewItem Content="Footer Item 1" x:Name="FI1" SelectsOnInvoked="False">
+                    <muxcontrols:NavigationViewItem.MenuItems>
+                        <muxcontrols:NavigationViewItem Content="Footer Item 2" x:Name="FI2" SelectsOnInvoked="False">
+                            <muxcontrols:NavigationViewItem.MenuItems>
+                                <muxcontrols:NavigationViewItem Content="Footer Item 3" x:Name="FI3" />
+                            </muxcontrols:NavigationViewItem.MenuItems>
+                        </muxcontrols:NavigationViewItem>
+                        <muxcontrols:NavigationViewItem Content="Footer Item 4" x:Name="FI4" />
+                    </muxcontrols:NavigationViewItem.MenuItems>
+                </muxcontrols:NavigationViewItem>
+                <muxcontrols:NavigationViewItem Content="Footer Item 5" x:Name="FI5" />
+            </muxcontrols:NavigationView.FooterMenuItems>
+
+            <StackPanel Margin="10,10,0,0" Spacing="5">
+                <TextBlock x:Name="SelectedItemLabel" AutomationProperties.Name="SelectedItemLabel" Text="uninitialized"/>
+                <Button Content="Get Selected Item Label" x:Name="GetSelectedItemLabelButton" AutomationProperties.Name="GetSelectedItemLabelButton" Click="PrintSelectedItem"/>
+                <TextBlock x:Name="FooterItem2ParentLabel" AutomationProperties.Name="FooterItem2ParentLabel" Text="uninitialized"/>
+                <Button Content="Get Footer Item 2 Parent" x:Name="GetFooterItem2ParentButton" AutomationProperties.Name="GetFooterItem2ParentButton" Click="PrintFooterItem2Parent"/>
+
+                <ComboBox x:Name="PaneDisplayModeCombobox"
+                          AutomationProperties.Name="PaneDisplayModeCombobox"
+                          Header="PaneDisplayMode"
+                          SelectionChanged="PaneDisplayModeCombobox_SelectionChanged"
+                          Margin="5">
+                    <ComboBoxItem Content="Top" Tag="Top"/>
+                    <ComboBoxItem Content="Left" Tag="Left"/>
+                    <ComboBoxItem Content="LeftCompact" Tag="LeftCompact"/>
+                </ComboBox>
+            </StackPanel>
+        </muxcontrols:NavigationView>
+    </Grid>
+</Page>

--- a/controls/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewFooterMenuItems.xaml.cs
+++ b/controls/dev/NavigationView/TestUI/Hierarchical/HierarchicalNavigationViewFooterMenuItems.xaml.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using MUXControlsTestApp.Utilities;
+
+namespace MUXControlsTestApp
+{
+    public sealed partial class HierarchicalNavigationViewFooterMenuItems : Page
+    {
+        public HierarchicalNavigationViewFooterMenuItems()
+        {
+            this.InitializeComponent();
+        }
+
+        private void PrintSelectedItem(object sender, RoutedEventArgs e)
+        {
+            var selectedItem = navview.SelectedItem;
+            SelectedItemLabel.Text = selectedItem != null
+                ? (string)((NavigationViewItem)selectedItem).Content
+                : "No Item Selected";
+        }
+
+        // Children hosted in the flyout are reparented out of the item itself, so the presence of a
+        // FlyoutPresenter above them is what tells the flyout and inline layouts apart.
+        private void PrintFooterItem2Parent(object sender, RoutedEventArgs e)
+        {
+            if (FI2.FindVisualParentByType<FlyoutPresenter>() != null)
+            {
+                FooterItem2ParentLabel.Text = "Flyout";
+            }
+            else if (FI2.FindVisualParentByType<NavigationViewItem>() != null)
+            {
+                FooterItem2ParentLabel.Text = "Inline";
+            }
+            else
+            {
+                FooterItem2ParentLabel.Text = "Not realized";
+            }
+        }
+
+        private void PaneDisplayModeCombobox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var tag = Convert.ToString(((sender as ComboBox).SelectedItem as ComboBoxItem).Tag);
+            navview.PaneDisplayMode = (NavigationViewPaneDisplayMode)Enum.Parse(typeof(NavigationViewPaneDisplayMode), tag);
+        }
+    }
+}

--- a/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml
+++ b/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml
@@ -50,9 +50,6 @@
                 <Button x:Name="NavigationViewMenuItemStretchPageButton" AutomationProperties.Name="NavigationView Menuitem Stretch Test" Margin="2" HorizontalAlignment="Stretch">NavigationView Menuitem Stretch Test</Button>
                 <Button x:Name="NavigationViewMenuItemsSourcePage" AutomationProperties.Name="NavigationViewMenuItemsSourcePage" Margin="2" HorizontalAlignment="Stretch">NavigationView MenuItemsSource</Button>
                 <Button x:Name="NavigationViewFooterMenuItemsSourcePage" AutomationProperties.Name="NavigationViewFooterMenuItemsSourcePage" Margin="2" HorizontalAlignment="Stretch">NavigationView FooterMenuItemsSource</Button>
-                <TextBlock Text="Hierarchy Tests" />
-                <Button x:Name="NavigateToHierarchicalNavigationViewMarkupPage" AutomationProperties.Name="HierarchicalNavigationView Markup Test" Margin="2" HorizontalAlignment="Stretch">Hierarchical NavigationView Markup Test</Button>
-                <Button x:Name="NavigateToHierarchicalNavigationViewDataBindingPage" AutomationProperties.Name="HierarchicalNavigationView DataBinding Test" Margin="2" HorizontalAlignment="Stretch">Hierarchical NavigationView DataBinding Test</Button>
             </StackPanel>
             
             <StackPanel>
@@ -65,6 +62,11 @@
                 <TextBlock Text="Footer item tests"/>
                 <Button x:Name="PaneLayoutTestPageButton" AutomationProperties.Name="PaneLayoutTestPage" Margin="2" HorizontalAlignment="Stretch">PaneLayoutTestPage</Button>
                 <Button x:Name="PaneFooterTestPageButton" AutomationProperties.Name="PaneFooterTestPage" Margin="2" HorizontalAlignment="Stretch">PaneFooterTestPage</Button>
+
+                <TextBlock Text="Hierarchy Tests" />
+                <Button x:Name="NavigateToHierarchicalNavigationViewMarkupPage" AutomationProperties.Name="HierarchicalNavigationView Markup Test" Margin="2" HorizontalAlignment="Stretch">Hierarchical NavigationView Markup Test</Button>
+                <Button x:Name="NavigateToHierarchicalNavigationViewDataBindingPage" AutomationProperties.Name="HierarchicalNavigationView DataBinding Test" Margin="2" HorizontalAlignment="Stretch">Hierarchical NavigationView DataBinding Test</Button>
+                <Button x:Name="NavigateToHierarchicalNavigationViewFooterMenuItemsPage" AutomationProperties.Name="HierarchicalNavigationView FooterMenuItems Test" Margin="2" HorizontalAlignment="Stretch">Hierarchical NavigationView FooterMenuItems Test</Button>
             </StackPanel>
 
             <StackPanel>

--- a/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml.cs
+++ b/controls/dev/NavigationView/TestUI/NavigationViewCaseBundle.xaml.cs
@@ -43,6 +43,7 @@ namespace MUXControlsTestApp
             NavigationViewMenuItemStretchPageButton.Click += delegate { Frame.NavigateWithoutAnimation(typeof(NavigationViewMenuItemStretchPage), 0); };
             NavigateToHierarchicalNavigationViewMarkupPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(HierarchicalNavigationViewMarkup), 0); };
             NavigateToHierarchicalNavigationViewDataBindingPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(HierarchicalNavigationViewDataBinding), 0); };
+            NavigateToHierarchicalNavigationViewFooterMenuItemsPage.Click += delegate { Frame.NavigateWithoutAnimation(typeof(HierarchicalNavigationViewFooterMenuItems), 0); };
             PaneLayoutTestPageButton.Click += delegate { Frame.NavigateWithoutAnimation(typeof(PaneLayoutTestPage), 0); };
             PaneFooterTestPageButton.Click += delegate { Frame.NavigateWithoutAnimation(typeof(PaneFooterTestPage), 0); };
         }

--- a/controls/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
+++ b/controls/dev/NavigationView/TestUI/NavigationView_TestUI.projitems
@@ -30,6 +30,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Hierarchical\HierarchicalNavigationViewFooterMenuItems.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Hierarchical\HierarchicalNavigationViewMarkup.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -149,6 +153,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Hierarchical\HierarchicalNavigationViewDataBinding.xaml.cs">
       <DependentUpon>HierarchicalNavigationViewDataBinding.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Hierarchical\HierarchicalNavigationViewFooterMenuItems.xaml.cs">
+      <DependentUpon>HierarchicalNavigationViewFooterMenuItems.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Hierarchical\HierarchicalNavigationViewMarkup.xaml.cs">
       <DependentUpon>HierarchicalNavigationViewMarkup.xaml</DependentUpon>


### PR DESCRIPTION
## Fixes

Fixes #5356

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

A `NavigationViewItem` in `FooterMenuItems` with child `MenuItems` never used the children flyout that items in `MenuItems` get.

`NavigationViewItem::ShouldRepeaterShowInFlyout()` only recognised `TopPrimary` and closed-compact top-level items. This adds `IsOnFooter()` to that check, so every top-level footer item shows its children in a flyout — in Left, LeftMinimal, Top and the already-flyout LeftCompact alike. Only items directly in `FooterMenuItems` carry `LeftFooter`/`TopFooter` (children of a footer item are positioned as regular nav items), so nested levels still expand inline *inside* the flyout, which is how Top mode already behaves for the main menu.

Two supporting fixes for footer children now hosted in a flyout:

- `GetIndexPathForContainer` assumed anything inside a flyout belonged to the main menu repeater, producing a wrong index path — and so wrong selection and no flyout dismissal — for footer children. It now asks the expanded item for its actual parent repeater. This was already wrong for footer children in LeftCompact, where the flyout worked before this change.
- `OnRepeaterElementPrepared` reset child depth to 0 only for `TopPrimary`, so footer children were indented inside the flyout.

`CloseFlyoutIfRequired` gated on "closed compact or Top" before deciding whether to collapse the root item. That list no longer matches where flyouts appear, and it was only ever an approximation of the `ShouldRepeaterShowInFlyout` check it already does on the root item, so it is dropped and the item answers for itself.

### Current Behavior

Sub-items of a footer item never get a flyout:

- **Top mode** — the children render inline, stacked on top of the item itself, which makes the NavigationView unusable (see the GIFs in #5356).
- **Left mode (open pane)** — the children expand inline into the footer. The footer lives in `FooterItemsScrollViewer`, whose `MaxHeight` `MeasureOverride` partitions against the main menu list, so the children eat the footer's height budget: the sibling below is clipped to ~3px and the footer starts to scroll.
- **LeftCompact (closed pane)** — the flyout appears, but selecting a footer child resolves to the wrong index path, so selection lands on the wrong item and the flyout is not dismissed.

### New Behavior

Top-level footer items show their children in the same flyout the main menu items use, in every pane display mode. Grandchildren expand inline within that flyout, at the correct depth. Selecting a leaf in the flyout selects the right item and closes the flyout.

## Customer Impact

User-facing. Hierarchical `FooterMenuItems` becomes usable — the "account menu in the footer" scenario from the proposal — without workarounds such as hosting a `MenuFlyout` manually.

⚠️ This changes behaviour for apps that today get inline expansion for footer items in an **open Left pane**. Those apps will now get a flyout instead. Given that inline expansion there squashes the rest of the footer, this looks like the intended fix rather than a behaviour worth preserving, but it is worth a conscious call during review.

## Regression Potential

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The changes are confined to NavigationView, but `GetIndexPathForContainer` and `CloseFlyoutIfRequired` are on shared selection paths used by main-menu flyouts too. The behaviour change for open-Left footer items is called out above.

## How Has This Been Tested?

New test page `HierarchicalNavigationViewFooterMenuItems`: a footer item with children and a grandchild, a plain footer sibling to catch the footer being squashed, and a `PaneDisplayMode` switch.

**API tests** (`NavigationViewTests.cs`) — children are hosted in the item's flyout rather than inline, in Top, Left and LeftCompact.

**Interaction tests**
- `TopNavigationFooterItemShowsChildrenInFlyoutTest` — expand and collapse through the chevron, children laid out below the item rather than on top of it.
- `TopNavigationCanSelectChildOfFooterItemTest` — select a grandchild out of the flyout; correct item selected, flyout dismissed.
- `VerifyFooterItemChildrenUseFlyoutInLeftMode` — the Left mode regression: a sibling footer item keeps its height when its neighbour expands.

`NavigationViewCaseBundle` also moves the Hierarchy Tests group to the second column, which has the room; a third button in the first column pushed it past the bottom of the page.

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

## Screenshots (if appropriate)

Before: see the GIFs in #5356.
