### PR TITLE
Suppresses 0612 warnings when accessing members on obsolete classes

### DIFF
--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass1.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass1.cs
@@ -178,7 +178,7 @@ this.Write("\r\n");
 
              if (fieldData.IsDeprecated) 
              { 
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
              } 
 this.Write("        ");
@@ -197,7 +197,7 @@ this.Write("; \r\n");
 
              if (fieldData.IsDeprecated) 
              { 
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
              } 
          } 

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass1.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass1.tt
@@ -99,12 +99,12 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
         <#=GeneratedCodeAttribute#>
 <#+             if (fieldData.IsDeprecated) #>
 <#+             { #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+             } #>
         <#=fieldData.FieldModifier#> global::<#=fieldData.FieldTypeName#> <#=fieldData.FieldName#>; 
 <#+             if (fieldData.IsDeprecated) #>
 <#+             { #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+             } #>
 <#+         } #>
 #pragma warning restore 0649

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.cs
@@ -659,7 +659,7 @@ this.Write("            return returnValue;\r\n        }\r\n");
      {
          if (isDeprecated) 
          { 
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
          } 
      }
@@ -667,7 +667,7 @@ this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n")
      {
          if (isDeprecated) 
          { 
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
          } 
      }

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpPagePass2.tt
@@ -371,7 +371,7 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
 <#+     {#>
 <#+         if (isDeprecated) #>
 <#+         { #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+         } #>
 <#+     }#>
 
@@ -379,7 +379,7 @@ namespace <#=Model.CodeInfo.ClassName.Namespace#>
 <#+     {#>
 <#+         if (isDeprecated) #>
 <#+         { #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+         } #>
 <#+     }#>
 

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpTypeInfoPass2.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpTypeInfoPass2.cs
@@ -710,7 +710,7 @@ this.Write("];\r\n");
              InternalTypeEntry entry = SchemaInfo.TypeTable[i];      
              if (entry.IsDeprecated)                                 
              {                                                       
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
              }                                                       
 this.Write("            _typeTable[");
@@ -725,7 +725,7 @@ this.Write(");\r\n");
 
              if (entry.IsDeprecated)                                 
              {                                                       
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
              }                                                       
          }                                                           
@@ -906,7 +906,7 @@ this.Write(";\r\n");
                              // ([Obsolete(message, true)]) emits CS0619 (an error), which pragma 0618 does not suppress.
                              if (uentry.IsDeprecated)
                              {
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
                              }
                              if (uentry.TypeEntry.UnderlyingType.IsValueType)
@@ -929,7 +929,7 @@ this.Write(";\r\n");
                              }
                              if (uentry.IsDeprecated)
                              {
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
                              }
                          }
@@ -946,7 +946,7 @@ this.Write("\");\r\n");
                          {                               
                              if (uentry.IsDeprecated)    
                              {                           
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
                              }                                            
                              foreach(string eValue in uentry.EnumValues)  
@@ -968,7 +968,7 @@ this.Write(");\r\n");
                              }                           
                              if (uentry.IsDeprecated)    
                              {                           
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
                              }                           
                          }                               
@@ -1010,7 +1010,7 @@ this.Write("            return xamlType;\r\n        }\r\n");
                  {                                                               
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
                      }                                                           
 this.Write("        private object ");
@@ -1025,7 +1025,7 @@ this.Write("(); }\r\n");
 
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
                      }                                                           
                  }           
@@ -1039,7 +1039,7 @@ this.Write("#pragma warning restore 0618\r\n");
                  {                                                               
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
                      }                                                           
 this.Write("        private void ");
@@ -1055,7 +1055,7 @@ this.Write(").TypeHandle);\r\n");
 
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
                      }                                                           
                  }           
@@ -1069,7 +1069,7 @@ this.Write("#pragma warning restore 0618\r\n");
                  {                                                               
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
                      }                                                           
 this.Write("        private void ");
@@ -1089,7 +1089,7 @@ this.Write(")item;\r\n            collection.Add(newItem);\r\n        }\r\n");
 
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
                      }                                                           
                  }                       
