### PR TITLE
CImageBase::EnsureBrush: guard null m_pImageSource in remeasure block

### DIFF
--- a/dxaml/xcp/core/core/elements/imagebase.cpp
+++ b/dxaml/xcp/core/core/elements/imagebase.cpp
@@ -110,7 +110,16 @@ CImageBase::EnsureBrush()
     // we're forced to make the UpdateMeasure call here.
     if ((m_pImageSource && m_pImageSource->m_fSourceNeedsMeasure) || m_containerRequiresMeasure)
     {
-        m_pImageSource->m_fSourceNeedsMeasure = FALSE;
+        // The block is also entered when only m_containerRequiresMeasure is set. That flag is set
+        // source-independently by CMediaBase::UpdateInternalSize on container size changes (including
+        // 0x0) per TFS 6673752, so m_pImageSource can legitimately be null here (Source=null,
+        // virtualized item recycle, or a torn-down async decode). Guard the deref to match every
+        // other m_pImageSource access in this function; the remeasure must still run for the
+        // container-size change, so only the flag clear is conditional.
+        if (m_pImageSource)
+        {
+            m_pImageSource->m_fSourceNeedsMeasure = FALSE;
+        }
         m_containerRequiresMeasure = false;
         IFC_RETURN(UpdateMeasure());
     }


### PR DESCRIPTION
## Summary
Fixes a null-pointer access violation in `CImageBase::EnsureBrush` (`dxaml/xcp/core/core/elements/imagebase.cpp`). Watson: `ACCESS_VIOLATION ... Microsoft.UI.Xaml.dll!CImageBase::EnsureBrush`.

## Related work items (ADO)
- **OS#61985596** — `Microsoft.UI.Xaml.dll` Watson bug this PR fixes: https://microsoft.visualstudio.com/OS/_workitems/edit/61985596
- **OS#57621304** — high-volume System XAML (`Windows.UI.Xaml.dll`) twin, ~336K in-market hits/14d (maintenance-mode binary; RCA/escalation only): https://microsoft.visualstudio.com/OS/_workitems/edit/57621304

## Root cause
The remeasure block is entered when **either** operand is true:
```cpp
if ((m_pImageSource && m_pImageSource->m_fSourceNeedsMeasure) || m_containerRequiresMeasure)
```
The `m_pImageSource &&` only guards the first operand. `m_containerRequiresMeasure` is set **source-independently** by `CMediaBase::UpdateInternalSize` on any container-size change including 0×0 (deliberate — TFS 6673752). So the block can run while `m_pImageSource` is null (`Source=null`, virtualized item recycle, torn-down/late async decode), and the first statement then dereferences null:
```cpp
m_pImageSource->m_fSourceNeedsMeasure = FALSE;   // near-null write -> AV
```

## Fix
Guard the deref; the remeasure still runs for the container-size change, so only the flag-clear is conditional:
```cpp
if (m_pImageSource)
{
    m_pImageSource->m_fSourceNeedsMeasure = FALSE;
}
m_containerRequiresMeasure = false;
IFC_RETURN(UpdateMeasure());
```
Every other `m_pImageSource` access in this function is already null-checked — this one line violated that invariant. The producer is intentionally source-independent and is left unchanged to avoid reopening TFS 6673752.

## Blast radius
- Only unguarded `m_pImageSource` deref in the function.
- Sole caller `CMediaBase::EnsureMedia`; the `CImage::EnsureBrush` override already null-guards `m_pImageSource` after calling the base — no duplicate.
- `UpdateMeasure()` does not require a non-null source (that is the point of the TFS 6673752 container-size path).

Raised as **draft** for self-review before publishing.
