### PR TITLE
Add XAML profiler memory attribution events

### DIFF
--- a/dxaml/xcp/components/allocation/inc/XcpAllocation.h
+++ b/dxaml/xcp/components/allocation/inc/XcpAllocation.h
@@ -34,6 +34,10 @@ namespace XcpAllocation {
     size_t GetAllocationCount();
     size_t GetAllocationSize();
     size_t GetDeallocationCount();
+    size_t GetOutstandingAllocationCount();
+    size_t GetOutstandingAllocationSize();
+    uint64_t GetHeapHandle();
+    bool IsUsingPrivateHeap();
 
     void UpdateAllocatedMemory(INT64 cSize);
 

--- a/dxaml/xcp/components/allocation/lib/XcpAllocation.cpp
+++ b/dxaml/xcp/components/allocation/lib/XcpAllocation.cpp
@@ -79,11 +79,8 @@ namespace
     void RecordOutstandingAllocation(_In_ const void *pAddress)
     {
         const size_t cSize = XcpAllocation::OSMemoryGetBlockSize(pAddress);
-        if (cSize != 0)
-        {
-            g_outstandingAllocCount.fetch_add(1, std::memory_order_relaxed);
-            g_outstandingAllocSize.fetch_add(cSize, std::memory_order_relaxed);
-        }
+        g_outstandingAllocCount.fetch_add(1, std::memory_order_relaxed);
+        g_outstandingAllocSize.fetch_add(cSize, std::memory_order_relaxed);
     }
 }
 #endif
@@ -372,7 +369,7 @@ void XcpAllocation::OSMemoryFree(_Frees_ptr_opt_ void *pAddress)
 #endif
 
 #if COUNT_OUTSTANDING_ALLOC
