### PR TITLE
Tabular: version the merged public types against the in-development contract

### DIFF
--- a/controls/dev/dll-tabular/Microsoft.UI.Xaml.Controls.Tabular.idl
+++ b/controls/dev/dll-tabular/Microsoft.UI.Xaml.Controls.Tabular.idl
@@ -128,6 +128,9 @@ namespace MU_X_XTI_NAMESPACE
 {
     [webhosthidden]
     [default_interface]
+    // Unlike MUXC's XamlControlsXamlMetaDataProvider, this type is new in the merged public winmd,
+    // so it needs an explicit contract version or the WinMD compat static test reports VERSION_NO.
+    [MUX_PUBLIC_V12]
     runtimeclass XamlControlsTabularXamlMetaDataProvider
     // IXMP needs to be implemented by a public type in our assembly, but it doesn't need to be
     // named anything special. Let's leverage the fact that we have this existing runtimeclass
@@ -144,7 +147,8 @@ namespace MU_XC_NAMESPACE
 {
     [webhosthidden]
     [default_interface]
-    [MUX_PUBLIC]
+    // Not MUX_PUBLIC: this type has never shipped, so it belongs to the in-development contract.
+    [MUX_PUBLIC_V12]
     runtimeclass TabularControlsResources : Microsoft.UI.Xaml.ResourceDictionary
     {
         TabularControlsResources();


### PR DESCRIPTION
## Problem

The WinMD compatibility static test fails on `main` with five `VERSION_NO` errors, e.g. [WinUI-GitHub-PR_20260831.40](https://dev.azure.com/microsoft/WinUI/_build/results?buildId=156359586) (step *Run WinMD Compat Test*):

```
TYPE_INTERFACE;Microsoft.UI.Xaml.Controls.Tabular.ITabularControlsResources;CHANGETYPE_NEW;TARGETTYPE_UNSPECIFIED;;VERSION_NO;;
TYPE_RUNTIMECLASS;Microsoft.UI.Xaml.Controls.Tabular.TabularControlsResources;CHANGETYPE_NEW;TARGETTYPE_UNSPECIFIED;;VERSION_NO;;
TYPE_INTERFACE;Microsoft.UI.Xaml.XamlTypeInfo.IXamlControlsTabularXamlMetaDataProvider;CHANGETYPE_NEW;TARGETTYPE_UNSPECIFIED;;VERSION_NO;;
TYPE_INTERFACE;Microsoft.UI.Xaml.XamlTypeInfo.IXamlControlsTabularXamlMetaDataProviderStatics;CHANGETYPE_NEW;TARGETTYPE_UNSPECIFIED;;VERSION_NO;;
TYPE_RUNTIMECLASS;Microsoft.UI.Xaml.XamlTypeInfo.XamlControlsTabularXamlMetaDataProvider;CHANGETYPE_NEW;TARGETTYPE_UNSPECIFIED;;VERSION_NO;;
```

`MergedWinMD` merges the Tabular winmd into the public `Microsoft.UI.Xaml.winmd`, so the Tabular types introduced by #11641 are now compared against the last public `Microsoft.WindowsAppSDK.WinUI` package. Every `TableView*` type is `[MUX_PREVIEW]` and passes. The only two non-preview declarations in `controls\dev\dll-tabular\Microsoft.UI.Xaml.Controls.Tabular.idl` are exactly the two that fail:

| Type | State before | Why it fails |
| --- | --- | --- |
| `TabularControlsResources` | `[MUX_PUBLIC]` = `contract(XamlContract, 1)` | Claims it shipped in WinAppSDK 1.0, but it is new, so it is a new type in an already-shipped contract. |
| `XamlControlsTabularXamlMetaDataProvider` | no contract attribute | Copied from MUXC's `XamlControlsXamlMetaDataProvider`, which only passes because it is grandfathered into a shipped contract. |

The other three rows are the interfaces MIDL generates for those two runtimeclasses.

## Fix

`docs/publishing/build-pipelines.md` says new types must be attached to a new contract version. `dxaml\xcp\tools\XCPTypesAutoGen\XamlOM\Model\Contracts.cs` labels contract `12` as `Experimental`, the in-development bucket, so both types move to `MUX_PUBLIC_V12`. MIDL propagates the contract onto the generated interfaces, which clears all five errors from one two-line change.

### Why `MUX_PUBLIC_V12` and not `MUX_PREVIEW`

`MUX_PREVIEW` is `contract(XamlContract, 12), feature(Feature_Experimental)`. `Feature_Experimental` becomes `AlwaysDisabled` once `MUXFinalRelease` is true (`eng\muxfinalrelease.props`), which would strip both types from the final-release winmd — but `TabularControlsResources.cpp`, `XamlMetadataProvider.cpp` and `MUXControlsFactory.cpp` reference them unconditionally, so the final-release Tabular build would break. A version-only attribute leaves both prerelease and release metadata contents exactly as they are today and only supplies the missing version.

## Notes

- No behavioural change: no type is added or removed from any winmd, only version metadata is attached.
- `build\PipelineScripts\WinMDCompatExceptions_*.txt` was deliberately left empty; the contract bump is the documented remedy rather than an exception entry.
- Verify with `build\PipelineScripts\VerifyWinMDCompat.ps1` after rebuilding the IDL.
