### PR TITLE
Fix x:Bind function bindings not updating when an argument becomes null

### DIFF
--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/BindUniverse.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/BindUniverse.cs
@@ -267,6 +267,11 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
                     {
                         AddTryGetValueStep(steps, param.Path);
                     }
+
+                    if (functionStep.InstanceStep != null)
+                    {
+                        AddTryGetValueStep(steps, functionStep.InstanceStep);
+                    }
                 }
                 return steps.Values;
             }

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/BindUniverse.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/BindUniverse.cs
@@ -282,7 +282,7 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
             if (step.IsIncludedInUpdate)
             {
                 steps[step.TryGetValueCodeName] = step;
-                if (step.Parent != null)
+                if (step.IsRetrievedThroughParent)
                 {
                     AddTryGetValueStep(steps, step.Parent);
                 }

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/BindPathStepCodeGenerators.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/BindPathStepCodeGenerators.cs
@@ -11,6 +11,7 @@ namespace Microsoft.UI.Xaml.Markup.Compiler.CodeGen
         ICodeGenOutput PathExpression { get; }
         ICodeGenOutput UpdateCallParam { get; }
         ICodeGenOutput PathSetExpression(ICodeGenOutput input);
+        ICodeGenOutput InstanceCallExpression(string instanceName);
         ICodeGenOutput MemberAccessOperator { get; }
     }
 
@@ -113,6 +114,12 @@ namespace Microsoft.UI.Xaml.Markup.Compiler.CodeGen
         {
             // Derived steps should all be implementing UpdateCallParam.
             get { throw new NotImplementedException(); }
+        }
+
+        public virtual ICodeGenOutput InstanceCallExpression(string instanceName)
+        {
+            // Only function steps are ever invoked on a separately retrieved instance.
+            throw new NotImplementedException();
         }
     }
 
@@ -466,6 +473,23 @@ namespace Microsoft.UI.Xaml.Markup.Compiler.CodeGen
         public override ICodeGenOutput UpdateCallParam
         {
             get { return new LanguageSpecificString(() => String.Empty); }
+        }
+
+        /// <summary>
+        /// The call expression for this function, invoked on an instance held in a local instead of
+        /// by re-evaluating the path that produces it. Used when <see cref="FunctionStep.InstanceStep"/>
+        /// has to be null checked before the call, so that the path is only walked once.
+        /// </summary>
+        public override ICodeGenOutput InstanceCallExpression(string instanceName)
+        {
+            MethodStep method = Instance.Method;
+            var memberAccessOperator = method.Parent.CodeGen().MemberAccessOperator;
+            var paramList = method.Parameters.ForCall();
+            return new LanguageSpecificString(
+                () => $"{instanceName}{memberAccessOperator.CppCXName()}{method.MethodName}({paramList})",
+                () => $"{instanceName}{memberAccessOperator.CppWinRTName()}{method.MethodName}({paramList})",
+                () => $"{instanceName}.{method.MethodName}({paramList})",
+                () => $"{instanceName}.{method.MethodName}({paramList})");
         }
     }
 }

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
@@ -1919,7 +1919,8 @@ this.Write("(obj);\r\n");
 
                  }
                  Output_Update_Steps(bindStep.ValueType.IsNullable, "this", bindStep.Children, true, "phase");
-                 Output_Update_Steps(bindStep.ValueType.IsNullable, "this", bindStep.Dependents, false, "phase");
+                 // Dependents are function bindings: a null value is a valid argument, not an unresolved path.
+                 Output_Update_Steps(false, "this", bindStep.Dependents, false, "phase");
                  foreach (int distinctPhase in bindStep.DistinctPhases)
                  {
                      Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
@@ -3601,13 +3601,38 @@ this.Write(";\r\n");
 
              }
          }