-    if (cSize != 0)
+    if (pAddress != nullptr)
     {
         g_outstandingAllocCount.fetch_sub(1, std::memory_order_relaxed);
         g_outstandingAllocSize.fetch_sub(cSize, std::memory_order_relaxed);

--- a/dxaml/xcp/components/allocation/lib/XcpAllocation.cpp
+++ b/dxaml/xcp/components/allocation/lib/XcpAllocation.cpp
@@ -62,7 +62,24 @@ _Check_return_ size_t XcpAllocation::OSMemoryGetBlockSize(_In_opt_ const void *p
 std::atomic<size_t> g_allocCount = 0;
 std::atomic<size_t> g_allocSize = 0;
 std::atomic<size_t> g_deallocCount = 0;
+std::atomic<size_t> g_outstandingAllocCount = 0;
+std::atomic<size_t> g_outstandingAllocSize = 0;
 #endif
+
+namespace
+{
+    void RecordOutstandingAllocation(_In_ const void *pAddress)
+    {
+#if COUNT_ALLOC
+        const size_t cSize = XcpAllocation::OSMemoryGetBlockSize(pAddress);
+        if (cSize != 0)
+        {
+            g_outstandingAllocCount.fetch_add(1, std::memory_order_relaxed);
+            g_outstandingAllocSize.fetch_add(cSize, std::memory_order_relaxed);
+        }
+#endif
+    }
+}
 
 size_t XcpAllocation::GetAllocationCount()
 {
@@ -89,6 +106,36 @@ size_t XcpAllocation::GetDeallocationCount()
 #else
     return 0;
 #endif
+}
+
+size_t XcpAllocation::GetOutstandingAllocationCount()
+{
+#if COUNT_ALLOC
+    return g_outstandingAllocCount.load(std::memory_order_relaxed);
+#else
+    return 0;
+#endif
+}
+
+size_t XcpAllocation::GetOutstandingAllocationSize()
+{
+#if COUNT_ALLOC
+    return g_outstandingAllocSize.load(std::memory_order_relaxed);
+#else
+    return 0;
+#endif
+}
+
+uint64_t XcpAllocation::GetHeapHandle()
+{
+    EnsureHeap();
+    return reinterpret_cast<uint64_t>(ghHeap);
+}
+
+bool XcpAllocation::IsUsingPrivateHeap()
+{
+    EnsureHeap();
+    return ghHeap != GetProcessHeap();
 }
 
 void XcpAllocation::EnableMemoryTracking()
@@ -130,6 +177,7 @@ _Check_return_ void *XcpAllocation::OSMemoryAllocateFailFast(_In_ size_t cSize)
     if (pAddress)
     {
         UpdateAllocatedMemory(cSize);
+        RecordOutstandingAllocation(pAddress);
     }
     else
     {
@@ -165,6 +213,7 @@ _Check_return_ void *XcpAllocation::OSMemoryAllocateZeroMemoryFailFast(_In_ size
     if (pAddress)
     {
         UpdateAllocatedMemory(cSize);
+        RecordOutstandingAllocation(pAddress);
     }
     else
     {
@@ -214,6 +263,7 @@ _Check_return_ void *XcpAllocation::OSMemoryAllocateNoFailFast(_In_ size_t cSize
     if (pAddress)
     {
         UpdateAllocatedMemory(cSize);
+        RecordOutstandingAllocation(pAddress);
     }
 
     return pAddress;
@@ -230,12 +280,14 @@ _Check_return_ void *XcpAllocation::OSMemoryResize(_Frees_ptr_opt_ void *pAddres
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
 #endif
 
-    // Skip the HeapSize call entirely when tracking is disabled which saves a
-    // kernel call per realloc.
     const bool trackMemory = g_memoryTrackingEnabled;
+    bool needBlockSize = trackMemory;
+#if COUNT_ALLOC
+    needBlockSize = true;
+#endif
 
     size_t cOldSize = 0;
-    if (trackMemory && pAddress)
+    if (needBlockSize && pAddress)
     {
         cOldSize = HeapSize(ghHeap, 0, pAddress);
         ASSERT(cOldSize != (SIZE_T)-1);
@@ -260,6 +312,21 @@ _Check_return_ void *XcpAllocation::OSMemoryResize(_Frees_ptr_opt_ void *pAddres
         UpdateAllocatedMemory(static_cast<INT64>(cSize) - static_cast<INT64>(cOldSize));
     }
 
+#if COUNT_ALLOC
+    if (newAddress)
+    {
+        const size_t cNewSize = XcpAllocation::OSMemoryGetBlockSize(newAddress);
+        if (cNewSize >= cOldSize)
+        {
+            g_outstandingAllocSize.fetch_add(cNewSize - cOldSize, std::memory_order_relaxed);
+        }
+        else
+        {
+            g_outstandingAllocSize.fetch_sub(cOldSize - cNewSize, std::memory_order_relaxed);
+        }
+    }
+#endif
+
     return newAddress;
 }
 
@@ -267,19 +334,33 @@ void XcpAllocation::OSMemoryFree(_Frees_ptr_opt_ void *pAddress)
 {
     EnsureHeap();
 
-    // Skip the HeapSize call entirely when tracking is disabled to give
-    // unmanaged apps near-zero tracking overhead.
-    if (pAddress && g_memoryTrackingEnabled)
+    const bool trackMemory = g_memoryTrackingEnabled;
+    bool needBlockSize = trackMemory;
+#if COUNT_ALLOC
+    needBlockSize = true;
+#endif
+
+    size_t cSize = 0;
+    if (needBlockSize && pAddress)
     {
-        size_t cSize = HeapSize(ghHeap, 0, pAddress);
+        cSize = HeapSize(ghHeap, 0, pAddress);
         ASSERT(cSize != (SIZE_T)-1);
-        UpdateAllocatedMemory(-(INT64)cSize);
+
+        if (g_memoryTrackingEnabled)
+        {
+            UpdateAllocatedMemory(-(INT64)cSize);
+        }
     }
 
     HeapFree(ghHeap, 0, pAddress);
 
 #if COUNT_ALLOC
     g_deallocCount.fetch_add(1, std::memory_order_relaxed);
+    if (cSize != 0)
+    {
+        g_outstandingAllocCount.fetch_sub(1, std::memory_order_relaxed);
+        g_outstandingAllocSize.fetch_sub(cSize, std::memory_order_relaxed);
+    }
 #endif
 
 #if TRACE_ALLOC

--- a/dxaml/xcp/components/allocation/lib/XcpAllocation.cpp
+++ b/dxaml/xcp/components/allocation/lib/XcpAllocation.cpp
@@ -58,28 +58,35 @@ _Check_return_ size_t XcpAllocation::OSMemoryGetBlockSize(_In_opt_ const void *p
 #define COUNT_ALLOC 1
 #endif
 
+#if COUNT_ALLOC && defined(XAMLPROFILER_ENABLED)
+#define COUNT_OUTSTANDING_ALLOC 1
+#endif
+
 #if COUNT_ALLOC
 std::atomic<size_t> g_allocCount = 0;
 std::atomic<size_t> g_allocSize = 0;
 std::atomic<size_t> g_deallocCount = 0;
+#endif
+
+#if COUNT_OUTSTANDING_ALLOC
 std::atomic<size_t> g_outstandingAllocCount = 0;
 std::atomic<size_t> g_outstandingAllocSize = 0;
 #endif
 
+#if COUNT_OUTSTANDING_ALLOC
 namespace
 {
     void RecordOutstandingAllocation(_In_ const void *pAddress)
     {
-#if COUNT_ALLOC
         const size_t cSize = XcpAllocation::OSMemoryGetBlockSize(pAddress);
         if (cSize != 0)
         {
             g_outstandingAllocCount.fetch_add(1, std::memory_order_relaxed);
             g_outstandingAllocSize.fetch_add(cSize, std::memory_order_relaxed);
         }
-#endif
     }
 }
+#endif
 
 size_t XcpAllocation::GetAllocationCount()
 {
@@ -110,7 +117,7 @@ size_t XcpAllocation::GetDeallocationCount()
 
 size_t XcpAllocation::GetOutstandingAllocationCount()
 {
-#if COUNT_ALLOC
+#if COUNT_OUTSTANDING_ALLOC
     return g_outstandingAllocCount.load(std::memory_order_relaxed);
 #else
     return 0;
@@ -119,7 +126,7 @@ size_t XcpAllocation::GetOutstandingAllocationCount()
 
 size_t XcpAllocation::GetOutstandingAllocationSize()
 {
-#if COUNT_ALLOC
+#if COUNT_OUTSTANDING_ALLOC
     return g_outstandingAllocSize.load(std::memory_order_relaxed);
 #else
     return 0;
@@ -177,7 +184,9 @@ _Check_return_ void *XcpAllocation::OSMemoryAllocateFailFast(_In_ size_t cSize)
     if (pAddress)
     {
         UpdateAllocatedMemory(cSize);
+#if COUNT_OUTSTANDING_ALLOC
         RecordOutstandingAllocation(pAddress);
+#endif
     }
     else
     {
@@ -213,7 +222,9 @@ _Check_return_ void *XcpAllocation::OSMemoryAllocateZeroMemoryFailFast(_In_ size
     if (pAddress)
     {
         UpdateAllocatedMemory(cSize);
+#if COUNT_OUTSTANDING_ALLOC
         RecordOutstandingAllocation(pAddress);
+#endif
     }
     else
     {
@@ -263,7 +274,9 @@ _Check_return_ void *XcpAllocation::OSMemoryAllocateNoFailFast(_In_ size_t cSize
     if (pAddress)
     {
         UpdateAllocatedMemory(cSize);
+#if COUNT_OUTSTANDING_ALLOC
         RecordOutstandingAllocation(pAddress);
+#endif
     }
 
     return pAddress;
@@ -282,7 +295,7 @@ _Check_return_ void *XcpAllocation::OSMemoryResize(_Frees_ptr_opt_ void *pAddres
 
     const bool trackMemory = g_memoryTrackingEnabled;
     bool needBlockSize = trackMemory;
-#if COUNT_ALLOC
+#if COUNT_OUTSTANDING_ALLOC
     needBlockSize = true;
 #endif
 
@@ -312,7 +325,7 @@ _Check_return_ void *XcpAllocation::OSMemoryResize(_Frees_ptr_opt_ void *pAddres
         UpdateAllocatedMemory(static_cast<INT64>(cSize) - static_cast<INT64>(cOldSize));
     }
 
-#if COUNT_ALLOC
+#if COUNT_OUTSTANDING_ALLOC
     if (newAddress)
     {
         const size_t cNewSize = XcpAllocation::OSMemoryGetBlockSize(newAddress);
@@ -336,7 +349,7 @@ void XcpAllocation::OSMemoryFree(_Frees_ptr_opt_ void *pAddress)
 
     const bool trackMemory = g_memoryTrackingEnabled;
     bool needBlockSize = trackMemory;
-#if COUNT_ALLOC
+#if COUNT_OUTSTANDING_ALLOC
     needBlockSize = true;
 #endif
 
@@ -356,6 +369,9 @@ void XcpAllocation::OSMemoryFree(_Frees_ptr_opt_ void *pAddress)
 
 #if COUNT_ALLOC
     g_deallocCount.fetch_add(1, std::memory_order_relaxed);
+#endif
+
+#if COUNT_OUTSTANDING_ALLOC
     if (cSize != 0)
     {
         g_outstandingAllocCount.fetch_sub(1, std::memory_order_relaxed);

--- a/dxaml/xcp/components/base/inc/XamlProfilerTracing.h
+++ b/dxaml/xcp/components/base/inc/XamlProfilerTracing.h
@@ -115,6 +115,18 @@ public:
         bool, IsLive,
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
 
+    // Snapshot of XAML allocator-owned CPU heap blocks. This excludes GPU texture backing and
+    // process allocations owned by other components/runtimes.
+    DEFINE_TRACELOGGING_EVENT_PARAM7(XamlHeapSnapshot,
+        uint64_t, HeapHandle,
+        bool,     IsPrivateHeap,
+        uint64_t, OutstandingBytes,
+        uint64_t, OutstandingAllocationCount,
+        uint64_t, CumulativeAllocatedBytes,
+        uint64_t, CumulativeAllocationCount,
+        uint64_t, CumulativeDeallocationCount,
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+
     // =====================================================================
     // Peer Association Events
     // =====================================================================
@@ -266,6 +278,60 @@ public:
     // Fired when a composition target/island root is cleared (Root set to null).
     DEFINE_TRACELOGGING_EVENT_PARAM1(WucVisualRootCleared,
         uint64_t, TargetId,
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+
+    // =====================================================================
+    // GPU Memory Events
+    // =====================================================================
+
+    // Reports the lifecycle and logical dimensions of a DComp surface. EstimatedSizeBytes
+    // is width-with-gutters * height-with-gutters * pixel stride. It is useful for attribution,
+    // but is not exact committed VRAM because DComp may atlas, share, or sparsely tile surfaces.
+    DEFINE_TRACELOGGING_EVENT_PARAM7(DCompSurfaceMemoryChanged,
+        uint64_t, SurfaceId,
+        bool,     IsAllocation,
+        uint64_t, EstimatedSizeBytes,
+        uint32_t, Width,
+        uint32_t, Height,
+        uint32_t, PixelStride,
+        bool,     IsVirtual,
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+
+    // Reports the transient D3D11 texture exposed by DComp during BeginDraw. For atlased
+    // surfaces, Width/Height describe the shared backing texture and OffsetX/OffsetY locate
+    // this surface's update region within it. The resource must not be retained after EndDraw.
+    DEFINE_TRACELOGGING_EVENT_PARAM10(DCompSurfaceTextureObserved,
+        uint64_t, SurfaceId,
+        uint64_t, ResourceId,
+        uint32_t, Width,
+        uint32_t, Height,
+        uint32_t, MipLevels,
+        uint32_t, ArraySize,
+        uint32_t, Format,
+        uint32_t, SampleCount,
+        int32_t,  OffsetX,
+        int32_t,  OffsetY,
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+
+    // Associates a rendered IVisual with the DComp surface used by one of its brush roles.
+    // SurfaceId == 0 clears the role. Role 0 is the brush texture; role 1 is the mask texture.
+    // VisualId joins the existing WUC events, whose OwnerCompNodeId joins CompPeerLinked.
+    DEFINE_TRACELOGGING_EVENT_PARAM3(VisualSurfaceChanged,
+        uint64_t, VisualId,
+        uint64_t, SurfaceId,
+        uint32_t, Role,
+        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
+
+    // Driver-reported memory usage for this process on the D3D device's adapter. This is the
+    // closest available view of committed GPU memory, but allocations owned by DWM/DComp may
+    // be charged outside the app process.
+    DEFINE_TRACELOGGING_EVENT_PARAM6(GpuMemorySnapshot,
+        uint64_t, LocalCurrentUsage,
+        uint64_t, LocalBudget,
+        bool,     LocalAvailable,
+        uint64_t, NonLocalCurrentUsage,
+        uint64_t, NonLocalBudget,
+        bool,     NonLocalAvailable,
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
 };
 

--- a/dxaml/xcp/core/core/elements/uielement.cpp
+++ b/dxaml/xcp/core/core/elements/uielement.cpp
@@ -1330,6 +1330,15 @@ _Check_return_ HRESULT CUIElement::EnterImpl(_In_ CDependencyObject *pNamescopeO
             sourceUri.GetBuffer(),
             sourceLine,
             sourceColumn);
+
+        XamlProfilerTracing::XamlHeapSnapshot(
+            XcpAllocation::GetHeapHandle(),
+            XcpAllocation::IsUsingPrivateHeap(),
+            XcpAllocation::GetOutstandingAllocationSize(),
+            XcpAllocation::GetOutstandingAllocationCount(),
+            XcpAllocation::GetAllocationSize(),
+            XcpAllocation::GetAllocationCount(),
+            XcpAllocation::GetDeallocationCount());
     }
 #endif // XAMLPROFILER_ENABLED
 
@@ -1942,6 +1951,15 @@ _Check_return_ HRESULT CUIElement::LeaveImpl(_In_ CDependencyObject *pNamescopeO
             reinterpret_cast<uint64_t>(this),
             reinterpret_cast<uint64_t>(GetUIElementParentInternal()),
             static_cast<bool>(params.fIsLive));
+
+        XamlProfilerTracing::XamlHeapSnapshot(
+            XcpAllocation::GetHeapHandle(),
+            XcpAllocation::IsUsingPrivateHeap(),
+            XcpAllocation::GetOutstandingAllocationSize(),
+            XcpAllocation::GetOutstandingAllocationCount(),
+            XcpAllocation::GetAllocationSize(),
+            XcpAllocation::GetAllocationCount(),
+            XcpAllocation::GetDeallocationCount());
     }
 #endif // XAMLPROFILER_ENABLED
 

--- a/dxaml/xcp/core/hw/VisualContentRenderer.cpp
+++ b/dxaml/xcp/core/hw/VisualContentRenderer.cpp
@@ -80,6 +80,15 @@ VisualContentRenderer::RenderSolidColorRectangle(
     IFCFAILFAST(spContentVisual->put_Brush(wucBrush.Get()));
     IFC_RETURN(LinkVisual(pBrush, nullptr, spVisual.Get()));
 
+#ifdef XAMLPROFILER_ENABLED
+    if (XamlProfilerTracing::IsEnabled())
+    {
+        const auto visualId = reinterpret_cast<uint64_t>(spVisual.Get());
+        XamlProfilerTracing::VisualSurfaceChanged(visualId, 0, 0);
+        XamlProfilerTracing::VisualSurfaceChanged(visualId, 0, 1);
+    }
+#endif
+
     return S_OK;
 }
 
@@ -413,6 +422,8 @@ _Check_return_ HRESULT VisualContentRenderer::RenderPrimitive(
         IFC_RETURN(spContentVisual->put_Brush(newBrush.Get()));
     }
 
+    IFC_RETURN(LinkVisual(brush, nullptr, spVisual.Get()));
+
 #ifdef XAMLPROFILER_ENABLED
     if (XamlProfilerTracing::IsEnabled())
     {
@@ -430,8 +441,6 @@ _Check_return_ HRESULT VisualContentRenderer::RenderPrimitive(
         XamlProfilerTracing::VisualSurfaceChanged(visualId, getSurfaceId(maskTexture), 1);
     }
 #endif
-
-    IFC_RETURN(LinkVisual(brush, nullptr, spVisual.Get()));
 
     return S_OK;
 }

--- a/dxaml/xcp/core/hw/VisualContentRenderer.cpp
+++ b/dxaml/xcp/core/hw/VisualContentRenderer.cpp
@@ -7,6 +7,9 @@
 #include <WUCBrushManager.h>
 #include "XamlCompositionBrush.h"
 #include <XamlLight.h>
+#ifdef XAMLPROFILER_ENABLED
+#include "XamlProfilerTracing.h"
+#endif
 
 using namespace Microsoft::WRL;
 using namespace Microsoft::WRL::Wrappers;
@@ -409,6 +412,24 @@ _Check_return_ HRESULT VisualContentRenderer::RenderPrimitive(
     {
         IFC_RETURN(spContentVisual->put_Brush(newBrush.Get()));
     }
+
+#ifdef XAMLPROFILER_ENABLED
+    if (XamlProfilerTracing::IsEnabled())
+    {
+        const auto getSurfaceId = [](HWTexture* texture) -> uint64_t
+        {
+            if (texture == nullptr || texture->GetCompositionSurface() == nullptr)
+            {
+                return 0;
+            }
+            return reinterpret_cast<uint64_t>(texture->GetCompositionSurface());
+        };
+
+        const auto visualId = reinterpret_cast<uint64_t>(spVisual.Get());
+        XamlProfilerTracing::VisualSurfaceChanged(visualId, getSurfaceId(brushTexture), 0);
+        XamlProfilerTracing::VisualSurfaceChanged(visualId, getSurfaceId(maskTexture), 1);
+    }
+#endif
 
     IFC_RETURN(LinkVisual(brush, nullptr, spVisual.Get()));
 

--- a/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
+++ b/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
@@ -1120,6 +1120,8 @@ DCompSurface::Resize(
 
     ASSERT(m_compositionSurfaceHelper.HasSurface());
 
+    IFC(m_compositionSurfaceHelper.Resize(width, height));
+
 #ifdef XAMLPROFILER_ENABLED
     TraceProfilerMemoryChange(false);
 #endif
@@ -1128,8 +1130,6 @@ DCompSurface::Resize(
     {
         UpdateMemoryFootprint(FALSE);
     }
-
-    IFC(m_compositionSurfaceHelper.Resize(width, height));
 
     // If the surface size changed, then we clear out the pending update list. If the surface became smaller,
     // the existing surface updates can draw to a part of the surface that exceeds the new smaller bounds. If

--- a/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
+++ b/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
@@ -250,6 +250,10 @@ DCompSurface::InitializeSurface(
 
         SetInterface(m_pCompositionSurface, m_pVirtualCompositionSurface);
 
+#ifdef XAMLPROFILER_ENABLED
+        TraceProfilerMemoryChange(true);
+#endif
+
         // Wrap with an ICompositionSurface
         auto hr = pDCompTreeHost->GetCompositionHelper()->CreateCompositionSurfaceForDCompositionSurface(
             m_pVirtualCompositionSurface, &m_spWinRTSurface);
@@ -276,14 +280,14 @@ DCompSurface::InitializeSurface(
 
         UpdateMemoryFootprint(TRUE);
 
+#ifdef XAMLPROFILER_ENABLED
+        TraceProfilerMemoryChange(true);
+#endif
+
         // Wrap with an ICompositionSurface
         IFC_RETURN(pDCompTreeHost->GetCompositionHelper()->CreateCompositionSurfaceForDCompositionSurface(
             m_pCompositionSurface, &m_spWinRTSurface));
     }
-
-#ifdef XAMLPROFILER_ENABLED
-    TraceProfilerMemoryChange(true);
-#endif
 
     IFCFAILFAST(m_compositionSurfaceHelper.Initialize(m_pCompositionSurface));
 
@@ -368,13 +372,13 @@ void DCompSurface::ReleaseLegacyDCompResources(bool resetWucSurface)
     }
 #endif
 
+    m_d3dDevice.reset();
+    m_surfaceUpdates.clear();
+
     if (m_pVirtualCompositionSurface == nullptr)
     {
         UpdateMemoryFootprint(FALSE);
     }
-
-    m_d3dDevice.reset();
-    m_surfaceUpdates.clear();
 
     if (m_pSystemMemoryBitsForUIThread != NULL)
     {
@@ -1120,16 +1124,16 @@ DCompSurface::Resize(
 
     ASSERT(m_compositionSurfaceHelper.HasSurface());
 
+    if (!IsVirtual())
+    {
+        UpdateMemoryFootprint(FALSE);
+    }
+
     IFC(m_compositionSurfaceHelper.Resize(width, height));
 
 #ifdef XAMLPROFILER_ENABLED
     TraceProfilerMemoryChange(false);
 #endif
-
-    if (!IsVirtual())
-    {
-        UpdateMemoryFootprint(FALSE);
-    }
 
     // If the surface size changed, then we clear out the pending update list. If the surface became smaller,
     // the existing surface updates can draw to a part of the surface that exceeds the new smaller bounds. If

--- a/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
+++ b/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
@@ -1439,7 +1439,7 @@ void DCompSurface::TraceProfilerMemoryChange(bool isAllocation)
         GetWidthWithGutters(),
         GetHeightWithGutters(),
         GetPixelStride(),
-        IsVirtual());
+        m_pVirtualCompositionSurface != nullptr);
     XamlProfilerTracing::XamlHeapSnapshot(
         XcpAllocation::GetHeapHandle(),
         XcpAllocation::IsUsingPrivateHeap(),

--- a/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
+++ b/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
@@ -1423,10 +1423,15 @@ void DCompSurface::TraceProfilerMemoryChange(bool isAllocation)
         return;
     }
 
+    const uint64_t estimatedSizeBytes =
+        static_cast<uint64_t>(GetWidthWithGutters()) *
+        static_cast<uint64_t>(GetHeightWithGutters()) *
+        static_cast<uint64_t>(GetPixelStride());
+
     XamlProfilerTracing::DCompSurfaceMemoryChanged(
         reinterpret_cast<uint64_t>(this),
         isAllocation,
-        static_cast<uint64_t>(GetTextureSizeInBytes()),
+        estimatedSizeBytes,
         GetWidthWithGutters(),
         GetHeightWithGutters(),
         GetPixelStride(),

--- a/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
+++ b/dxaml/xcp/plat/win/desktop/DCompSurface.cpp
@@ -8,6 +8,9 @@
 #include <RuntimeEnabledFeatures.h>
 #include <DependencyLocator.h>
 #include <PixelFormat.h>
+#ifdef XAMLPROFILER_ENABLED
+#include "XamlProfilerTracing.h"
+#endif
 
 #include "XcpAllocation.h"
 
@@ -189,6 +192,10 @@ DCompSurface::InitializeSurface(
         UpdateMemoryFootprint(TRUE);
     }
 
+#ifdef XAMLPROFILER_ENABLED
+    TraceProfilerMemoryChange(true);
+#endif
+
     if (m_spWinRTSurface == nullptr)
     {
         // Wrap with an ICompositionSurface
@@ -274,6 +281,10 @@ DCompSurface::InitializeSurface(
             m_pCompositionSurface, &m_spWinRTSurface));
     }
 
+#ifdef XAMLPROFILER_ENABLED
+    TraceProfilerMemoryChange(true);
+#endif
+
     IFCFAILFAST(m_compositionSurfaceHelper.Initialize(m_pCompositionSurface));
 
     return S_OK;
@@ -350,13 +361,20 @@ void DCompSurface::ReleaseLegacyDCompResources(bool resetWucSurface)
         }
     }
 
-    m_d3dDevice.reset();
-    m_surfaceUpdates.clear();
+#ifdef XAMLPROFILER_ENABLED
+    if (m_pCompositionSurface != nullptr || m_pVirtualCompositionSurface != nullptr)
+    {
+        TraceProfilerMemoryChange(false);
+    }
+#endif
 
     if (m_pVirtualCompositionSurface == nullptr)
     {
         UpdateMemoryFootprint(FALSE);
     }
+
+    m_d3dDevice.reset();
+    m_surfaceUpdates.clear();
 
     if (m_pSystemMemoryBitsForUIThread != NULL)
     {
@@ -763,6 +781,10 @@ DCompSurface::CopySubresource(
         sourceBoxWithGutters.bottom = pSource->GetHeight();
     }
 
+#ifdef XAMLPROFILER_ENABLED
+    TraceProfilerTextureObserved(pDestD3DResource, dstOffsetWithGutters);
+#endif
+
     // Nobody should be staging from heap memory
     ASSERT(pSource->IsDriverVisible());
 
@@ -917,6 +939,10 @@ DCompSurface::BeginDraw(
     pOffsetIntoSurface->x = offset.x;
     pOffsetIntoSurface->y = offset.y;
 
+#ifdef XAMLPROFILER_ENABLED
+    TraceProfilerTextureObserved(*ppSurface, offset);
+#endif
+
     if (s_traceDCompSurfaceUpdates)
     {
         m_updateRects.push_back(rect);
@@ -968,6 +994,10 @@ DCompSurface::BeginDrawWithGutters(
     // before drawing to the 'real' offset into the texture, not into the gutter region.
     pOffsetIntoSurface->x = offset.x;
     pOffsetIntoSurface->y = offset.y;
+
+#ifdef XAMLPROFILER_ENABLED
+    TraceProfilerTextureObserved(*ppSurface, offset);
+#endif
 
     if (s_traceDCompSurfaceUpdates)
     {
@@ -1090,6 +1120,10 @@ DCompSurface::Resize(
 
     ASSERT(m_compositionSurfaceHelper.HasSurface());
 
+#ifdef XAMLPROFILER_ENABLED
+    TraceProfilerMemoryChange(false);
+#endif
+
     if (!IsVirtual())
     {
         UpdateMemoryFootprint(FALSE);
@@ -1116,6 +1150,10 @@ DCompSurface::Resize(
     {
         UpdateMemoryFootprint(TRUE);
     }
+
+#ifdef XAMLPROFILER_ENABLED
+    TraceProfilerMemoryChange(true);
+#endif
 
 Cleanup:
     RRETURN(hr);
@@ -1328,6 +1366,121 @@ DCompSurface::GetTextureSizeInBytes() const
 {
     return GetWidthWithGutters() * GetHeightWithGutters() * GetPixelStride();
 }
+
+#ifdef XAMLPROFILER_ENABLED
+void DCompSurface::TraceProfilerTextureObserved(
+    _In_ IUnknown* updateObject,
+    const POINT& offset) noexcept
+{
+    if (!XamlProfilerTracing::IsEnabled())
+    {
+        return;
+    }
+
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+    if (FAILED(updateObject->QueryInterface(IID_PPV_ARGS(&texture))))
+    {
+        Microsoft::WRL::ComPtr<ID2D1DeviceContext> deviceContext;
+        Microsoft::WRL::ComPtr<ID2D1Image> target;
+        Microsoft::WRL::ComPtr<ID2D1Bitmap1> targetBitmap;
+        Microsoft::WRL::ComPtr<IDXGISurface> targetSurface;
+
+        if (FAILED(updateObject->QueryInterface(IID_PPV_ARGS(&deviceContext))))
+        {
+            return;
+        }
+
+        deviceContext->GetTarget(&target);
+        if (target == nullptr ||
+            FAILED(target.As(&targetBitmap)) ||
+            FAILED(targetBitmap->GetSurface(&targetSurface)) ||
+            FAILED(targetSurface.As(&texture)))
+        {
+            return;
+        }
+    }
+
+    D3D11_TEXTURE2D_DESC desc = {};
+    texture->GetDesc(&desc);
+
+    XamlProfilerTracing::DCompSurfaceTextureObserved(
+        reinterpret_cast<uint64_t>(this),
+        reinterpret_cast<uint64_t>(texture.Get()),
+        desc.Width,
+        desc.Height,
+        desc.MipLevels,
+        desc.ArraySize,
+        static_cast<uint32_t>(desc.Format),
+        desc.SampleDesc.Count,
+        offset.x,
+        offset.y);
+}
+
+void DCompSurface::TraceProfilerMemoryChange(bool isAllocation)
+{
+    if (!XamlProfilerTracing::IsEnabled())
+    {
+        return;
+    }
+
+    XamlProfilerTracing::DCompSurfaceMemoryChanged(
+        reinterpret_cast<uint64_t>(this),
+        isAllocation,
+        static_cast<uint64_t>(GetTextureSizeInBytes()),
+        GetWidthWithGutters(),
+        GetHeightWithGutters(),
+        GetPixelStride(),
+        IsVirtual());
+    XamlProfilerTracing::XamlHeapSnapshot(
+        XcpAllocation::GetHeapHandle(),
+        XcpAllocation::IsUsingPrivateHeap(),
+        XcpAllocation::GetOutstandingAllocationSize(),
+        XcpAllocation::GetOutstandingAllocationCount(),
+        XcpAllocation::GetAllocationSize(),
+        XcpAllocation::GetAllocationCount(),
+        XcpAllocation::GetDeallocationCount());
+
+    if (m_d3dDevice == nullptr)
+    {
+        return;
+    }
+
+    DXGI_QUERY_VIDEO_MEMORY_INFO localInfo{};
+    DXGI_QUERY_VIDEO_MEMORY_INFO nonLocalInfo{};
+    bool localAvailable = false;
+    bool nonLocalAvailable = false;
+
+    CD3D11SharedDeviceGuard guard;
+    if (SUCCEEDED(m_d3dDevice->TakeLockAndCheckDeviceLost(&guard)))
+    {
+        Microsoft::WRL::ComPtr<IDXGIDevice> dxgiDevice;
+        Microsoft::WRL::ComPtr<IDXGIAdapter> adapter;
+        Microsoft::WRL::ComPtr<IDXGIAdapter3> adapter3;
+
+        if (SUCCEEDED(m_d3dDevice->GetDevice(&guard)->QueryInterface(IID_PPV_ARGS(&dxgiDevice))) &&
+            SUCCEEDED(dxgiDevice->GetAdapter(&adapter)) &&
+            SUCCEEDED(adapter.As(&adapter3)))
+        {
+            localAvailable = SUCCEEDED(adapter3->QueryVideoMemoryInfo(
+                0,
+                DXGI_MEMORY_SEGMENT_GROUP_LOCAL,
+                &localInfo));
+            nonLocalAvailable = SUCCEEDED(adapter3->QueryVideoMemoryInfo(
+                0,
+                DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL,
+                &nonLocalInfo));
+        }
+    }
+
+    XamlProfilerTracing::GpuMemorySnapshot(
+        localInfo.CurrentUsage,
+        localInfo.Budget,
+        localAvailable,
+        nonLocalInfo.CurrentUsage,
+        nonLocalInfo.Budget,
+        nonLocalAvailable);
+}
+#endif
 
 //-------------------------------------------------------------------------
 //

--- a/dxaml/xcp/plat/win/desktop/DCompSurface.h
+++ b/dxaml/xcp/plat/win/desktop/DCompSurface.h
@@ -236,6 +236,13 @@ private:
         bool increase
         );
 
+#ifdef XAMLPROFILER_ENABLED
+    void TraceProfilerMemoryChange(bool isAllocation);
+    void TraceProfilerTextureObserved(
+        _In_ IUnknown* updateObject,
+        const POINT& offset) noexcept;
+#endif
+
     _Check_return_ HRESULT CopySubresource(
         _In_ const XRECT& destRect,
         _In_ SystemMemoryBits *pSource
@@ -367,4 +374,3 @@ private:
     IDXGISurface *m_pDxgiSurface;
     XUINT32 m_stride;
 };
-


### PR DESCRIPTION
## Summary

- add outstanding XAML allocator accounting and heap snapshots
- trace DComp surface lifecycle, backing textures, visual associations, and process GPU memory
- preserve the current public allocator behavior and the 10-field `ElementEnteredTree` payload

## Validation

- `amd64chk` Microsoft.UI.Xaml project build: 0 warnings, 0 errors
- `amd64fre` Microsoft.UI.Xaml project build with local PGO disabled: 0 warnings, 0 errors
- WinUI code review: no Critical, Important, or Minor findings