### PR TITLE
Honor FontStretch in TextBox and RichEditBox

### DIFF
--- a/dxaml/test/managed/controls/RichEditBox/RichEditBoxTests.cs
+++ b/dxaml/test/managed/controls/RichEditBox/RichEditBoxTests.cs
@@ -483,6 +483,56 @@ namespace Microsoft.UI.Xaml.Tests.Controls
             TestServices.Utilities.VerifyUIElementTree("3");
         }
 
+        [TestMethod]
+        [TestProperty("Description", "Validates that RichEditBox honors FontStretch instead of falling back to a condensed face.")]
+        [TestProperty("TestPass:ExcludeOn", "WindowsCore")]
+        public void VerifyRichEditBoxHonorsFontStretch()
+        {
+            TestServices.WindowHelper.SetWindowSizeOverride(new global::Windows.Foundation.Size(800, 400));
+
+            // Bahnschrift ships with Windows and has separate Normal, SemiCondensed and Condensed faces,
+            // so whichever face gets resolved shows up as a difference in the measured width.
+            double unset = MeasureFontStretchSample(null);
+            double normal = MeasureFontStretchSample("Normal");
+            double semiCondensed = MeasureFontStretchSample("SemiCondensed");
+            double condensed = MeasureFontStretchSample("Condensed");
+
+            Log.Comment($"Widths - unset: {unset}, Normal: {normal}, SemiCondensed: {semiCondensed}, Condensed: {condensed}");
+
+            Verify.IsGreaterThan(normal, semiCondensed, "Normal should be wider than SemiCondensed");
+            Verify.IsGreaterThan(semiCondensed, condensed, "SemiCondensed should be wider than Condensed");
+            Verify.AreEqual(normal, unset, "An unset FontStretch should render the same as Normal");
+        }
+
+        private static double MeasureFontStretchSample(string fontStretch)
+        {
+            string fontStretchAttribute = fontStretch == null ? string.Empty : $" FontStretch='{fontStretch}'";
+            string rootPanelXaml =
+                    $@"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+                        <RichEditBox x:Name='reb' HorizontalAlignment='Left' FontFamily='Bahnschrift' FontSize='20'{fontStretchAttribute} />
+                      </StackPanel>";
+
+            StackPanel rootPanel = null;
+            RichEditBox richEditBox = null;
+            double width = 0;
+
+            UIExecutor.Execute(() =>
+            {
+                rootPanel = (StackPanel)XamlReader.Load(rootPanelXaml);
+                richEditBox = (RichEditBox)rootPanel.FindName("reb");
+                richEditBox.Document.SetText(TextSetOptions.None, "HHHHHHHHHHHHHHHHHHHH");
+                TestServices.WindowHelper.WindowContent = rootPanel;
+            });
+
+            TestServices.WindowHelper.WaitForIdle();
+
+            UIExecutor.Execute(() =>
+            {
+                width = richEditBox.ActualWidth;
+            });
+
+            return width;
+        }
     }
 }
 

--- a/dxaml/test/managed/controls/TextBox/TextBoxTests.cs
+++ b/dxaml/test/managed/controls/TextBox/TextBoxTests.cs
@@ -915,6 +915,101 @@ namespace Microsoft.UI.Xaml.Tests.Controls
         }
 
         [TestMethod]