+         BindPathStep instanceStep = functionStep.InstanceStep;
+         if (instanceStep != null) {
+this.Write("                ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType));
+
+this.Write(" ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(";\r\n                if (!");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.TryGetValueCodeName));
+
+this.Write("(out ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(")");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType.IsNullable ? " || " + KnownStrings.FunctionInstanceName + " == null" : ""));
+
+this.Write(") { return; }\r\n");
+
+         }
 this.Write("                ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.ValueType));
 
 this.Write(" result = ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.CodeGen().PathExpression));
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName)));
 
 this.Write(";\r\n");
 

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
@@ -3659,7 +3659,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(step.ValueType));
 
 this.Write(" val)\r\n            {\r\n");
 
-         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {
+         if (!step.IsRetrievedThroughParent) {
 this.Write("                val = ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(step.CodeGen().PathExpression));

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
@@ -1977,7 +1977,12 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
                 <#=param.ValueType#> <#=param.Name#> = <#=param.CodeGen().PathExpression#>;
 <#+             }#>
 <#+         }#>
-                <#=functionStep.ValueType#> result = <#= functionStep.CodeGen().PathExpression #>;
+<#+         BindPathStep instanceStep = functionStep.InstanceStep;#>
+<#+         if (instanceStep != null) {#>
+                <#=instanceStep.ValueType#> <#=KnownStrings.FunctionInstanceName#>;
+                if (!<#=instanceStep.TryGetValueCodeName#>(out <#=KnownStrings.FunctionInstanceName#>)<#=instanceStep.ValueType.IsNullable ? " || " + KnownStrings.FunctionInstanceName + " == null" : ""#>) { return; }
+<#+         }#>
+                <#=functionStep.ValueType#> result = <#= instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName) #>;
 <#+         foreach (int distinctPhase in functionStep.DistinctPhases) {#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, true, functionStep, true);#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, false, functionStep, true);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
@@ -1092,7 +1092,8 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
                 this.bindingsTracking.UpdateChildListeners_<#=bindStep.CodeName#>(obj);
 <#+                 }#>
 <#+                 Output_Update_Steps(bindStep.ValueType.IsNullable, "this", bindStep.Children, true, "phase");#>
-<#+                 Output_Update_Steps(bindStep.ValueType.IsNullable, "this", bindStep.Dependents, false, "phase");#>
+<#+                 // Dependents are function bindings: a null value is a valid argument, not an unresolved path.#>
+<#+                 Output_Update_Steps(false, "this", bindStep.Dependents, false, "phase");#>
 <#+                 foreach (int distinctPhase in bindStep.DistinctPhases)#>
 <#+                 {#>
 <#+                     Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
@@ -1999,7 +1999,7 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
 
             private bool <#=step.TryGetValueCodeName#>(out <#=step.ValueType#> val)
             {
-<#+         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {#>
+<#+         if (!step.IsRetrievedThroughParent) {#>
                 val = <#=step.CodeGen().PathExpression#>;
                 return true;
 <#+         }#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.cs
@@ -1598,7 +1598,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(step.ValueType));
 
 this.Write("& val)\r\n        {\r\n");
 
-         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {
+         if (!step.IsRetrievedThroughParent) {
 this.Write("            val = ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(step.CodeGen().PathExpression));

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.cs
@@ -1519,13 +1519,59 @@ this.Write(";\r\n");
 
              }
          }
+         BindPathStep instanceStep = functionStep.InstanceStep;
+         if (instanceStep != null) {
+             if (instanceStep.ValueType.IsNullable) {
+this.Write("            ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType));
+
+this.Write(" ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(" = nullptr;\r\n            if (!");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.TryGetValueCodeName));
+
+this.Write("(");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(") || !");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(") { return; }\r\n");
+
+             } else { 
+this.Write("            ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType));
+
+this.Write(" ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(";\r\n            if (!");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.TryGetValueCodeName));
+
+this.Write("(");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(")) { return; }\r\n");
+
+             }
+         }
 this.Write("            ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.ValueType));
 
 this.Write(" result = ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.CodeGen().PathExpression));
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName)));
 
 this.Write(";\r\n");
 

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.cs
@@ -335,6 +335,7 @@ namespace Microsoft.UI.Xaml.Markup.Compiler.CodeGen
             this.Write("        {\r\n");
       Output_UpdateChildListeners_Call(bindStep, "obj");
       Output_Update_Steps(bindStep.ValueType.IsNullable, bindStep.Children, true, "phase");
+      // Dependents are function bindings: a null value is a valid argument, not an unresolved path.
       Output_Update_Steps(false, bindStep.Dependents, false, "phase");
       foreach (int distinctPhase in bindStep.DistinctPhases) { 
           Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.tt
@@ -270,6 +270,7 @@
         {
 <#      Output_UpdateChildListeners_Call(bindStep, "obj");#>
 <#      Output_Update_Steps(bindStep.ValueType.IsNullable, bindStep.Children, true, "phase");#>
+<#      // Dependents are function bindings: a null value is a valid argument, not an unresolved path.#>
 <#      Output_Update_Steps(false, bindStep.Dependents, false, "phase");#>
 <#      foreach (int distinctPhase in bindStep.DistinctPhases) { #>
 <#          Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.tt
@@ -1017,7 +1017,7 @@
 
         bool <#=step.TryGetValueCodeName#>(<#=step.ValueType#>& val)
         {
-<#+         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {#>
+<#+         if (!step.IsRetrievedThroughParent) {#>
             val = <#=step.CodeGen().PathExpression#>;
             return true;
 <#+         }#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_PageBinding.tt
@@ -990,7 +990,17 @@
             <#=param.ValueType#> <#=param.Name#> = <#=param.CodeGen().PathExpression#>;
 <#+             }#>
 <#+         }#>
-            <#=functionStep.ValueType#> result = <#= functionStep.CodeGen().PathExpression #>;
+<#+         BindPathStep instanceStep = functionStep.InstanceStep;#>
+<#+         if (instanceStep != null) {#>
+<#+             if (instanceStep.ValueType.IsNullable) {#>
+            <#=instanceStep.ValueType#> <#=KnownStrings.FunctionInstanceName#> = nullptr;
+            if (!<#=instanceStep.TryGetValueCodeName#>(<#=KnownStrings.FunctionInstanceName#>) || !<#=KnownStrings.FunctionInstanceName#>) { return; }
+<#+             } else { #>
+            <#=instanceStep.ValueType#> <#=KnownStrings.FunctionInstanceName#>;
+            if (!<#=instanceStep.TryGetValueCodeName#>(<#=KnownStrings.FunctionInstanceName#>)) { return; }
+<#+             }#>
+<#+         }#>
+            <#=functionStep.ValueType#> result = <#= instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName) #>;
 <#+         foreach (int distinctPhase in functionStep.DistinctPhases) {#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, true, functionStep, true);#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, false, functionStep, true);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.cs
@@ -2955,13 +2955,38 @@ this.Write(";\r\n");
 
              }
          }
+         BindPathStep instanceStep = functionStep.InstanceStep;
+         if (instanceStep != null) {
+this.Write("        ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType));
+
+this.Write(" ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(";\r\n        if (!");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.TryGetValueCodeName));
+
+this.Write("(");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(")");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType.IsNullable ? " || " + KnownStrings.FunctionInstanceName + " == nullptr" : ""));
+
+this.Write(") { return; }\r\n");
+
+         }
 this.Write("        ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.ValueType));
 
 this.Write(" result = ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.CodeGen().PathExpression));
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName)));
 
 this.Write(";\r\n");
 

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.cs
@@ -3013,7 +3013,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(step.ValueType));
 
 this.Write("& val)\r\n    {\r\n");
 
-         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {
+         if (!step.IsRetrievedThroughParent) {
 this.Write("        val = ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(step.CodeGen().PathExpression));

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.cs
@@ -1616,7 +1616,8 @@ this.Write(")\r\n    {\r\n");
 
                  Output_UpdateChildListeners_Call(bindStep, "obj");
                  Output_Update_Steps(bindStep.ValueType.IsNullable, bindStep.Children, true, "phase");
-                 Output_Update_Steps(bindStep.ValueType.IsNullable, bindStep.Dependents, false, "phase");
+                 // Dependents are function bindings: a null value is a valid argument, not an unresolved path.
+                 Output_Update_Steps(false, bindStep.Dependents, false, "phase");
                  foreach (int distinctPhase in bindStep.DistinctPhases)
                  {
                      Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.tt
@@ -976,7 +976,8 @@ private:
     {
 <#+                 Output_UpdateChildListeners_Call(bindStep, "obj");#>
 <#+                 Output_Update_Steps(bindStep.ValueType.IsNullable, bindStep.Children, true, "phase");#>
-<#+                 Output_Update_Steps(bindStep.ValueType.IsNullable, bindStep.Dependents, false, "phase");#>
+<#+                 // Dependents are function bindings: a null value is a valid argument, not an unresolved path.#>
+<#+                 Output_Update_Steps(false, bindStep.Dependents, false, "phase");#>
 <#+                 foreach (int distinctPhase in bindStep.DistinctPhases)#>
 <#+                 {#>
 <#+                     Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.tt
@@ -1772,7 +1772,12 @@ bool <#=GetBindingFullClassName(bindUniverse, Model.CodeInfo)#>::<#=ba.DisableFl
         <#=param.ValueType#> <#=param.Name#> = <#=param.CodeGen().PathExpression#>;
 <#+             }#>
 <#+         }#>
-        <#=functionStep.ValueType#> result = <#= functionStep.CodeGen().PathExpression #>;
+<#+         BindPathStep instanceStep = functionStep.InstanceStep;#>
+<#+         if (instanceStep != null) {#>
+        <#=instanceStep.ValueType#> <#=KnownStrings.FunctionInstanceName#>;
+        if (!<#=instanceStep.TryGetValueCodeName#>(<#=KnownStrings.FunctionInstanceName#>)<#=instanceStep.ValueType.IsNullable ? " || " + KnownStrings.FunctionInstanceName + " == nullptr" : ""#>) { return; }
+<#+         }#>
+        <#=functionStep.ValueType#> result = <#= instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName) #>;
 <#+         foreach (int distinctPhase in functionStep.DistinctPhases) {#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, true, functionStep, true);#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, false, functionStep, true);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/MoComCppPagePass2.tt
@@ -1794,7 +1794,7 @@ bool <#=GetBindingFullClassName(bindUniverse, Model.CodeInfo)#>::<#=ba.DisableFl
 
     bool <#=step.TryGetValueCodeName#>(<#=step.ValueType#>& val)
     {
-<#+         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {#>
+<#+         if (!step.IsRetrievedThroughParent) {#>
         val = <#=step.CodeGen().PathExpression#>;
         return true;
 <#+         }#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.cs
@@ -1854,7 +1854,8 @@ this.Write("(obj)\r\n");
 
                  }
                  Output_Update_Steps(bindStep.ValueType.IsNullable, "Me", bindStep.Children, true, "phase");
-                 Output_Update_Steps(bindStep.ValueType.IsNullable, "Me", bindStep.Dependents, false, "phase");
+                 // Dependents are function bindings: a null value is a valid argument, not an unresolved path.
+                 Output_Update_Steps(false, "Me", bindStep.Dependents, false, "phase");
                  foreach (int distinctPhase in bindStep.DistinctPhases)
                  {
                      Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.cs
@@ -3484,7 +3484,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(step.ValueType));
 
 this.Write(") As Boolean\r\n");
 
-         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {
+         if (!step.IsRetrievedThroughParent) {
 this.Write("                val = ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(step.CodeGen().PathExpression));

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.cs
@@ -3426,13 +3426,38 @@ this.Write("\r\n");
 
              }
          }
+         BindPathStep instanceStep = functionStep.InstanceStep;
+         if (instanceStep != null) {
+this.Write("                Dim ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(" As ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType));
+
+this.Write(" = Nothing\r\n                If Not ");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.TryGetValueCodeName));
+
+this.Write("(");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(KnownStrings.FunctionInstanceName));
+
+this.Write(")");
+
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep.ValueType.IsNullable ? " OrElse " + KnownStrings.FunctionInstanceName + " Is Nothing" : ""));
+
+this.Write(" Then Return\r\n");
+
+         }
 this.Write("                Dim result As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.ValueType));
 
 this.Write(" = ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(functionStep.CodeGen().PathExpression));
+this.Write(this.ToStringHelper.ToStringWithCulture(instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName)));
 
 this.Write("\r\n");
 

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.tt
@@ -950,7 +950,8 @@ End Namespace
                 Me.bindingsTracking.UpdateChildListeners_<#=bindStep.CodeName#>(obj)
 <#+                 }#>
 <#+                 Output_Update_Steps(bindStep.ValueType.IsNullable, "Me", bindStep.Children, true, "phase");#>
-<#+                 Output_Update_Steps(bindStep.ValueType.IsNullable, "Me", bindStep.Dependents, false, "phase");#>
+<#+                 // Dependents are function bindings: a null value is a valid argument, not an unresolved path.#>
+<#+                 Output_Update_Steps(false, "Me", bindStep.Dependents, false, "phase");#>
 <#+                 foreach (int distinctPhase in bindStep.DistinctPhases)#>
 <#+                 {#>
 <#+                     Output_Binding_Phased_SetValue(distinctPhase, true, bindStep, false);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.tt
@@ -1712,7 +1712,12 @@ End Namespace
                 Dim <#=param.Name#> As <#=param.ValueType#> = <#=param.CodeGen().PathExpression#>
 <#+             }#>
 <#+         }#>
-                Dim result As <#=functionStep.ValueType#> = <#= functionStep.CodeGen().PathExpression #>
+<#+         BindPathStep instanceStep = functionStep.InstanceStep;#>
+<#+         if (instanceStep != null) {#>
+                Dim <#=KnownStrings.FunctionInstanceName#> As <#=instanceStep.ValueType#> = Nothing
+                If Not <#=instanceStep.TryGetValueCodeName#>(<#=KnownStrings.FunctionInstanceName#>)<#=instanceStep.ValueType.IsNullable ? " OrElse " + KnownStrings.FunctionInstanceName + " Is Nothing" : ""#> Then Return
+<#+         }#>
+                Dim result As <#=functionStep.ValueType#> = <#= instanceStep == null ? functionStep.CodeGen().PathExpression : functionStep.CodeGen().InstanceCallExpression(KnownStrings.FunctionInstanceName) #>
 <#+         foreach (int distinctPhase in functionStep.DistinctPhases) {#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, true, functionStep, true);#>
 <#+             Output_Binding_Phased_SetValue(distinctPhase, false, functionStep, true);#>

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/VisualBasicPagePass2.tt
@@ -1733,7 +1733,7 @@ End Namespace
 <#+     {#>
 
             Private Function <#=step.TryGetValueCodeName#>(<Global.System.Runtime.InteropServices.Out()> ByRef val As <#=step.ValueType#>) As Boolean
-<#+         if (step is RootStep || !step.Parent.IsIncludedInUpdate) {#>
+<#+         if (!step.IsRetrievedThroughParent) {#>
                 val = <#=step.CodeGen().PathExpression#>
                 Return True
 <#+         }#>

--- a/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Core/KnownStrings.cs
+++ b/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Core/KnownStrings.cs
@@ -203,6 +203,7 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
         public const string op_Explicit = "op_Explicit";
         public const string UpdateParamName = "obj";
         public const string UpdateParamBindingsName = "bindings";
+        public const string FunctionInstanceName = "instance";
         public const string DataChanged = "DATA_CHANGED";
         public const string NotPhased = "NOT_PHASED";
         public const string DirectCast = "DirectCast";

--- a/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Parsing/BindPathStep.cs
+++ b/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Parsing/BindPathStep.cs
@@ -212,6 +212,19 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
 
         public virtual bool IsIncludedInUpdate => BindStatus.HasFlag(BindStatus.HasBinding);
 
+        /// <summary>
+        /// The element root stands in for the namescope owning the named elements a path can start
+        /// from, rather than for a value of its own, so it is never retrieved or walked through.
+        /// </summary>
+        public virtual bool IsElementRoot => false;
+
+        /// <summary>
+        /// Whether this step's value has to be obtained by first obtaining its parent's. Roots hold
+        /// their own value, and so do named elements, which are reached through the bindings class
+        /// rather than through the element root.
+        /// </summary>
+        public bool IsRetrievedThroughParent => Parent != null && Parent.IsIncludedInUpdate && !Parent.IsElementRoot;
+
         public string PhaseList => string.Join(":", DistinctPhases);
 
         public virtual bool NeedsCheckForNull => ValueType.IsNullable;

--- a/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Parsing/FunctionStep.cs
+++ b/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Parsing/FunctionStep.cs
@@ -39,6 +39,30 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
         public bool RequiresSafeParameterRetrieval => true;
 
         /// <summary>
+        /// The step producing the instance the method is invoked on, or null when that instance is
+        /// already known to be non null wherever this function can be scheduled from.
+        /// A function binding is scheduled either as a child of that step, which is only updated
+        /// while its own value is non null, or as a dependent of one of its path parameters. So the
+        /// instance only needs to be retrieved safely when a parameter sits outside of its path.
+        /// </summary>
+        public BindPathStep InstanceStep
+        {
+            get
+            {
+                if (Parent is StaticRootStep)
+                {
+                    return null;
+                }
+
+                bool isScheduledOutsideInstancePath = Parameters
+                    .OfType<FunctionPathParam>()
+                    .Any(param => !param.Path.Parents.Any(step => step.CodeName == Parent.CodeName));
+
+                return isScheduledOutsideInstancePath ? Parent : null;
+            }
+        }
+
+        /// <summary>
         /// ValueTypeIsConditional indicates if a step if of a conditional type. It is different than
         /// checking ApiInformation on the step itself, which is used to tell to not use that step unless the 
         /// ApiInformation check is satisfied. This checks against the step value type itself.

--- a/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Parsing/RootStep.cs
+++ b/src/XamlCompiler/Microsoft.UI.Xaml.Markup.Compiler.Parsing/RootStep.cs
@@ -20,6 +20,6 @@ namespace Microsoft.UI.Xaml.Markup.Compiler
 
         public override bool NeedsCheckForNull => IsElementRoot ? false : base.NeedsCheckForNull;
 
-        public bool IsElementRoot;
+        public override bool IsElementRoot { get; }
     }
 }

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCS/obj/x86/Debug/CastingTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCS/obj/x86/Debug/CastingTests.g.cs
@@ -913,10 +913,7 @@ namespace BindTestbed
             }
             private void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Prefix(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
-                }
+                this.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
             }
             private void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Postfix(global::System.Double obj, int phase)
             {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
@@ -821,7 +821,9 @@ namespace BindTestbed
             {
                 global::System.String p0;
                 if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(out p0)) { return; }
-                global::System.String result = this.dataRoot.Model.FunctionOnModelOneStringArg(p0);
+                global::BindTestbedModel.DataModel instance;
+                if (!TryGet_Model(out instance) || instance == null) { return; }
+                global::System.String result = instance.FunctionOnModelOneStringArg(p0);
                 if ((phase & ((1 << 0) | NOT_PHASED )) != 0)
                 {
                     // FunctionTests.xaml line 51

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
@@ -1380,10 +1380,7 @@ namespace BindTestbed
                         this.Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(phase);
                     }
                 }
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
-                }
+                this.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
             }
             private void Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(int phase)
             {
@@ -1538,10 +1535,7 @@ namespace BindTestbed
             }
             private void Update_Model_StringPropertyDP(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
-                }
+                this.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
             }
             private void Update_Model_M_FunctionOnModelThreeArgs_706606279(int phase)
             {
@@ -1592,10 +1586,7 @@ namespace BindTestbed
             }
             private void Update_Model_Employees_I0_Name(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
-                }
+                this.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
             }
             private void Update_Model_Employees_I0_IsManager(global::System.Boolean obj, int phase)
             {
@@ -1672,14 +1663,7 @@ namespace BindTestbed
                         this.UpdateFallback_Model_NullEmployee_FirstName_M_ToString_757602046(phase);
                     }
                 }
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-                }
-                else
-                {
-                    this.UpdateFallback_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-                }
+                this.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
             }
             private void Update_Model_NullEmployee_FirstName_M_ToString_757602046(int phase)
             {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCX/Generated Files/CastingTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCX/Generated Files/CastingTests.g.hpp
@@ -858,10 +858,7 @@ private:
     }
     void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Prefix(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
-        }
+        this->Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
     }
     void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Postfix(::default::float64 obj, int phase)
     {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCX/Generated Files/FunctionTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCX/Generated Files/FunctionTests.g.hpp
@@ -1394,10 +1394,7 @@ private:
     }
     void Update_Model_StaticStringProperty(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_2484059362(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_2484059362(phase);
     }
     void Update_Model_M_FunctionOnModelOneStringArg_2484059362(int phase)
     {
@@ -1442,10 +1439,7 @@ private:
                 this->Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
     }
     void Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(int phase)
     {
@@ -1624,10 +1618,7 @@ private:
                 this->Update_Model_Employees_I0_Name_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
     }
     void Update_Model_Employees_I0_Name_M_ToString_757602046(int phase)
     {
@@ -1651,10 +1642,7 @@ private:
     }
     void Update_Model_StringPropertyDP(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
     }
     void Update_Model_M_FunctionOnModelThreeArgs_706606279(int phase)
     {
@@ -1741,14 +1729,7 @@ private:
                 this->UpdateFallback_Model_NullEmployee_FirstName_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-        }
-        else
-        {
-            this->UpdateFallback_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
     }
     void Update_Model_NullEmployee_FirstName_M_ToString_757602046(int phase)
     {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCX/Generated Files/FunctionTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCX/Generated Files/FunctionTests.g.hpp
@@ -846,7 +846,9 @@ private:
     {
         ::Platform::String^ p0;
         if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0)) { return; }
-        ::Platform::String^ result = this->GetDataRoot()->Model->FunctionOnModelOneStringArg(p0);
+        ::BindTestbedModel::DataModel^ instance;
+        if (!TryGet_Model(instance) || instance == nullptr) { return; }
+        ::Platform::String^ result = instance->FunctionOnModelOneStringArg(p0);
         if ((phase & ((1 << 0) | NOT_PHASED )) != 0)
         {
             // FunctionTests.xaml line 52

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCppWinRT/Generated Files/FunctionTests.xaml.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedCppWinRT/Generated Files/FunctionTests.xaml.g.hpp
@@ -874,7 +874,9 @@ namespace winrt::BindTestbed::implementation
         {
             ::winrt::hstring p0;
             if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0)) { return; }
-            ::winrt::hstring result = GetDataRoot().Model().FunctionOnModelOneStringArg(p0);
+            ::winrt::BindTestbedModel::DataModel instance = nullptr;
+            if (!TryGet_Model(instance) || !instance) { return; }
+            ::winrt::hstring result = instance.FunctionOnModelOneStringArg(p0);
             if((phase & ((1 << 0) | NOT_PHASED )) != 0)
             {
                 // FunctionTests.xaml line 52

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedVB/obj/x86/Debug/CastingTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedVB/obj/x86/Debug/CastingTests.g.vb
@@ -678,9 +678,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_DataContext_Cast_DataContext_To_CastingTestsVM_Prefix(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase)
-                End If
+                Me.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase)
             End Sub
             Private Sub Update_DataContext_Cast_DataContext_To_CastingTestsVM_Postfix(obj As Global.System.Double, phase As Integer)
                 If (phase And (NOT_PHASED Or (1 << 0))) <> 0 Then

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
@@ -635,7 +635,9 @@ Namespace Global.BindTestbed
             Private Sub Invoke_Model_M_FunctionOnModelOneStringArg_1668010001(phase As Integer)
                 Dim p0 As Global.System.String = Nothing
                 If Not TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0) Then Return
-                Dim result As Global.System.String = Me.dataRoot.Model.FunctionOnModelOneStringArg(p0)
+                Dim instance As Global.BindTestbedModel.DataModel = Nothing
+                If Not TryGet_Model(instance) OrElse instance Is Nothing Then Return
+                Dim result As Global.System.String = instance.FunctionOnModelOneStringArg(p0)
                 If (phase And ((1 << 0) Or NOT_PHASED )) <> 0 Then
                     If isobj13TextDisabled = False Then
                         XamlBindingSetters.Set_Windows_UI_Xaml_Controls_TextBlock_Text(Me.obj13, result, Nothing)

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedBackcompat/RS1/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
@@ -1047,9 +1047,7 @@ Namespace Global.BindTestbed
                         Me.Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(phase)
                     End If
                 End If
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase)
             End Sub
             Private Sub Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED )) <> 0 Then