@@ -1097,7 +1097,7 @@ this.Write("#pragma warning restore 0618\r\n");
                  {                       
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
                      }                                                           
 this.Write("        private void ");
@@ -1125,7 +1125,7 @@ this.Write(")item;\r\n            collection.Add(newKey, newItem);\r\n        }\
 
                      if (entry.IsDeprecated)                                     
                      {                                                           
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
                      }                                                           
                  }           
@@ -1249,7 +1249,7 @@ this.Write("            return xamlMember;\r\n        }\r\n");
                      continue;                       
                  if (entry.IsDeprecated)             
                  {                                   
-this.Write("#pragma warning disable 0618  //   Warning on Deprecated usage\r\n");
+this.Write("#pragma warning disable 0612, 0618  //   Warning on Deprecated usage\r\n");
 
                  }                                   
                  if (entry.HasPublicGetter)          
@@ -1385,7 +1385,7 @@ this.Write("        }\r\n");
                 }    
                      if (entry.IsDeprecated) 
                      {                       
-this.Write("#pragma warning restore 0618\r\n");
+this.Write("#pragma warning restore 0612, 0618\r\n");
 
                      }                       
             }        

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpTypeInfoPass2.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CSharpTypeInfoPass2.tt
@@ -707,12 +707,12 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+             InternalTypeEntry entry = SchemaInfo.TypeTable[i];      #>
 <#+             if (entry.IsDeprecated)                                 #>
 <#+             {                                                       #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+             }                                                       #>
             _typeTable[<#=entry.TypeIndex#>] = typeof(<#=entry.FullName#>);
 <#+             if (entry.IsDeprecated)                                 #>
 <#+             {                                                       #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+             }                                                       #>
 <#+         }                                                           #>
         }
@@ -819,7 +819,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                             // ([Obsolete(message, true)]) emits CS0619 (an error), which pragma 0618 does not suppress.#>
 <#+                             if (uentry.IsDeprecated)#>
 <#+                             {#>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+                             }#>
 <#+                             if (uentry.TypeEntry.UnderlyingType.IsValueType)#>
 <#+                             {#>
@@ -831,7 +831,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                             }#>
 <#+                             if (uentry.IsDeprecated)#>
 <#+                             {#>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+                             }#>
 <#+                         }#>
 <#+                         foreach(InternalXamlUserMemberInfo mem in uentry.Members)   #>
@@ -842,7 +842,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                         {                               #>
 <#+                             if (uentry.IsDeprecated)    #>
 <#+                             {                           #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+                             }                                            #>
 <#+                             foreach(string eValue in uentry.EnumValues)  #>
 <#+                             {                                            #>
@@ -850,7 +850,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                             }                           #>
 <#+                             if (uentry.IsDeprecated)    #>
 <#+                             {                           #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+                             }                           #>
 <#+                         }                               #>
 <#+                         if(uentry.IsBindable)           #>
@@ -888,12 +888,12 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                 {                                                               #>
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+                     }                                                           #>
         private object <#=Model.ActivatorName(entry)#>() { return new <#=entry.FullName#>(); }
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+                     }                                                           #>
 
 <#+                 }           #>
@@ -908,12 +908,12 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                 {                                                               #>
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+                     }                                                           #>
         private void <#=Model.StaticInitializerName(entry)#>() => global::System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(<#=entry.FullName#>).TypeHandle);
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+                     }                                                           #>
 <#+                 }           #>
 <#+             }               #>
@@ -927,7 +927,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                 {                                                               #>
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+                     }                                                           #>
         private void <#=Model.VectorAddName(entry)#>(object instance, object item)
         {
@@ -937,7 +937,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
         }
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+                     }                                                           #>
 
 <#+                 }                       #>
@@ -945,7 +945,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                 {                       #>
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+                     }                                                           #>
         private void <#=Model.MapAddName(entry)#>(object instance, object key, object item)
         {
@@ -956,7 +956,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
         }
 <#+                     if (entry.IsDeprecated)                                     #>
 <#+                     {                                                           #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+                     }                                                           #>
 
 <#+                 }           #>
@@ -1028,7 +1028,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 
 <#+                 if (entry.IsDeprecated)             #>
 <#+                 {                                   #>
