### PR TITLE
Fix null-pointer crash in ToolTipService::StartSafeZoneCheckTimer on threads without a DispatcherQueue

### DIFF
--- a/dxaml/xcp/dxaml/lib/ToolTipService_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/ToolTipService_Partial.cpp
@@ -394,6 +394,15 @@ ToolTipService::StartSafeZoneCheckTimer(
 
         IFC_RETURN(GetDispatcherQueueForCurrentThread(&dispatcherQueue));
 
+        // IDispatcherQueueStatics::GetForCurrentThread succeeds with a null queue when the
+        // calling thread has no DispatcherQueue (for example, legacy CoreDispatcher-based
+        // hosts). Guard against dereferencing it below: skip the safe-zone timer and let the
+        // ToolTip fall back to its normal pointer-exit close behavior instead of crashing.
+        if (!dispatcherQueue)
+        {
+            return S_OK;
+        }
+
         IFC_RETURN(dispatcherQueue->CreateTimer(&dispatcherQueueTimer));
 
         EventRegistrationToken token;


### PR DESCRIPTION
## Summary
Fixes a null-pointer access violation (read at `0x0`) in `ToolTipService::StartSafeZoneCheckTimer`.

## Root cause
`StartSafeZoneCheckTimer` creates the safe-zone `DispatcherQueueTimer` from the current thread's `DispatcherQueue`, obtained via `IDispatcherQueueStatics::GetForCurrentThread`. That API returns `S_OK` with a **null** queue when the calling thread has no `DispatcherQueue` (for example, legacy `CoreDispatcher`-based hosts). The code checked only the `HRESULT` and then dereferenced the queue to call `CreateTimer` -> access violation.

## Fix
Guard the returned queue. When it is null, skip creating the safe-zone timer and return success. The ToolTip is already open and still dismisses through its normal pointer-exit path, so the keep-open / safe-zone enhancement degrades gracefully on threads without a `DispatcherQueue`. Threads that do have a `DispatcherQueue` are unaffected.

## Risk
Low. Additive null check with an early return; no behavior change on the common path (thread has a `DispatcherQueue`).

## Testing
- Verified the ToolTip's normal dismissal path (pointer-leave -> `CancelAutomaticToolTip` -> `CloseAutomaticToolTip`) is independent of the safe-zone timer, so skipping it cannot leave a ToolTip stuck open.
- CI build/validation.