@@ -1158,9 +1156,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_StringPropertyDP(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase)
             End Sub
             Private Sub Update_Model_M_FunctionOnModelThreeArgs_706606279(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then
@@ -1195,9 +1191,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_Employees_I0_Name(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase)
             End Sub
             Private Sub Update_Model_Employees_I0_IsManager(obj As Global.System.Boolean, phase As Integer)
                 Me.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase)
@@ -1251,11 +1245,7 @@ Namespace Global.BindTestbed
                         Me.UpdateFallback_Model_NullEmployee_FirstName_M_ToString_757602046(phase)
                     End If
                 End If
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase)
-                Else
-                    Me.UpdateFallback_Model_M_FunctionOnModelThreeArgs_1187614766(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase)
             End Sub
             Private Sub Update_Model_NullEmployee_FirstName_M_ToString_757602046(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED )) <> 0 Then

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/CastingTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/CastingTests.g.cs
@@ -918,10 +918,7 @@ namespace BindTestbed
             }
             private void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Prefix(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
-                }
+                this.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
             }
             private void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Postfix(global::System.Double obj, int phase)
             {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
@@ -940,7 +940,9 @@ namespace BindTestbed
             {
                 global::System.String p0;
                 if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(out p0)) { return; }
-                global::System.String result = this.dataRoot.Model.FunctionOnModelOneStringArg(p0);
+                global::BindTestbedModel.DataModel instance;
+                if (!TryGet_Model(out instance) || instance == null) { return; }
+                global::System.String result = instance.FunctionOnModelOneStringArg(p0);
                 if ((phase & ((1 << 0) | NOT_PHASED )) != 0)
                 {
                     // FunctionTests.xaml line 51

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/FunctionTests.g.cs
@@ -1446,14 +1446,7 @@ namespace BindTestbed
                         this.UpdateFallback_Model_ReentrancyString(phase);
                     }
                 }