-#pragma warning disable 0618  //   Warning on Deprecated usage
+#pragma warning disable 0612, 0618  //   Warning on Deprecated usage
 <#+                 }                                   #>
 <#+                 if (entry.HasPublicGetter)          #>
 <#+                 {                                   #>
@@ -1080,7 +1080,7 @@ namespace <#=ProjectInfo.XamlTypeInfoNamespace#>
 <#+                }    #>
 <#+                     if (entry.IsDeprecated) #>
 <#+                     {                       #>
-#pragma warning restore 0618
+#pragma warning restore 0612, 0618
 <#+                     }                       #>
 <#+            }        #>
 <#+        }            #>

--- a/src/XamlCompiler/Tests/UnitTests/CodeGeneratorTests.cs
+++ b/src/XamlCompiler/Tests/UnitTests/CodeGeneratorTests.cs
@@ -107,5 +107,54 @@ namespace UnitTests
                 Assert.IsFalse(pairs[0].Contents.Contains("ButtonBase"));
             }
         }
+
+        [TestMethod]
+        public void CodeGenerator_ObsoleteWithoutMessageSuppressesCS0612()
+        {
+            string xaml = @"
+<Page
+    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:dll='using:LibManagedDll'
+    x:Class='MyNamespace.MyPage'>
+    <dll:ObsoleteClass x:Name='obsoleteElement' ObsoleteProperty='value' />
+</Page>";
+
+            DirectUISchemaContext schema = _testHelper.LoadSchema(SchemaMode.LoadUserDll);
+            CodeGeneratorProjectContext context = new CodeGeneratorProjectContext(new Version(KnownVersions.Latest));
+            TypeInfoCollector collector = _testHelper.CollectTypes(xaml, schema);
+
+            List<FileNameAndContentPair> pairs = _testHelper.GenerateTypeInfo(
+                false,
+                collector.SchemaInfo,
+                context.ProjectInfo,
+                new ClassName("MyNamespace.App"),
+                CodeGenLanguage.CSharp);
+
+            Assert.AreEqual(1, pairs.Count);
+            Assert.IsTrue(pairs[0].Contents.Contains("#pragma warning disable 0612, 0618"));
+            Assert.IsTrue(pairs[0].Contents.Contains("ObsoleteClass.FromString"));
+            Assert.IsTrue(pairs[0].Contents.Contains("that.ObsoleteProperty"));
+
+            context.IsPass1 = true;
+            pairs = _testHelper.GenerateCodeBehind(
+                context,
+                new List<string> { xaml },
+                schema,
+                CodeGenLanguage.CSharp);
+
+            Assert.AreEqual(1, pairs.Count);
+            Assert.IsTrue(pairs[0].Contents.Contains("#pragma warning disable 0612, 0618"));
+
+            context.IsPass1 = false;
+            pairs = _testHelper.GenerateCodeBehind(
+                context,
+                new List<string> { xaml },
+                schema,
+                CodeGenLanguage.CSharp);
+
+            Assert.AreEqual(1, pairs.Count);
+            Assert.IsTrue(pairs[0].Contents.Contains("#pragma warning disable 0612, 0618"));
+        }
     }
 }

--- a/src/XamlCompiler/Tests/UnitTests/CodeGeneratorTests.cs
+++ b/src/XamlCompiler/Tests/UnitTests/CodeGeneratorTests.cs
@@ -108,21 +108,39 @@ namespace UnitTests
             }
         }
 
