### PR TITLE
CommandBar: hide the More button when every secondary command is collapsed

### DIFF
--- a/dxaml/test/native/external/controls/commandbar/CommandBarIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/commandbar/CommandBarIntegrationTests.cpp
@@ -4475,6 +4475,71 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
         });
     }
 
+    // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/783 - clicking the
+    // more button while every secondary command is collapsed would open an empty overflow menu,
+    // so with OverflowButtonVisibility set to Auto the button should hide instead.
+    void CommandBarIntegrationTests::ValidateMoreButtonHidesWhenAllSecondaryCommandsAreCollapsed()
+    {
+        TestCleanupWrapper cleanup;
+
+        xaml_controls::CommandBar^ cmdBar = nullptr;
+        xaml_primitives::ButtonBase^ moreButton = nullptr;
+        xaml_controls::AppBarButton^ secondaryButton = nullptr;
+        xaml_controls::AppBarToggleButton^ secondaryToggleButton = nullptr;
+
+        auto hasLoadedEvent = std::make_shared<Event>();
+        auto loadedRegistration = CreateSafeEventRegistration(xaml_controls::CommandBar, Loaded);
+
+        RunOnUIThread([&]()
+        {
+            cmdBar = ref new xaml_controls::CommandBar();
+            loadedRegistration.Attach(cmdBar, [&]() { hasLoadedEvent->Set(); });
+
+            secondaryButton = ref new xaml_controls::AppBarButton();
+            secondaryButton->Label = L"secondary button";
+            secondaryButton->Visibility = xaml::Visibility::Collapsed;
+            cmdBar->SecondaryCommands->Append(secondaryButton);
+
+            secondaryToggleButton = ref new xaml_controls::AppBarToggleButton();
+            secondaryToggleButton->Label = L"secondary toggle button";
+            secondaryToggleButton->Visibility = xaml::Visibility::Collapsed;
+            cmdBar->SecondaryCommands->Append(secondaryToggleButton);
+
+            auto page = TestServices::WindowHelper->SetupSimulatedAppPage();
+            page->BottomAppBar = cmdBar;
+        });
+
+        hasLoadedEvent->WaitForDefault();
+        TestServices::WindowHelper->WaitForIdle();
+
+        RunOnUIThread([&]()
+        {
+            LOG_OUTPUT(L"Every secondary command is collapsed, so the more button should be collapsed as well.");
+            moreButton = safe_cast<xaml_primitives::ButtonBase^>(GetMoreButton(cmdBar));
+            VERIFY_ARE_EQUAL(xaml::Visibility::Collapsed, moreButton->Visibility);
+
+            LOG_OUTPUT(L"Making one secondary command visible.  The more button should become visible.");
+            secondaryToggleButton->Visibility = xaml::Visibility::Visible;
+        });
+
+        TestServices::WindowHelper->WaitForIdle();
+
+        RunOnUIThread([&]()
+        {
+            VERIFY_ARE_EQUAL(xaml::Visibility::Visible, moreButton->Visibility);
+
+            LOG_OUTPUT(L"Collapsing it again.  The more button should go back to being collapsed.");
+            secondaryToggleButton->Visibility = xaml::Visibility::Collapsed;
+        });
+
+        TestServices::WindowHelper->WaitForIdle();
+
+        RunOnUIThread([&]()
+        {
+            VERIFY_ARE_EQUAL(xaml::Visibility::Collapsed, moreButton->Visibility);
+        });
+    }
+
     void CommandBarIntegrationTests::ValidateButtonsMoveToAndFromOverflowWithoutSizeChange()
     {
         TestCleanupWrapper cleanup;

--- a/dxaml/test/native/external/controls/commandbar/CommandBarIntegrationTests.h
+++ b/dxaml/test/native/external/controls/commandbar/CommandBarIntegrationTests.h
@@ -340,6 +340,10 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             TEST_METHOD_PROPERTY(L"Description", L"Validates that adding elements to the secondary collection or changing the value of ClosedDisplayMode changes the visibility of the more button.")
         END_TEST_METHOD()
 
+        BEGIN_TEST_METHOD(ValidateMoreButtonHidesWhenAllSecondaryCommandsAreCollapsed)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates that the more button is collapsed while every secondary command is collapsed, and comes back once one of them becomes visible.")
+        END_TEST_METHOD()
+
         BEGIN_TEST_METHOD(ValidateButtonsMoveToAndFromOverflowWithoutSizeChange)
             TEST_METHOD_PROPERTY(L"Description", L"Validates that AppBarButtons move to and from the overflow as expected when sizing the CommandBar less than the size it minimally needs to display all its content, and then sizing it to be larger than that.")
         END_TEST_METHOD()

--- a/dxaml/xcp/dxaml/lib/AppBarElementContainer_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/AppBarElementContainer_Partial.cpp
@@ -23,3 +23,9 @@ IFACEMETHODIMP AppBarElementContainer::OnApplyTemplate()
 {
     return S_OK;
 }
+
+_Check_return_ HRESULT AppBarElementContainer::OnVisibilityChanged()
+{
+    IFC_RETURN(__super::OnVisibilityChanged());
+    return CommandBar::OnCommandBarElementVisibilityChanged(this);
+}

--- a/dxaml/xcp/dxaml/lib/AppBarElementContainer_Partial.h
+++ b/dxaml/xcp/dxaml/lib/AppBarElementContainer_Partial.h
@@ -17,5 +17,7 @@ namespace DirectUI
         AppBarElementContainer();
 
         IFACEMETHOD(OnApplyTemplate)() override;
+
+        _Check_return_ HRESULT OnVisibilityChanged() override;
     };
 }