-                if (obj != null)
-                {
-                    this.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-                }
-                else
-                {
-                    this.UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-                }
+                this.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
             }
             private void Update_Model_M_FunctionOnModelNoArgs_757602046(int phase)
             {
@@ -1600,10 +1593,7 @@ namespace BindTestbed
                         this.Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString1_757602046(phase);
                     }
                 }
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
-                }
+                this.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
             }
             private void Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString1_757602046(int phase)
             {
@@ -1796,10 +1786,7 @@ namespace BindTestbed
             }
             private void Update_Model_NullEmployee_Name(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelNullArg_3348340388(phase);
-                }
+                this.Update_Model_M_FunctionOnModelNullArg_3348340388(phase);
             }
             private void Update_Model_M_FunctionOnModelNullArg_3348340388(int phase)
             {
@@ -1823,10 +1810,7 @@ namespace BindTestbed
             }
             private void Update_Model_StringPropertyDP(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
-                }
+                this.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
             }
             private void Update_Model_M_FunctionOnModelThreeArgs_706606279(int phase)
             {
@@ -1878,11 +1862,8 @@ namespace BindTestbed
             }
             private void Update_Model_Employees_I0_Name(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
-                    this.Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase);
-                }
+                this.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
+                this.Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase);
             }
             private void Update_Model_Employees_I0_IsManager(global::System.Boolean obj, int phase)
             {
@@ -1925,14 +1906,7 @@ namespace BindTestbed
                         this.UpdateFallback_Model_NullEmployee_FirstName_M_ToString1_757602046(phase);
                     }
                 }
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-                }
-                else
-                {
-                    this.UpdateFallback_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-                }
+                this.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
             }
             private void Update_Model_NullEmployee_FirstName_M_ToString1_757602046(int phase)
             {
@@ -2011,10 +1985,7 @@ namespace BindTestbed
             }
             private void Update_Model_Employees_I2_Name(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase);
-                }
+                this.Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase);
             }
             private void Update_Model_M_FunctionOnModelOneStringArg_2530340821(int phase)
             {
@@ -2028,14 +1999,7 @@ namespace BindTestbed
             }
             private void Update_Model_ReentrancyString(global::System.String obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-                }
-                else
-                {
-                    this.UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-                }
+                this.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
             }
             private void Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(int phase)
             {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/NullableTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCS/obj/x86/Debug/NullableTests.g.cs
@@ -316,10 +316,7 @@ namespace BindTestbed
             }
             private void Update_Model_NullableDoublePropertyDP(global::System.Nullable<global::System.Double> obj, int phase)
             {
-                if (obj != null)
-                {
-                    this.Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
-                }
+                this.Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
                 if ((phase & ((1 << 0) | NOT_PHASED | DATA_CHANGED)) != 0)
                 {
                     // NullableTests.xaml line 39

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/CastingTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/CastingTests.g.hpp
@@ -858,10 +858,7 @@ private:
     }
     void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Prefix(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
-        }
+        this->Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
     }
     void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Postfix(::default::float64 obj, int phase)
     {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/FunctionTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/FunctionTests.g.hpp
@@ -1474,14 +1474,7 @@ private:
                 this->UpdateFallback_Model_ReentrancyString(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
-        else
-        {
-            this->UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
+        this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
     }
     void Update_Model_M_FunctionOnModelNoArgs_757602046(int phase)
     {
@@ -1607,10 +1600,7 @@ private:
     }
     void Update_Model_StaticStringProperty(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_2484059362(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_2484059362(phase);
     }
     void Update_Model_M_FunctionOnModelOneStringArg_2484059362(int phase)
     {
@@ -1655,10 +1645,7 @@ private:
                 this->Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
     }
     void Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(int phase)
     {
@@ -1838,11 +1825,8 @@ private:
                 this->Update_Model_Employees_I0_Name_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
-            this->Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
+        this->Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase);
     }
     void Update_Model_Employees_I0_Name_M_ToString_757602046(int phase)
     {
@@ -1904,10 +1888,7 @@ private:
     }
     void Update_Model_NullEmployee_Name(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelNullArg_3348340388(phase);
-        }
+        this->Update_Model_M_FunctionOnModelNullArg_3348340388(phase);
     }
     void Update_Model_M_FunctionOnModelNullArg_3348340388(int phase)
     {
@@ -1931,10 +1912,7 @@ private:
     }
     void Update_Model_StringPropertyDP(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
     }
     void Update_Model_M_FunctionOnModelThreeArgs_706606279(int phase)
     {
@@ -1987,14 +1965,7 @@ private:
                 this->UpdateFallback_Model_NullEmployee_FirstName_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-        }
-        else
-        {
-            this->UpdateFallback_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
     }
     void Update_Model_NullEmployee_FirstName_M_ToString_757602046(int phase)
     {
@@ -2073,10 +2044,7 @@ private:
     }
     void Update_Model_Employees_I2_Name(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase);
     }
     void Update_Model_M_FunctionOnModelOneStringArg_2530340821(int phase)
     {
@@ -2090,14 +2058,7 @@ private:
     }
     void Update_Model_ReentrancyString(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
-        else
-        {
-            this->UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
+        this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
     }
     void Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(int phase)
     {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/FunctionTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/FunctionTests.g.hpp
@@ -958,7 +958,9 @@ private:
     {
         ::Platform::String^ p0;
         if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0)) { return; }
-        ::Platform::String^ result = this->GetDataRoot()->Model->FunctionOnModelOneStringArg(p0);
+        ::BindTestbedModel::DataModel^ instance;
+        if (!TryGet_Model(instance) || instance == nullptr) { return; }
+        ::Platform::String^ result = instance->FunctionOnModelOneStringArg(p0);
         if ((phase & ((1 << 0) | NOT_PHASED )) != 0)
         {
             // FunctionTests.xaml line 52

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/NullableTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Generated Files/NullableTests.g.hpp
@@ -284,10 +284,7 @@ private:
     }
     void Update_Model_NullableDoublePropertyDP(::Platform::IBox<::default::float64>^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
-        }
+        this->Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
         if ((phase & ((1 << 0) | NOT_PHASED | DATA_CHANGED)) != 0)
         {
             // NullableTests.xaml line 39

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/CastingTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/CastingTests.g.hpp
@@ -858,10 +858,7 @@ private:
     }
     void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Prefix(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
-        }
+        this->Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase);
     }
     void Update_DataContext_Cast_DataContext_To_CastingTestsVM_Postfix(::default::float64 obj, int phase)
     {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/FunctionTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/FunctionTests.g.hpp
@@ -1474,14 +1474,7 @@ private:
                 this->UpdateFallback_Model_ReentrancyString(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
-        else
-        {
-            this->UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
+        this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
     }
     void Update_Model_M_FunctionOnModelNoArgs_757602046(int phase)
     {
@@ -1607,10 +1600,7 @@ private:
     }
     void Update_Model_StaticStringProperty(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_2484059362(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_2484059362(phase);
     }
     void Update_Model_M_FunctionOnModelOneStringArg_2484059362(int phase)
     {
@@ -1655,10 +1645,7 @@ private:
                 this->Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase);
     }
     void Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString_757602046(int phase)
     {
@@ -1838,11 +1825,8 @@ private:
                 this->Update_Model_Employees_I0_Name_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
-            this->Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase);
+        this->Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase);
     }
     void Update_Model_Employees_I0_Name_M_ToString_757602046(int phase)
     {
@@ -1904,10 +1888,7 @@ private:
     }
     void Update_Model_NullEmployee_Name(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelNullArg_3348340388(phase);
-        }
+        this->Update_Model_M_FunctionOnModelNullArg_3348340388(phase);
     }
     void Update_Model_M_FunctionOnModelNullArg_3348340388(int phase)
     {
@@ -1931,10 +1912,7 @@ private:
     }
     void Update_Model_StringPropertyDP(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_706606279(phase);
     }
     void Update_Model_M_FunctionOnModelThreeArgs_706606279(int phase)
     {
@@ -1987,14 +1965,7 @@ private:
                 this->UpdateFallback_Model_NullEmployee_FirstName_M_ToString_757602046(phase);
             }
         }
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-        }
-        else
-        {
-            this->UpdateFallback_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
-        }
+        this->Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase);
     }
     void Update_Model_NullEmployee_FirstName_M_ToString_757602046(int phase)
     {
@@ -2073,10 +2044,7 @@ private:
     }
     void Update_Model_Employees_I2_Name(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase);