+        [TestProperty("Description", "Validates that TextBox honors FontStretch instead of falling back to a condensed face.")]
+        [TestProperty("TestPass:ExcludeOn", "WindowsCore")]
+        public void VerifyTextBoxHonorsFontStretch()
+        {
+            TestServices.WindowHelper.SetWindowSizeOverride(new Size(800, 400));
+
+            // Bahnschrift ships with Windows and has separate Normal, SemiCondensed and Condensed faces,
+            // so whichever face gets resolved shows up as a difference in the measured width.
+            double unset = MeasureFontStretchSample(null);
+            double normal = MeasureFontStretchSample("Normal");
+            double semiCondensed = MeasureFontStretchSample("SemiCondensed");
+            double condensed = MeasureFontStretchSample("Condensed");
+
+            Log.Comment($"Widths - unset: {unset}, Normal: {normal}, SemiCondensed: {semiCondensed}, Condensed: {condensed}");
+
+            Verify.IsGreaterThan(normal, semiCondensed, "Normal should be wider than SemiCondensed");
+            Verify.IsGreaterThan(semiCondensed, condensed, "SemiCondensed should be wider than Condensed");
+            Verify.AreEqual(normal, unset, "An unset FontStretch should render the same as Normal");
+        }
+
+        [TestMethod]
+        [TestProperty("Description", "Validates that changing TextBox.FontStretch after load re-resolves the font face.")]
+        [TestProperty("TestPass:ExcludeOn", "WindowsCore")]
+        public void VerifyTextBoxFontStretchChangeIsReflected()
+        {
+            TestServices.WindowHelper.SetWindowSizeOverride(new Size(800, 400));
+
+            const string rootPanelXaml =
+                    @"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+                        <TextBox x:Name='tb' HorizontalAlignment='Left' FontFamily='Bahnschrift' FontSize='20'
+                                 Text='HHHHHHHHHHHHHHHHHHHH' />
+                      </StackPanel>";
+
+            StackPanel rootPanel = null;
+            TextBox textBox = null;
+            double normalWidth = 0;
+            double condensedWidth = 0;
+
+            UIExecutor.Execute(() =>
+            {
+                rootPanel = (StackPanel)XamlReader.Load(rootPanelXaml);
+                textBox = (TextBox)rootPanel.FindName("tb");
+                TestServices.WindowHelper.WindowContent = rootPanel;
+            });
+
+            TestServices.WindowHelper.WaitForIdle();
+
+            UIExecutor.Execute(() =>
+            {
+                normalWidth = textBox.ActualWidth;
+                textBox.FontStretch = global::Windows.UI.Text.FontStretch.Condensed;
+            });
+
+            TestServices.WindowHelper.WaitForIdle();
+
+            UIExecutor.Execute(() =>
+            {
+                condensedWidth = textBox.ActualWidth;
+            });
+
+            Log.Comment($"Widths - Normal: {normalWidth}, Condensed: {condensedWidth}");
+            Verify.IsGreaterThan(normalWidth, condensedWidth, "Setting FontStretch to Condensed should narrow the text");
+        }
+
+        private static double MeasureFontStretchSample(string fontStretch)
+        {
+            string fontStretchAttribute = fontStretch == null ? string.Empty : $" FontStretch='{fontStretch}'";
+            string rootPanelXaml =
+                    $@"<StackPanel xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+                        <TextBox x:Name='tb' HorizontalAlignment='Left' FontFamily='Bahnschrift' FontSize='20'{fontStretchAttribute}
+                                 Text='HHHHHHHHHHHHHHHHHHHH' />
+                      </StackPanel>";
+
+            StackPanel rootPanel = null;
+            TextBox textBox = null;
+            double width = 0;
+
+            UIExecutor.Execute(() =>
+            {
+                rootPanel = (StackPanel)XamlReader.Load(rootPanelXaml);
+                textBox = (TextBox)rootPanel.FindName("tb");
+                TestServices.WindowHelper.WindowContent = rootPanel;
+            });
+
+            TestServices.WindowHelper.WaitForIdle();
+
+            UIExecutor.Execute(() =>
+            {
+                width = textBox.ActualWidth;
+            });
+
+            return width;
+        }
+
+        [TestMethod]
         [TestProperty("Description", "Verify Hold on grippers invokes Context Menu.")]
         [TestProperty("TestPass:ExcludeOn", "WindowsCore")]
         [TestProperty("Hosting:Mode", "UAP")]

--- a/dxaml/xcp/core/native/text/Controls/TextBoxView.cpp
+++ b/dxaml/xcp/core/native/text/Controls/TextBoxView.cpp
@@ -317,7 +317,14 @@ _Check_return_ HRESULT CTextBoxView::PullInheritedTextFormatting()
             charFormatMask |= CFM_ITALIC;
         }
 
-        m_pTextFormatting->m_nFontStretch = pParentTextFormatting->m_nFontStretch;
+        if (m_pTextFormatting->m_nFontStretch != pParentTextFormatting->m_nFontStretch)
+        {
+            m_pTextFormatting->m_nFontStretch = pParentTextFormatting->m_nFontStretch;
+
+            // RichEdit has no CHARFORMAT field for stretch - it picks the face up through
+            // IProvideFontInfo, so a stretch change needs the same invalidation as a face change.
+            charFormatMask |= CFM_FACE;
+        }
 
         if (m_pTextFormatting->m_nCharacterSpacing != pParentTextFormatting->m_nCharacterSpacing)
         {
@@ -3306,14 +3313,25 @@ _Check_return_ HRESULT CTextBoxView::GetFontFaceRun(
     _Out_ XUINT32 *pRunCount
     )
 {
-    // The use of zero for the optical size will cause the MapCharacters to fall
-    // back to legacy versions (non optical).
-    CFontFaceCriteria fontFaceCriteria(weight, style, stretch, 0.0f);
     DWriteFontFace *pDWriteFontFace;
     const TextFormatting* pTextFormatting = NULL;
     XFLOAT mappedScale;
 
     IFC_RETURN(GetTextFormatting(&pTextFormatting));
+
+    // RichEdit's CHARFORMAT2 has no font stretch field, so runs that carry no explicit stretch of
+    // their own come back as undefined. Fall back to the control's FontStretch - left undefined,
+    // MapCharacters clamps the value to ultra condensed and families that have a narrow face
+    // (Arial, Bahnschrift, ...) render at the wrong width.
+    XUINT32 resolvedStretch = stretch;
+    if (resolvedStretch == static_cast<XUINT32>(DirectUI::FontStretch::Undefined))
+    {
+        resolvedStretch = static_cast<XUINT32>(pTextFormatting->m_nFontStretch);
+    }
+
+    // The use of zero for the optical size will cause the MapCharacters to fall
+    // back to legacy versions (non optical).
+    CFontFaceCriteria fontFaceCriteria(weight, style, resolvedStretch, 0.0f);
 
     wrl::ComPtr<PALText::IFontFace> pFontFace;
     IFC_RETURN(pCompositeFontFamily->MapCharacters(


### PR DESCRIPTION
Fixes #808.

## The bug

`FontFamily="Arial"` on a `TextBox` and `RichEditBox` render as **Arial Narrow**, and setting `FontStretch` to correct it does nothing.

```xml
<TextBlock Text="Arial" FontFamily="Arial" FontSize="32" />
<TextBox   Text="Arial" FontFamily="Arial" FontSize="32" FontStretch="Normal" />
```

## Root cause

XAML hands RichEdit its default formatting through a `CHARFORMAT2`, and that struct has no font stretch field, so `FontStretch` never leaves XAML. RichEdit then calls back through `IProvideFontInfo::GetRunFontFaceId` to turn a family name into a face, passing the stretch *it* knows about — `DWRITE_FONT_STRETCH_UNDEFINED` (0) for any run with no explicit stretch of its own, which is every run in a plain `TextBox`.

A temporary trace in `GetRunFontFaceId`, logging what RichEdit passes next to what XAML holds at that moment:

```
GetRunFontFaceId font='Bahnschrift' weight=400 stretch=0 style=0 xamlStretch=5 charCount=20
GetRunFontFaceId font='Bahnschrift' weight=400 stretch=0 style=0 xamlStretch=4 charCount=20
GetRunFontFaceId font='Bahnschrift' weight=400 stretch=0 style=0 xamlStretch=3 charCount=20
```

Three controls, three different `FontStretch` values, all resolved correctly on the XAML side, and all three arriving at the font matcher as 0.

`CCompositeFontFamily::MapCharacters` then scopes the criteria to a legal range before handing them to DirectWrite:

```cpp
MIN(MAX(1, fontFaceCriteria.m_stretch), 9),  // Scope to a valid stretch
```

`MAX(1, 0)` is 1 — **ultra condensed**. DirectWrite answers with the nearest width the family actually ships. In the DWrite WWS model `Arial` is `{Normal, Condensed}`, so the request resolves to Arial Narrow. `Bahnschrift` and `Roboto` behave the same way; `Segoe UI` has no condensed face, so nothing looked wrong there, which is likely why this went unnoticed.

## The fix

Two changes, both in `TextBoxView.cpp`:

1. `GetFontFaceRun` falls back to the control's `FontStretch` when RichEdit reports undefined. Runs that *do* carry an explicit stretch (set through the document API on a `RichEditBox`) are non-zero and keep winning, so per-run formatting is unaffected.
2. `PullInheritedTextFormatting` was copying the inherited stretch across without raising any invalidation, so assigning `FontStretch` after load had no effect. Stretch reaches RichEdit through the same callback as the face does, so it now flags `CFM_FACE` and lets RichEdit re-resolve.

`PasswordBox` shares `CTextBoxView` and is fixed by the same change.

## Verification

Rendered width in DIPs of the same string, same build, product DLL swapped in and out. The `TextBlock` column is the control group and never changed.

| Bahnschrift | Before | After | TextBlock |
|---|---|---|---|
| TextBox, unset | 188.00 | 289.33 | — |
| TextBox, Normal | 188.00 | 289.33 | 271.48 |
| TextBox, SemiCondensed | 188.00 | 239.33 | 220.70 |
| TextBox, Condensed | 188.00 | 188.00 | 169.92 |
| RichEditBox, Normal | 194.00 | 296.00 | 271.48 |
| RichEditBox, SemiCondensed | 194.00 | 245.33 | 220.70 |
| RichEditBox, Condensed | 194.00 | 194.00 | 169.92 |
| Arial TextBox, Normal | 216.00 | 260.00 | 241.91 |
| Runtime change Normal → Condensed | 188 → 188 | 289 → 188 | — |

Before, every row is pinned to the Condensed value. After, each text control sits a constant ~18 DIPs wider than the matching `TextBlock` — its border and padding — meaning it now resolves the same faces `TextBlock` does.

## Tests

Three tests, using Bahnschrift's three real widths as the observable signal since no API reports which face a text control resolved:

- `TextBoxTests.VerifyTextBoxHonorsFontStretch`
- `TextBoxTests.VerifyTextBoxFontStretchChangeIsReflected` — covers the invalidation half of the fix
- `RichEditBoxTests.VerifyRichEditBoxHonorsFontStretch`