--- a/dxaml/xcp/dxaml/lib/CommandBar_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/CommandBar_Partial.cpp
@@ -2094,12 +2094,19 @@ CommandBar::OnCommandBarElementVisibilityChanged(_In_ xaml_controls::ICommandBar
 
     if (parentCmdBar)
     {
-        IFC_RETURN(parentCmdBar.Cast<CommandBar>()->UpdateVisualState());
+        auto cmdBar = parentCmdBar.Cast<CommandBar>();
+        IFC_RETURN(cmdBar->UpdateVisualState());
+
+        xaml_controls::CommandBarOverflowButtonVisibility overflowButtonVisibility{};
+        IFC_RETURN(cmdBar->get_OverflowButtonVisibility(&overflowButtonVisibility));
 
         // Secondary commands live in the overflow popup, so collapsing one doesn't resize the
         // CommandBar and won't refresh the template settings on its own. Do it here so the
         // overflow button's effective visibility stays in sync.
-        IFC_RETURN(parentCmdBar.Cast<CommandBar>()->UpdateTemplateSettings());
+        if (overflowButtonVisibility == xaml_controls::CommandBarOverflowButtonVisibility_Auto)
+        {
+            IFC_RETURN(cmdBar->UpdateTemplateSettings());
+        }
     }
 
     return S_OK;

--- a/dxaml/xcp/dxaml/lib/CommandBar_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/CommandBar_Partial.cpp
@@ -2095,6 +2095,11 @@ CommandBar::OnCommandBarElementVisibilityChanged(_In_ xaml_controls::ICommandBar
     if (parentCmdBar)
     {
         IFC_RETURN(parentCmdBar.Cast<CommandBar>()->UpdateVisualState());
+
+        // Secondary commands live in the overflow popup, so collapsing one doesn't resize the
+        // CommandBar and won't refresh the template settings on its own. Do it here so the
+        // overflow button's effective visibility stays in sync.
+        IFC_RETURN(parentCmdBar.Cast<CommandBar>()->UpdateTemplateSettings());
     }
 
     return S_OK;
@@ -2318,15 +2323,18 @@ CommandBar::UpdateTemplateSettings()
     else if (overflowButtonVisibility == xaml_controls::CommandBarOverflowButtonVisibility_Auto)
     {
         // In the auto case, we should show the overflow button in one of four circumstances:
-        // - when we have at least one element in the secondary items collection, 
-        // - or when there is a delta between the compact height and the height of the CommandBar, 
+        // - when we have at least one visible element in the secondary items collection,
+        // - or when there is a delta between the compact height and the height of the CommandBar,
         // - or when there is a Visible ICommandBarLabeledElement Primary Command with a Bottom Label,
         // - or when our closed display mode is something other than compact.
-        UINT32 secondaryItemsCount = 0;
+        //
+        // Collapsed secondary commands don't count - opening the overflow would just show an
+        // empty menu. See https://github.com/microsoft/microsoft-ui-xaml/issues/783.
+        bool hasVisibleSecondaryElements = false;
 
-        IFC_RETURN(m_tpDynamicSecondaryCommands.Get()->get_Size(&secondaryItemsCount));
+        IFC_RETURN(HasVisibleElements(m_tpDynamicSecondaryCommands.Get(), &hasVisibleSecondaryElements));
 
-        if (secondaryItemsCount > 0)
+        if (hasVisibleSecondaryElements)
         {
             shouldShowOverflowButton = true;
         }


### PR DESCRIPTION
## Fixes

Fixes #783

## PR Type

- [x] Bugfix

## Description

With `OverflowButtonVisibility="Auto"`, `CommandBar` decided whether to show the More button by *counting* the elements in `m_tpDynamicSecondaryCommands`:

```cpp
IFC_RETURN(m_tpDynamicSecondaryCommands.Get()->get_Size(&secondaryItemsCount));
if (secondaryItemsCount > 0) { shouldShowOverflowButton = true; }
```

Commands collapsed through a binding still count, so the button stayed up and opened an empty overflow menu. The class already has a `HasVisibleElements()` helper — used by `ChangeVisualState`, `GetOverflowContentSize` and `MoveTransitionPrimaryCommandsIntoOverflow` — and this one spot just wasn't using it.

There was a second half to the bug. Secondary commands live in the overflow popup, so collapsing one doesn't resize the `CommandBar`, no `SizeChanged` fires, and `UpdateTemplateSettings()` never re-runs. `OnCommandBarElementVisibilityChanged` only called `UpdateVisualState()`. Without also refreshing the template settings there, the count fix alone would not help the scenario in the issue, where a view model flips visibility after load.

Finally, `AppBarElementContainer` was the only `ICommandBarElement` not forwarding its visibility changes to the parent bar (`AppBarButton`, `AppBarToggleButton` and `AppBarSeparator` all override `OnVisibilityChanged` for this), so a collapsed element container would have been invisible to the new check.

### Current Behavior

Bind `Visibility` on every secondary command and collapse them all, and the More button stays visible. Clicking it opens an empty overflow menu, so it looks like the button does nothing.

### New Behavior

With `OverflowButtonVisibility="Auto"`, the More button collapses once no secondary command is visible — the same as when the collection is empty — and comes back as soon as one becomes visible again. The other reasons the button can be shown (`ClosedDisplayMode` other than `Compact`, a compact/content height delta, or a visible primary command with a bottom label) are unchanged, as is `OverflowButtonVisibility="Visible"`.

Dynamic overflow still behaves correctly: primary commands moved into the overflow are added to the same dynamic secondary collection, so they keep the button visible on their own.

## Customer Impact

User facing. Fixes a six-year-old report of a dead-looking More button, and removes the need for apps to switch `OverflowButtonVisibility` by hand alongside their command visibility bindings.

## Regression Potential

- [x] Low risk — isolated change, limited scope

The visibility check is strictly narrower than the old count check, and only in the `Auto` branch. The one behavioural ripple is the extra `UpdateTemplateSettings()` call on a command's visibility change; that mirrors what `OnSecondaryCommandsChanged` already does on every collection change, and the expensive part of `UpdateTemplateSettings` is gated on `IsOpen`.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

Added `CommandBarIntegrationTests::ValidateMoreButtonHidesWhenAllSecondaryCommandsAreCollapsed`, covering both paths: a `CommandBar` loaded with every secondary command already collapsed, and a command whose visibility flips after load.

`Build.cmd /b /i x64chk prodtest` succeeds and TAEF discovers the new test. I was not able to execute the dxaml native suite locally — `dxaml/test/native/external/infra/ModuleCleanup.cpp` declares `RunFixtureAs:Module = ElevatedUserOrSystem`, and this machine has no elevated test environment set up. Relying on CI for the run of the new test and the neighbouring `ValidateOverflowButtonHidesWhenAppropriate*` and `ValidateMoreButtonCanShowWithoutSizeChanging` cases.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8N3aReuVqMeghHZ8XNfzH