-        }
+        this->Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase);
     }
     void Update_Model_M_FunctionOnModelOneStringArg_2530340821(int phase)
     {
@@ -2090,14 +2058,7 @@ private:
     }
     void Update_Model_ReentrancyString(::Platform::String^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
-        else
-        {
-            this->UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
-        }
+        this->Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase);
     }
     void Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(int phase)
     {

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/FunctionTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/FunctionTests.g.hpp
@@ -958,7 +958,9 @@ private:
     {
         ::Platform::String^ p0;
         if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0)) { return; }
-        ::Platform::String^ result = this->GetDataRoot()->Model->FunctionOnModelOneStringArg(p0);
+        ::BindTestbedModel::DataModel^ instance;
+        if (!TryGet_Model(instance) || instance == nullptr) { return; }
+        ::Platform::String^ result = instance->FunctionOnModelOneStringArg(p0);
         if ((phase & ((1 << 0) | NOT_PHASED )) != 0)
         {
             // FunctionTests.xaml line 52

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/NullableTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCX/Incremental/Generated Files/NullableTests.g.hpp
@@ -284,10 +284,7 @@ private:
     }
     void Update_Model_NullableDoublePropertyDP(::Platform::IBox<::default::float64>^ obj, int phase)
     {
-        if (obj != nullptr)
-        {
-            this->Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
-        }
+        this->Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
         if ((phase & ((1 << 0) | NOT_PHASED | DATA_CHANGED)) != 0)
         {
             // NullableTests.xaml line 39

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCppWinRT/Generated Files/FunctionTests.xaml.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCppWinRT/Generated Files/FunctionTests.xaml.g.hpp
@@ -895,7 +895,9 @@ namespace winrt::BindTestbed::implementation
         {
             ::winrt::hstring p0;
             if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0)) { return; }
-            ::winrt::hstring result = GetDataRoot().Model().FunctionOnModelOneStringArg(p0);
+            ::winrt::BindTestbedModel::DataModel instance = nullptr;
+            if (!TryGet_Model(instance) || !instance) { return; }
+            ::winrt::hstring result = instance.FunctionOnModelOneStringArg(p0);
             if((phase & ((1 << 0) | NOT_PHASED )) != 0)
             {
                 // FunctionTests.xaml line 52

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCppWinRT/Incremental/Generated Files/FunctionTests.xaml.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedCppWinRT/Incremental/Generated Files/FunctionTests.xaml.g.hpp
@@ -895,7 +895,9 @@ namespace winrt::BindTestbed::implementation
         {
             ::winrt::hstring p0;
             if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0)) { return; }
-            ::winrt::hstring result = GetDataRoot().Model().FunctionOnModelOneStringArg(p0);
+            ::winrt::BindTestbedModel::DataModel instance = nullptr;
+            if (!TryGet_Model(instance) || !instance) { return; }
+            ::winrt::hstring result = instance.FunctionOnModelOneStringArg(p0);
             if((phase & ((1 << 0) | NOT_PHASED )) != 0)
             {
                 // FunctionTests.xaml line 52

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/CastingTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/CastingTests.g.vb
@@ -681,9 +681,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_DataContext_Cast_DataContext_To_CastingTestsVM_Prefix(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase)
-                End If
+                Me.Update_DataContext_Cast_DataContext_To_CastingTestsVM_M_CombineStringWithInt_1807171632(phase)
             End Sub
             Private Sub Update_DataContext_Cast_DataContext_To_CastingTestsVM_Postfix(obj As Global.System.Double, phase As Integer)
                 If (phase And (NOT_PHASED Or (1 << 0))) <> 0 Then

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
@@ -1100,11 +1100,7 @@ Namespace Global.BindTestbed
                         Me.UpdateFallback_Model_ReentrancyString(phase)
                     End If
                 End If
-                If obj IsNot Nothing Then
-                    Me.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase)
-                Else
-                    Me.UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase)
-                End If
+                Me.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase)
             End Sub
             Private Sub Update_Model_M_FunctionOnModelNoArgs_757602046(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then
@@ -1210,9 +1206,7 @@ Namespace Global.BindTestbed
                         Me.Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString1_757602046(phase)
                     End If
                 End If
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelOneStringArg_1668010001(phase)
             End Sub
             Private Sub Update_BindTestbedModel_DataModel_StaticStringProperty_M_ToString1_757602046(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED )) <> 0 Then