-        [TestMethod]
+[TestMethod]
         public void CodeGenerator_ObsoleteWithoutMessageSuppressesCS0612()
         {
-            string xaml = @"
+            string typeInfoXaml = @"
+<Page
+    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:dll='using:LibManagedDll'>
+    <Page.Resources>
+        <dll:ObsoleteClassHolder x:Key='obsolete' ObsoleteProperty='value' />
+    </Page.Resources>
+</Page>";
+            string codeBehindXaml = @"
 <Page
     xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
     xmlns:dll='using:LibManagedDll'
     x:Class='MyNamespace.MyPage'>
-    <dll:ObsoleteClass x:Name='obsoleteElement' ObsoleteProperty='value' />
+    <dll:ObsoleteClass x:Name='obsoleteElement' />
 </Page>";
 
             DirectUISchemaContext schema = _testHelper.LoadSchema(SchemaMode.LoadUserDll);
-            CodeGeneratorProjectContext context = new CodeGeneratorProjectContext(new Version(KnownVersions.Latest));
-            TypeInfoCollector collector = _testHelper.CollectTypes(xaml, schema);
+            CodeGeneratorProjectContext context = new CodeGeneratorProjectContext(
+                new Version(KnownVersions.Latest),
+                "ObsoleteWithoutMessage");
+            context.IsLibrary = true;
+            context.RootNamespace = "MyNamespace";
+            context.ProjectInfo.SetCodeGenFlags("FullXamlMetadataProvider");
+            CompilerDomRootToken domRoot = _testHelper.LoadXamlDom(typeInfoXaml, schema);
+            XamlDomValidator validator = _testHelper.ValidateXamlDom(domRoot, false);
+            Assert.AreEqual(0, validator.Errors.Count);
+            TypeInfoCollector collector = new TypeInfoCollector(schema);
+            collector.Collect(domRoot);
 
             List<FileNameAndContentPair> pairs = _testHelper.GenerateTypeInfo(
                 false,
@@ -139,7 +157,7 @@ namespace UnitTests
             context.IsPass1 = true;
             pairs = _testHelper.GenerateCodeBehind(
                 context,
-                new List<string> { xaml },
+                new List<string> { codeBehindXaml },
                 schema,
                 CodeGenLanguage.CSharp);
 
@@ -149,7 +167,7 @@ namespace UnitTests
             context.IsPass1 = false;
             pairs = _testHelper.GenerateCodeBehind(
                 context,
-                new List<string> { xaml },
+                new List<string> { codeBehindXaml },
                 schema,
                 CodeGenLanguage.CSharp);
 

--- a/src/XamlCompiler/Tests/UnitTests/LibManagedDll/CGXamlTypes.cs
+++ b/src/XamlCompiler/Tests/UnitTests/LibManagedDll/CGXamlTypes.cs
@@ -48,6 +48,16 @@ namespace LibManagedDll
     public class MyFieldClass
     {
         public String MyProperty { get; set; }
+    }
+
+    [Obsolete]
+    [Windows.Foundation.Metadata.CreateFromString(MethodName = "LibManagedDll.ObsoleteClass.FromString")]
+    public class ObsoleteClass : FrameworkElement
+    {
+        [Obsolete]
+        public string ObsoleteProperty { get; set; }
+
+        public static ObsoleteClass FromString(string value) => new ObsoleteClass();
 
         public String MyStringField;
     }

--- a/src/XamlCompiler/Tests/UnitTests/LibManagedDll/CGXamlTypes.cs
+++ b/src/XamlCompiler/Tests/UnitTests/LibManagedDll/CGXamlTypes.cs
@@ -62,6 +62,12 @@ namespace LibManagedDll
         public String MyStringField;
     }
 
+    public class ObsoleteClassHolder : FrameworkElement
+    {
+        [Obsolete]
+        public ObsoleteClass ObsoleteProperty { get; set; }
+    }
+
     public class MyEventClass
     {
         public event EventHandler MyEvent;


### PR DESCRIPTION
## Fixes

Fixes #10855

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Previously only obsolete members were suppressed in generated code, but if the entire class is obsolete, a different warning is generated.
This just adds [CS0612](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0612) to the list of suppressed obsolete warnings, so both obsolete classes and members won't generate obsolete warnings in generated code.

### Current Behavior
Only obsolete members are suppressed. If an entire class is obsolete, warnings aren't suppressed.

### New Behavior
Both [CS0612 ](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0612) and [CS0618 ](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0618) gets suppressed.

## Customer Impact

Enables ability to have errors-as-warnings enabled. Even if a class isn't actually being actively called by a user, having something like CreateFromString defined causes (unused) code to get generated. Here is one example where they had to suppress all obsolete warnings, risking missing other actual obsolete warnings that do need to be addressed: https://github.com/openclaw/openclaw-windows-node/pull/1179

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally

