### PR TITLE
Tabular: mark the two remaining non-preview types [MUX_PREVIEW]

### DIFF
--- a/controls/dev/dll-tabular/Microsoft.UI.Xaml.Controls.Tabular.idl
+++ b/controls/dev/dll-tabular/Microsoft.UI.Xaml.Controls.Tabular.idl
@@ -128,6 +128,7 @@ namespace MU_X_XTI_NAMESPACE
 {
     [webhosthidden]
     [default_interface]
+    [MUX_PREVIEW]
     runtimeclass XamlControlsTabularXamlMetaDataProvider
     // IXMP needs to be implemented by a public type in our assembly, but it doesn't need to be
     // named anything special. Let's leverage the fact that we have this existing runtimeclass
@@ -144,7 +145,7 @@ namespace MU_XC_NAMESPACE
 {
     [webhosthidden]
     [default_interface]
-    [MUX_PUBLIC]
+    [MUX_PREVIEW]
     runtimeclass TabularControlsResources : Microsoft.UI.Xaml.ResourceDictionary
     {
         TabularControlsResources();

--- a/eng/productmetadata.props
+++ b/eng/productmetadata.props
@@ -53,10 +53,10 @@
     </MuxControlsWinMD>
     <!-- Tabular merges into the public winmd on the same terms as Charts above, from the
          metadata-only idl project rather than the DLL project, mirroring MUXC's entry.
-         Excluded from MUXFinalRelease: every Tabular type is [MUX_PREVIEW]/[MUX_INTERNAL], so the
-         public winmd keeps 6 of 93 types there. Registrations derive from the unmerged winmd and
-         would still be emitted, naming a DLL packaging does not build - the APPX0703 mismatch - so
-         metadata and registrations are dropped together. Revisit when TableView leaves [MUX_PREVIEW]. -->
+         Excluded from MUXFinalRelease: every Tabular type is [MUX_PREVIEW]/[MUX_INTERNAL], so
+         nothing survives there, and the DLL is not packaged in that configuration either -
+         dropping metadata and registrations together also avoids an APPX0703 mismatch.
+         Revisit when TableView leaves [MUX_PREVIEW]. -->
     <MuxControlsWinMD Include="$(XamlBuildOutputRoot)\controls\idl-tabular\Unmerged\Microsoft.UI.Xaml.Controls.Tabular.g.winmd"
                       Condition="'$(MUXFinalRelease)' != 'true'">
       <ImplementationDll>Microsoft.UI.Xaml.Controls.Tabular.dll</ImplementationDll>


### PR DESCRIPTION
## Problem

`MergedWinMD` merges the Tabular winmd into the public `Microsoft.UI.Xaml.winmd`, so the types added by #11641 are now compared by the WinMD compat static test. It fails with five `VERSION_NO` errors — [build 156359586](https://dev.azure.com/microsoft/WinUI/_build/results?buildId=156359586), step *Run WinMD Compat Test*.

Of the 73 Tabular types in a built winmd, 68 are `XamlContract v12` + `[experimental]`. The five failures are the only ones that are not:

| Type | Before | Why it failed |
| --- | --- | --- |
| `TabularControlsResources` + `ITabularControlsResources` | `XamlContract v1` | Claims it shipped in WinAppSDK 1.0, but it is new — a new type in an already-shipped contract. |
| `XamlControlsTabularXamlMetaDataProvider` + its 2 interfaces | no contract attribute at all | Copied from MUXC's `XamlControlsXamlMetaDataProvider`, which only passes because it is grandfathered into a shipped contract. |

The cause is provenance: the metadata IDL is a renamed copy of `controls\idl\Microsoft.UI.Xaml.Controls.idl`, and the rename carried MUXC's annotations over unchanged. Both are correct there and neither is correct here.

## Fix

Both types exist only to host `TableView`, which is `[MUX_PREVIEW]`, so they now carry the same attribute. Experimental types are exempt from the test — that is why the other 68 already pass — so this clears all five.

`eng\productmetadata.props` excludes Tabular from `MUXFinalRelease` on the grounds that *every* Tabular type is `[MUX_PREVIEW]`/`[MUX_INTERNAL]`; these two were the exception, so its comment is updated.

## Verification

Two full local product builds (`Build.cmd product`, amd64chk, 0 errors each), packed with `pack.component.cmd`, differing only in this IDL change:

**Metadata** — in `BuildOutput\packaging\Debug\lib\uap10.0\Microsoft.UI.Xaml.winmd`, the exact artifact `VerifyWinMDCompat.ps1` consumes:

| Tabular types (73 total) | Baseline | With fix |
| --- | --- | --- |
| `v12` + `[experimental]` | 68 | **73** |
| `v1`, not experimental | 2 | **0** |
| no contract attribute | 3 | **0** |

The five failing types now carry `ContractVersionAttribute` and `FeatureAttribute` blobs byte-identical to `TableView`'s.

**Runtime** — `Samples\TableViewApp\TableViewAppCppUnpackaged` built against each package (clean intermediates both times), launched twice for 45 s each:

| | Sample build | Runtime |
| --- | --- | --- |
| Baseline | 0 errors, 13 warnings | healthy, no crash |
| With fix | 0 errors, 14 warnings | healthy, no crash |

`TabularControlsResources` still activates and `TableView` still renders with the dictionary marked experimental.

**Warning delta** — exactly one new warning, in every app that merges the dictionary:

```
App.xaml(14): XamlCompiler warning WMC1501: TabularControlsResources is for
evaluation purposes only and is subject to change or removal in future updates.
```

That is a warning, not an error — no `TreatWarningsAsErrors` or `WarningsAsErrors` exists anywhere under `Samples/` — and it is arguably correct, since the dictionary genuinely is preview-only and these samples deliberately leave preview warnings visible (`Samples/TableViewApp/README.md`). `XamlControlsTabularXamlMetaDataProvider` adds nothing, appearing in no markup and no C#.

Not covered: the C# samples could not be built locally because `pack.component.cmd` produces a package without `lib/net6.0-*/Microsoft.WinUI.dll`, and `WinMDVersionVerifyLcr.exe` itself is on an internal feed unavailable here — the metadata table above is the direct substitute for that tool's check.

## Alternative considered

`MUX_PUBLIC_V12` emits the identical `ContractVersionAttribute(XamlContract, 12)` and would pass with no `WMC1501`, but it keeps two stable-contract types alive in the final-release winmd for a preview-only component.