@@ -1348,9 +1342,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_NullEmployee_Name(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelNullArg_3348340388(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelNullArg_3348340388(phase)
             End Sub
             Private Sub Update_Model_M_FunctionOnModelNullArg_3348340388(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then
@@ -1367,9 +1359,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_StringPropertyDP(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelThreeArgs_706606279(phase)
             End Sub
             Private Sub Update_Model_M_FunctionOnModelThreeArgs_706606279(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then
@@ -1405,10 +1395,8 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_Employees_I0_Name(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase)
-                    Me.Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase)
+                Me.Update_Model_M_FunctionOnModelOneStringArg_2532831189(phase)
             End Sub
             Private Sub Update_Model_Employees_I0_IsManager(obj As Global.System.Boolean, phase As Integer)
                 Me.Update_Model_M_FunctionOnModelThreeArgs_2448615814(phase)
@@ -1438,11 +1426,7 @@ Namespace Global.BindTestbed
                         Me.UpdateFallback_Model_NullEmployee_FirstName_M_ToString1_757602046(phase)
                     End If
                 End If
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase)
-                Else
-                    Me.UpdateFallback_Model_M_FunctionOnModelThreeArgs_1187614766(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelThreeArgs_1187614766(phase)
             End Sub
             Private Sub Update_Model_NullEmployee_FirstName_M_ToString1_757602046(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED )) <> 0 Then
@@ -1498,9 +1482,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_Employees_I2_Name(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase)
-                End If
+                Me.Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase)
             End Sub
             Private Sub Update_Model_M_FunctionOnModelOneStringArg_2530340821(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then
@@ -1510,11 +1492,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_ReentrancyString(obj As Global.System.String, phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase)
-                Else
-                    Me.UpdateFallback_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase)
-                End If
+                Me.Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase)
             End Sub
             Private Sub Update_BindTestbedModel_DataModel_M_UpdateReentrancyString_1481343332(phase As Integer)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/FunctionTests.g.vb
@@ -724,7 +724,9 @@ Namespace Global.BindTestbed
             Private Sub Invoke_Model_M_FunctionOnModelOneStringArg_1668010001(phase As Integer)
                 Dim p0 As Global.System.String = Nothing
                 If Not TryGet_BindTestbedModel_DataModel_StaticStringProperty(p0) Then Return
-                Dim result As Global.System.String = Me.dataRoot.Model.FunctionOnModelOneStringArg(p0)
+                Dim instance As Global.BindTestbedModel.DataModel = Nothing
+                If Not TryGet_Model(instance) OrElse instance Is Nothing Then Return
+                Dim result As Global.System.String = instance.FunctionOnModelOneStringArg(p0)
                 If (phase And ((1 << 0) Or NOT_PHASED )) <> 0 Then
                     If isobj13TextDisabled = False Then
                         XamlBindingSetters.Set_Windows_UI_Xaml_Controls_TextBlock_Text(Me.obj13, result, Nothing)

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/NullableTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/CompiledBinding/BindTestbedVB/obj/x86/Debug/NullableTests.g.vb
@@ -251,9 +251,7 @@ Namespace Global.BindTestbed
                 End If
             End Sub
             Private Sub Update_Model_NullableDoublePropertyDP(obj As Global.System.Nullable(Of Global.System.Double), phase As Integer)
-                If obj IsNot Nothing Then
-                    Me.Update_Model_M_FunctionReturningNullableDouble_1740600808(phase)
-                End If
+                Me.Update_Model_M_FunctionReturningNullableDouble_1740600808(phase)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then
                     If isobj5NullableDoubleDPDisabled = False Then
                         XamlBindingSetters.Set_BindTestbedModel_NullablePropertiesButton_NullableDoubleDP(Me.obj5, obj, Nothing)

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/Conditionals/ConditionalsCS/obj/x86/Debug/BindTests.g.cs
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/Conditionals/ConditionalsCS/obj/x86/Debug/BindTests.g.cs
@@ -1237,10 +1237,7 @@ namespace Conditionals
             private void Update_Model_Org_Employees(global::ConditionalControls.IObservableCollection obj, int phase)
             {
                 this.bindingsTracking.UpdateChildListeners_Model_Org_Employees(obj);
-                if (obj != null)
-                {
-                    this.Update_ConditionalControls_Organization_M_IsNonEmpty_2973382484(phase);
-                }
+                this.Update_ConditionalControls_Organization_M_IsNonEmpty_2973382484(phase);
                 if ((phase & ((1 << 0) | NOT_PHASED | DATA_CHANGED)) != 0)
                 {
                     // BindTests.xaml line 72

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/Conditionals/ConditionalsCX/Generated Files/BindTests.g.hpp
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/Conditionals/ConditionalsCX/Generated Files/BindTests.g.hpp
@@ -1109,10 +1109,7 @@ private:
     void Update_Model_Org_Employees(::ConditionalControls::IObservableCollection^ obj, int phase)
     {
         this->_bindingsTracking->UpdateCollectionChangedListener(obj, &cacheCC_Model_Org_Employees, &tokenCC_Model_Org_Employees);
-        if (obj != nullptr)
-        {
-            this->Update_ConditionalControls_Organization_M_IsNonEmpty_2973382484(phase);
-        }
+        this->Update_ConditionalControls_Organization_M_IsNonEmpty_2973382484(phase);
         if ((phase & ((1 << 0) | NOT_PHASED | DATA_CHANGED)) != 0)
         {
             // BindTests.xaml line 72

--- a/src/XamlCompiler/TestMasters/RegressionProjects/Features/Conditionals/ConditionalsVB/obj/x86/Debug/BindTests.g.vb
+++ b/src/XamlCompiler/TestMasters/RegressionProjects/Features/Conditionals/ConditionalsVB/obj/x86/Debug/BindTests.g.vb
@@ -948,9 +948,7 @@ Namespace Global.Conditionals
             End Sub
             Private Sub Update_Model_Org_Employees(obj As Global.ConditionalControls.IObservableCollection, phase As Integer)
                 Me.bindingsTracking.UpdateChildListeners_Model_Org_Employees(obj)
-                If obj IsNot Nothing Then
-                    Me.Update_ConditionalControls_Organization_M_IsNonEmpty_2973382484(phase)
-                End If
+                Me.Update_ConditionalControls_Organization_M_IsNonEmpty_2973382484(phase)
                 If (phase And ((1 << 0) Or NOT_PHASED Or DATA_CHANGED)) <> 0 Then
                     If isobj12ItemsSourceDisabled = False Then
                         XamlBindingSetters.Set_Windows_UI_Xaml_Controls_ItemsControl_ItemsSource(Me.obj12, obj, Nothing)

--- a/src/XamlCompiler/Tests/UnitTests/FunctionBindingCodegenTests.cs
+++ b/src/XamlCompiler/Tests/UnitTests/FunctionBindingCodegenTests.cs
@@ -29,7 +29,8 @@ namespace UnitTests
             string page = String.Format(
                 @"<Page x:Class='LibManagedDll.BindPathParserClass'
                 xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
-                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>{0}</Page>",
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                xmlns:dll='using:LibManagedDll'>{0}</Page>",
                 xaml);
 
             var context = new CodeGeneratorProjectContext(new Version(KnownVersions.Latest), "FunctionBindingCodegen");
@@ -115,6 +116,66 @@ namespace UnitTests
                 @"global::System\.String p0;\s*" +
                 @"if \(!TryGet_StringProperty\(out p0\)\) \{ return; \}\s*" +
                 @"global::System\.String result = this\.dataRoot\.FormatTitle\(p0\);");
+        }
+
+        /// <summary>
+        /// A path that starts at a named element inside a template is rooted at the element root, a
+        /// synthetic step standing in for the namescope rather than for a value, so it has to be
+        /// read straight off the bindings class instead of being walked to through that root.
+        /// </summary>
+        private const string NamedElementTemplate = @"
+            <ContentControl>
+                <ContentControl.ContentTemplate>
+                    <DataTemplate x:DataType='dll:BindPathParserClass'>
+                        <Grid>
+                            <dll:NamedElementForPathing x:Name='helper'/>
+                            {0}
+                        </Grid>
+                    </DataTemplate>
+                </ContentControl.ContentTemplate>
+            </ContentControl>";
+
+        [TestMethod]
+        public void FunctionBinding_RetrievesNamedElementInstanceInTemplate()
+        {
+            string code = GenerateBindings(
+                String.Format(NamedElementTemplate, "<TextBlock Text='{x:Bind helper.Format(StringProperty)}'/>"),
+                CodeGenLanguage.CSharp);
+
+            AssertGenerated(code,
+                @"private bool TryGet_helper\(out global::LibManagedDll\.NamedElementForPathing val\)\s*\{\s*" +
+                @"val = this\.obj\d+;\s*return true;\s*\}");
+        }
+
+        [TestMethod]
+        public void FunctionBinding_RetrievesNamedElementInstanceInTemplate_VisualBasic()
+        {
+            string code = GenerateBindings(
+                String.Format(NamedElementTemplate, "<TextBlock Text='{x:Bind helper.Format(StringProperty)}'/>"),
+                CodeGenLanguage.VisualBasic);
+
+            AssertGenerated(code,
+                @"Private Function TryGet_helper\(<Global\.System\.Runtime\.InteropServices\.Out\(\)> ByRef val As " +
+                @"Global\.LibManagedDll\.NamedElementForPathing\) As Boolean\s*" +
+                @"val = Me\.obj\d+\s*Return True\s*End Function");
+        }
+
+        [TestMethod]
+        public void FunctionBinding_RetrievesNamedElementArgumentInTemplate()
+        {
+            string code = GenerateBindings(
+                String.Format(NamedElementTemplate, "<TextBlock Text='{x:Bind FormatTitle(helper.Value)}'/>"),
+                CodeGenLanguage.CSharp);
+
+            // The step for the named element itself is read directly, and the step below it is
+            // walked to through that one as usual.
+            AssertGenerated(code,
+                @"private bool TryGet_helper\(out global::LibManagedDll\.NamedElementForPathing val\)\s*\{\s*" +
+                @"val = this\.obj\d+;\s*return true;\s*\}");
+            AssertGenerated(code,
+                @"private bool TryGet_helper_Value\(out global::System\.String val\)\s*\{\s*" +
+                @"global::LibManagedDll\.NamedElementForPathing obj;\s*" +
+                @"if \(TryGet_helper\(out obj\) && obj != null\)");
         }
     }
 }

--- a/src/XamlCompiler/Tests/UnitTests/FunctionBindingCodegenTests.cs
+++ b/src/XamlCompiler/Tests/UnitTests/FunctionBindingCodegenTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Win8Xaml.CompilerProxies;
+
+namespace UnitTests
+{
+    /// <summary>
+    /// Codegen tests for x:Bind function bindings. They assert on the generated Update_ and
+    /// Invoke_ methods, which are emitted the same way for every binding mode, so the bindings
+    /// below do not need to opt into change notification to cover the one way scenarios.
+    /// </summary>
+    [TestClass]
+    public class FunctionBindingCodegenTests
+    {
+        TestHelper _testHelper;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _testHelper = new TestHelper();
+        }
+
+        private string GenerateBindings(string xaml, CodeGenLanguage language)
+        {
+            string page = String.Format(
+                @"<Page x:Class='LibManagedDll.BindPathParserClass'
+                xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>{0}</Page>",
+                xaml);
+
+            var context = new CodeGeneratorProjectContext(new Version(KnownVersions.Latest), "FunctionBindingCodegen");
+            DirectUISchemaContext schema = _testHelper.LoadSchema(SchemaMode.ManagedRuntime | SchemaMode.LoadUserDll);
+            List<FileNameAndContentPair> pairs = _testHelper.GenerateCodeBehind(
+                context, new List<string> { page }, schema, language);
+
+            Assert.AreEqual(1, pairs.Count);
+            return pairs[0].Contents;
+        }
+
+        private static void AssertGenerated(string code, string pattern)
+        {
+            // Path steps are named after the path they walk plus a hash of the function arguments,
+            // so match the shape of the generated code rather than the exact code names.
+            Assert.IsTrue(Regex.IsMatch(code, pattern),
+                String.Format("Generated code does not match '{0}':{1}{2}", pattern, Environment.NewLine, code));
+        }
+
+        [TestMethod]
+        public void FunctionBinding_UpdatesWhenArgumentIsNull()
+        {
+            string code = GenerateBindings(
+                "<TextBlock Text='{x:Bind FormatTitle(StringProperty)}'/>", CodeGenLanguage.CSharp);
+
+            // The function binding depends on StringProperty. A null value is a legitimate
+            // argument rather than an unresolved path, so the update must not be skipped for it.
+            AssertGenerated(code,
+                @"private void Update_StringProperty\(global::System\.String obj, int phase\)\s*" +
+                @"\{\s*this\.Update_M_FormatTitle_\d+\(phase\);\s*\}");
+        }
+
+        [TestMethod]
+        public void FunctionBinding_UpdatesWhenArgumentIsNull_VisualBasic()
+        {
+            string code = GenerateBindings(
+                "<TextBlock Text='{x:Bind FormatTitle(StringProperty)}'/>", CodeGenLanguage.VisualBasic);
+
+            AssertGenerated(code,
+                @"Private Sub Update_StringProperty\(obj As Global\.System\.String, phase As Integer\)\s*" +
+                @"Me\.Update_M_FormatTitle_\d+\(phase\)\s*End Sub");
+        }
+
+        [TestMethod]
+        public void FunctionBinding_KeepsNullCheckOnPathSteps()
+        {
+            string code = GenerateBindings(
+                "<TextBlock Text='{x:Bind InnerClass.StringFunction()}'/>", CodeGenLanguage.CSharp);
+
+            // Walking on to a child step still has to be skipped when the step itself is null.
+            AssertGenerated(code,
+                @"private void Update_\(global::LibManagedDll\.BindPathParserClass obj, int phase\)\s*" +
+                @"\{\s*if \(obj != null\)");
+        }
+
+        [TestMethod]
+        public void FunctionBinding_RetrievesInstanceWhenArgumentIsOutsideItsPath()
+        {
+            string code = GenerateBindings(
+                "<TextBlock Text='{x:Bind InnerClass.Format(StringProperty)}'/>", CodeGenLanguage.CSharp);
+
+            // StringProperty can schedule the binding while InnerClass is null, so the instance
+            // has to be retrieved safely and the call made on it rather than on the path.
+            AssertGenerated(code,
+                @"private void Invoke_InnerClass_M_Format_\d+\(int phase\)\s*\{\s*" +
+                @"global::System\.String p0;\s*" +
+                @"if \(!TryGet_StringProperty\(out p0\)\) \{ return; \}\s*" +
+                @"global::LibManagedDll\.AnotherClassForPathing instance;\s*" +
+                @"if \(!TryGet_InnerClass\(out instance\) \|\| instance == null\) \{ return; \}\s*" +
+                @"global::System\.String result = instance\.Format\(p0\);");
+        }
+
+        [TestMethod]
+        public void FunctionBinding_DoesNotRetrieveInstanceWhenArgumentIsUnderIt()
+        {
+            string code = GenerateBindings(
+                "<TextBlock Text='{x:Bind FormatTitle(StringProperty)}'/>", CodeGenLanguage.CSharp);
+
+            // StringProperty sits under the data root the function is invoked on, so it can only
+            // schedule the binding while that root is non null and no retrieval is needed.
+            AssertGenerated(code,
+                @"private void Invoke_M_FormatTitle_\d+\(int phase\)\s*\{\s*" +
+                @"global::System\.String p0;\s*" +
+                @"if \(!TryGet_StringProperty\(out p0\)\) \{ return; \}\s*" +
+                @"global::System\.String result = this\.dataRoot\.FormatTitle\(p0\);");
+        }
+    }
+}

--- a/src/XamlCompiler/Tests/UnitTests/LibManagedDll/BindPathParserTypes.cs
+++ b/src/XamlCompiler/Tests/UnitTests/LibManagedDll/BindPathParserTypes.cs
@@ -11,6 +11,8 @@ namespace LibManagedDll
     public class AnotherClassForPathing
     {
         public string StringFunction() { return "StringFunction"; }
+
+        public string Format(string value) { return String.Format("Format: {0}", value); }
     }
 
     public class BindPathParserClass

--- a/src/XamlCompiler/Tests/UnitTests/LibManagedDll/BindPathParserTypes.cs
+++ b/src/XamlCompiler/Tests/UnitTests/LibManagedDll/BindPathParserTypes.cs
@@ -15,6 +15,13 @@ namespace LibManagedDll
         public string Format(string value) { return String.Format("Format: {0}", value); }
     }
 
+    public class NamedElementForPathing : FrameworkElement
+    {
+        public string Value { get; set; }
+
+        public string Format(string value) { return String.Format("Format: {0}", value); }
+    }
+
     public class BindPathParserClass
     {
         public Color[] Rainbow = {

--- a/src/XamlCompiler/Tests/UnitTests/TestHelper.cs
+++ b/src/XamlCompiler/Tests/UnitTests/TestHelper.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Win8Xaml.CompilerProxies;
@@ -521,6 +522,19 @@ namespace UnitTests
                 fileInfo.RelativePathFromGeneratedCodeToXamlFile = dummyFileName;
                 fileInfo.SourceXamlGivenPath = dummyFilePath;
                 sharedCodeInfo.AddXamlFileInfo(fileInfo);
+            }
+
+            if (!cpx.IsPass1)
+            {
+                // Mirror CompileXamlInternal, which parses the bind universes once every file has
+                // been harvested and before any code is generated. Without this the x:Binds have
+                // no path steps and no binding code is emitted at all.
+                foreach (BindUniverse bindUniverse in sharedCodeInfo.BindUniverses)
+                {
+                    IEnumerable<XamlCompileError> errors = bindUniverse.Parse(sharedCodeInfo);
+                    Assert.AreEqual(0, errors.Count(),
+                        String.Join(", ", errors.Select(error => error.ErrorCode + ": " + error.Message)));
+                }
             }
 
             if (!cpx.IsPass1 && lang == CodeGenLanguage.Cpp)

--- a/src/XamlCompiler/Tests/UnitTests/XamlCompilerUnitTests.csproj
+++ b/src/XamlCompiler/Tests/UnitTests/XamlCompilerUnitTests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="CodeCoverage.cs" />
     <Compile Include="CodeGeneratorProjectContext.cs" />
     <Compile Include="CodeGeneratorTests.cs" />
+    <Compile Include="FunctionBindingCodegenTests.cs" />
     <Compile Include="HarvesterTests.cs" />
     <Compile Include="KnownBugs.cs" />
     <Compile Include="MultipleViewTests.cs" />


### PR DESCRIPTION
## Fixes

Fixes #1904
Fixes #2166

## PR Type

- [x] Bugfix

## Description

A one-way `x:Bind` function binding stops updating the moment its argument becomes `null`. Setting the property to a value works, changing it to a different value works, but clearing it does nothing — the UI keeps whatever it was last given. There's no binding error and nothing in the debug output, so everything points at the view model being wrong when it isn't.

The easiest way to hit it is a visibility helper:

```xml
<Grid Visibility="{x:Bind local:BindingFunctions.VisibleIfNotNull(Detail), Mode=OneWay}">
```

The grid appears once `Detail` is set, and then can never be hidden again — because hiding it depends on exactly the update that gets skipped. Anything else works the same way: a `string?` feeding a `Text` binding keeps the last non-empty string instead of clearing.

This is the same thing reported in #1904 back in 2020, there with a `bool?` and a static converter method:

```xml
<DataTemplate x:DataType="MyModel">
    <TextBlock Text="{x:Bind converters:MyConverter.Convert(Property), Mode=OneWay}"/>
</DataTemplate>
```

I ran both repros from that issue through the compiler, and the generated code goes from skipping the call to always making it.

It also covers #2166, which is the same thing again — there the giveaway was that `FallbackValue` kicked in when the argument went null. After this change the function is called with the null, and `FallbackValue` is left for the case it is meant for, where the path genuinely cannot be resolved.

### Current Behavior

The generated code treats a null argument as "this path didn't resolve, don't bother", so it never calls the function:

```csharp
private void Update_Model_NullableDoublePropertyDP(global::System.Nullable<global::System.Double> obj, int phase)
{
    if (obj != null)
    {
        this.Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
    }
    ...
}
```

But null isn't an unresolved path here, it's a perfectly good argument. And the code that actually calls the function already knows the difference — it looks each argument up through a `TryGet_` helper that only gives up when something *in the middle* of the path is null:

```csharp
private bool TryGet_Model_NullableDoublePropertyDP(out global::System.Nullable<global::System.Double> val)
{
    global::BindTestbedModel.DataModel obj;
    if (TryGet_Model(out obj) && obj != null)   // checks the parent, not the value
    {
        val = obj.NullableDoublePropertyDP;     // may legitimately be null, and that's fine
        return true;
    }
    ...
}
```

So that check on the way in is the only thing in the way. C++/WinRT already didn't emit it — C#, VB and C++/CX did.

### New Behavior

It's gone, so the function runs and its result is applied:

```diff
 private void Update_Model_NullableDoublePropertyDP(global::System.Nullable<global::System.Double> obj, int phase)
 {
-    if (obj != null)
-    {
-        this.Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
-    }
+    this.Update_Model_M_FunctionReturningNullableDouble_1740600808(phase);
     if ((phase & ((1 << 0) | NOT_PHASED | DATA_CHANGED)) != 0)
     {
         // NullableTests.xaml line 39
         if (!isobj5NullableDoubleDPDisabled)
         {
             XamlBindingSetters.Set_BindTestbedModel_NullablePropertiesButton_NullableDoubleDP(this.obj5, obj, null);
         }
     }
 }
```

### One thing that had to be fixed first

Removing that check on its own would have swapped a stale UI for a crash in one case, so the first commit closes that hole.

When a function is called on something — `{x:Bind Model.Format(...)}` rather than a static helper — the generated code walked straight to it without checking it was there:

```csharp
global::System.String result = this.dataRoot.Model.FunctionOnModelOneStringArg(p0);
```

That's fine as long as the only way in is through `Model` itself, which the compiler does check. But a binding can also be woken up by one of its arguments, and an argument doesn't have to live under `Model`. `{x:Bind Model.Format(Title)}` with a null `Model` throws today the moment `Title` has a value; with the rest of this change it would also throw when both are null, which is a very ordinary state for a page that hasn't loaded its data yet.

So the instance now goes through the same lookup the arguments already use, and the call is made on what comes back:

```diff
 private void Invoke_Model_M_FunctionOnModelOneStringArg_1668010001(int phase)
 {
     global::System.String p0;
     if (!TryGet_BindTestbedModel_DataModel_StaticStringProperty(out p0)) { return; }
-    global::System.String result = this.dataRoot.Model.FunctionOnModelOneStringArg(p0);
+    global::BindTestbedModel.DataModel instance;
+    if (!TryGet_Model(out instance) || instance == null) { return; }
+    global::System.String result = instance.FunctionOnModelOneStringArg(p0);
     ...
 }
```

This is only emitted where an argument can reach the binding from outside the instance's own path — one binding across all four testbeds — so everything else generates exactly as before.

### A named element the function is called on

Copilot found a case the above broke: a named element inside a template, used as the thing the function is called on.

```xml
<DataTemplate x:DataType="local:ObservableModel">
    <Grid>
        <local:Formatter x:Name="formatter" />
        <TextBlock Text="{x:Bind formatter.Format(Child), Mode=OneWay}" />
    </Grid>
</DataTemplate>
```

Looking up a named element is a bit different: it isn't reached by walking down from the data, it lives on the generated bindings class. The lookup helper didn't know that and tried to walk anyway, producing code that doesn't compile:

```csharp
private bool TryGet_formatter(out Formatter val)
{
    ObservableModel obj;
    if (TryGet_(out obj) && obj != null)   // hands back the bindings object, not the model
    {
        val = bindings.obj4;               // 'bindings' isn't a thing in here
```

It now reads the element directly, which is what the rest of the generated code already does:

```csharp
private bool TryGet_formatter(out global::WinUIRepro.Formatter val)
{
    val = this.obj4;
    return true;
}
```

Worth noting this one isn't really new. The same broken helper is already produced on `main` today if you pass a named element to a function inside a template:

```xml
<TextBlock Text="{x:Bind formatter.Format(formatter.Tag), Mode=OneWay}" />
```

I checked that against a clean build of `main` to be sure. So this fixes a build break that was already there, and the earlier change had simply given it a second way to show up.

### The same element in C++/WinRT

C++/WinRT needed a second look. Reaching a named element walks to it through the thing that owns its namescope, but in C++/WinRT that owner has no expression at all and the element is a plain field, so the walk left a stray dot and called the field as if it were an accessor:

```cpp
val = .obj4();
```

It now reads the field, which is what the rest of the generated code already does:

```cpp
val = obj4;
```

This one also turned out to be older than the pull request. The same malformed expression is produced on `main` today by a two-way binding to a named element in a template, with no function binding anywhere in sight:

```xml
<TextBox Text="{x:Bind helper.Value, Mode=TwoWay}" />
```

```cpp
if (.obj4() != nullptr)
    .obj4().Value(obj8.Text());
```

So C++/WinRT gets two fixes here, and C#, VB and C++/CX generate exactly the same code as before.

### A named element as an argument, once more

Evelyn spotted one more case, and it's one the instance lookup above should already have caught. When the function is called on the data itself and takes a named element as an argument, the lookup was skipped:

```xml
<DataTemplate x:DataType="local:ObservableModel">
    <Grid>
        <local:Helper x:Name="helper" />
        <TextBlock Text="{x:Bind FormatTitle(helper.Value), Mode=OneWay}" />
    </Grid>
</DataTemplate>
```

The compiler decides whether it has to look the instance up by asking whether every argument already sits underneath it. It was answering that by comparing names, and the start of a named element path and the start of a data path both have no name — so the two looked like the same thing, the argument seemed to sit under the instance, and the call went out unguarded:

```csharp
global::System.String result = this.dataRoot.FormatTitle(p0);
```

which throws the moment the template is realized before its data arrives. Comparing the steps themselves rather than their names tells the two apart:

```diff
-    global::System.String result = this.dataRoot.FormatTitle(p0);
+    global::WinUIRepro.ObservableModel instance;
+    if (!TryGet_(out instance) || instance == null) { return; }
+    global::System.String result = instance.FormatTitle(p0);
```

Both directions are pinned by tests now, because it's easy to fix this one and break the mirror image of it — a function whose argument *is* the thing it's called on, like `{x:Bind Model.Describe(Model)}`, still needs the lookup, since `Model` going null is exactly what wakes the binding up.

## Customer Impact

User facing. Three things change for apps:

- A function binding now runs when one of its arguments becomes null, instead of leaving the target on its previous value. This is the fix.
- The same binding no longer throws when the object the function is called on is null and an unrelated argument changes.
- `FallbackValue` no longer kicks in when an argument is simply null. It still applies when the path genuinely can't be resolved — a null somewhere in the middle — which lines up with how a plain binding behaves, where a null value at the end gives you `TargetNullValue` and only a broken path gives you `FallbackValue`. This is the one behaviour someone could have been relying on, and it's also the workaround people reach for when they hit the bug in the first place.

## Regression Potential

- [x] Low risk — isolated change, limited scope

The check that was removed only ever guarded function bindings, and only on the way in. Everything else keeps its null checks, including walking down a path, and there are tests pinning that. C++/WinRT has generated the new shape all along, so this brings the other three languages in line rather than inventing something.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally

`FunctionBindingCodegenTests.cs` now holds 17 codegen tests across C#, VB, C++/CX and C++/WinRT, including two controls pinning shapes that must *not* change. Confirmed against a locally built compiler, before and after:

| | before | after |
| --- | --- | --- |
| null argument still updates the target (C#) | **fails** | passes |
| null argument still updates the target (VB) | **fails** | passes |
| null argument still updates the target (C++/CX) | **fails** | passes |
| null argument still updates the target (C++/WinRT) | passes | passes |
| instance looked up when an argument sits outside its path (C#) | **fails** | passes |
| instance looked up when an argument sits outside its path (C++/CX) | **fails** | passes |
| instance looked up when an argument sits outside its path (C++/WinRT) | **fails** | passes |
| named element the function is called on (C#) | **fails** | passes |
| named element the function is called on (VB) | **fails** | passes |
| named element the function is called on (C++/CX) | **fails** | passes |
| named element the function is called on (C++/WinRT) | **fails** | passes |
| two-way binding through a named element (C++/WinRT) | **fails** | passes |
| function called on the data with a named element argument | **fails** | passes |
| function whose argument is the instance it's called on | **fails** | passes |
| named element passed as an argument | passes | passes |
| walking down a path still skips a null step _(control)_ | passes | passes |
| no lookup when every argument sits under the instance _(control)_ | passes | passes |

"before" is a clean build of `main`, so the rows that already pass there are the ones guarding behaviour that was correct to begin with.

C++/WinRT had no unit test coverage at all before this — the test helper's language list simply did not include it — which is how the malformed expression went unnoticed. It is wired up now, and the function binding tests run across all four languages. I also ran every binding in both attached repro projects through the compiler in C#, VB, C++/CX and C++/WinRT and checked the output. The checked-in expected-codegen masters are updated to match, the generated files were produced by re-running the T4 generator rather than edited by hand, and the compiler builds clean for both target frameworks.

For the whole suite I ran it twice locally, once with this branch and once with the compiler built from `main`, and compared: 258 of 328 pass here against 241 of 311 on `main` — the difference being exactly the 17 new tests — with the same 22 failures either way. Those 22 are schema, type collector and validator tests that need a full product build to pass and are unrelated to binding.
