### PR TITLE
Add classic Binding API that takes a delegate

### DIFF
--- a/controls/dev/Repeater/APITests/RepeaterTests.cs
+++ b/controls/dev/Repeater/APITests/RepeaterTests.cs
@@ -962,6 +962,52 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
             });
         }
 
+        [TestMethod]
+        public void ValidateCodeAuthoredDataTemplateSupportsCompiledBinding()
+        {
+            var items = new[]
+            {
+                new DisplayNameViewModel("Item 1"),
+                new DisplayNameViewModel("Item 2"),
+                new DisplayNameViewModel("Item 3"),
+            };
+
+            RunOnUIThread.Execute(() =>
+            {
+                var template = new DataTemplate(() =>
+                {
+                    var textBlock = new TextBlock();
+                    textBlock.SetCompiledBinding(
+                        TextBlock.TextProperty,
+                        source => ((DisplayNameViewModel)source).DisplayName);
+                    return textBlock;
+                });
+
+                var repeater = new ItemsRepeater()
+                {
+                    ItemsSource = items,
+                    ItemTemplate = template,
+                };
+
+                Content = new ItemsRepeaterScrollHost()
+                {
+                    Width = 400,
+                    Height = 800,
+                    ScrollViewer = new ScrollViewer { Content = repeater }
+                };
+
+                Content.UpdateLayout();
+
+                for (int i = 0; i < items.Length; i++)
+                {
+                    var element = repeater.TryGetElement(i) as TextBlock;
+                    Verify.IsNotNull(element, $"Element {i} should be realized from the code-authored template.");
+                    Verify.AreSame(items[i], element.DataContext);
+                    Verify.AreEqual(items[i].DisplayName, element.Text);
+                }
+            });
+        }
+
         // Asserts each realized ItemsRepeater element reflects its item via DataContext, a {Binding} on Text,
         // and DataContextChanged, and that every element is a distinct instance the callback produced.
         private static void VerifyRealizedElements(ItemsRepeater repeater, IList<string> items, List<UIElement> created, Dictionary<TextBlock, object> changedContexts)
@@ -982,6 +1028,16 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
 
             // Each item maps to a distinct element instance.
             Verify.AreEqual(items.Count, realized.Distinct().Count());
+        }
+
+        private class DisplayNameViewModel
+        {
+            public DisplayNameViewModel(string displayName)
+            {
+                DisplayName = displayName;
+            }
+
+            public string DisplayName { get; }
         }
 
     }

--- a/controls/dev/Repeater/APITests/RepeaterTests.cs
+++ b/controls/dev/Repeater/APITests/RepeaterTests.cs
@@ -971,10 +971,16 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 new DisplayNameViewModel("Item 2"),
                 new DisplayNameViewModel("Item 3"),
             };
+            var twoWayItems = new[]
+            {
+                new DisplayNameViewModel("TwoWay Item 1"),
+                new DisplayNameViewModel("TwoWay Item 2"),
+                new DisplayNameViewModel("TwoWay Item 3"),
+            };
 
             RunOnUIThread.Execute(() =>
             {
-                var template = new DataTemplate(() =>
+                var oneWayTemplate = new DataTemplate(() =>
                 {
                     var textBlock = new TextBlock();
                     textBlock.SetCompiledBinding(
@@ -986,15 +992,29 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 var repeater = new ItemsRepeater()
                 {
                     ItemsSource = items,
-                    ItemTemplate = template,
+                    ItemTemplate = oneWayTemplate,
                 };
 
-                Content = new ItemsRepeaterScrollHost()
+                var twoWayTemplate = new DataTemplate(() =>
                 {
-                    Width = 400,
-                    Height = 800,
-                    ScrollViewer = new ScrollViewer { Content = repeater }
+                    var textBlock = new TextBlock();
+                    textBlock.SetCompiledBinding(
+                        TextBlock.TextProperty,
+                        source => ((DisplayNameViewModel)source).DisplayName,
+                        (source, value) => ((DisplayNameViewModel)source).DisplayName = (string)value);
+                    return textBlock;
+                });
+
+                var twoWayRepeater = new ItemsRepeater()
+                {
+                    ItemsSource = twoWayItems,
+                    ItemTemplate = twoWayTemplate,
                 };
+
+                var root = new StackPanel();
+                root.Children.Add(repeater);
+                root.Children.Add(twoWayRepeater);
+                Content = root;
 
                 Content.UpdateLayout();
 
@@ -1004,6 +1024,21 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                     Verify.IsNotNull(element, $"Element {i} should be realized from the code-authored template.");
                     Verify.AreSame(items[i], element.DataContext);
                     Verify.AreEqual(items[i].DisplayName, element.Text);
+                }
+
+                for (int i = 0; i < twoWayItems.Length; i++)
+                {
+                    var element = twoWayRepeater.TryGetElement(i) as TextBlock;
+                    Verify.IsNotNull(element, $"TwoWay element {i} should be realized from the code-authored template.");
+                    Verify.AreSame(twoWayItems[i], element.DataContext);
+                    Verify.AreEqual(twoWayItems[i].DisplayName, element.Text);
+
+                    var updatedDisplayName = $"Updated item {i + 1}";
+                    element.Text = updatedDisplayName;
+                    Verify.AreEqual(
+                        updatedDisplayName,
+                        twoWayItems[i].DisplayName,
+                        $"Changing TwoWay element {i} should write back to its data source.");
                 }
             });
         }
@@ -1037,7 +1072,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests.RepeaterTests
                 DisplayName = displayName;
             }
 
-            public string DisplayName { get; }
+            public string DisplayName { get; set; }
         }
 
     }

--- a/dxaml/test/infra/taefhostappnetcore/WinRT.Host.runtimeconfig.json
+++ b/dxaml/test/infra/taefhostappnetcore/WinRT.Host.runtimeconfig.json
@@ -1,0 +1,16 @@
+{
+  "runtimeOptions": {
+    "tfm": "net8.0",
+    "rollForward": "LatestMinor",
+    "frameworks": [
+      {
+        "name": "Microsoft.NETCore.App",
+        "version": "8.0.0"
+      },
+      {
+        "name": "Microsoft.WindowsDesktop.App",
+        "version": "8.0.0"
+      }
+    ]
+  }
+}

--- a/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
+++ b/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
@@ -752,6 +752,278 @@ namespace Framework { namespace DataBinding {
         });
     }
 
+    void BindingIntegrationTests::CanSetDataContextForCompiledBinding()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto dataContextFirstPanel = ref new StackPanel;
+            auto dataContextFirstSource = CreateInpcDataSource();
+            dataContextFirstPanel->DataContext = dataContextFirstSource;
+
+            dataContextFirstPanel->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+
+            VERIFY_ARE_EQUAL(
+                dataContextFirstSource->StringProperty,
+                safe_cast<String^>(dataContextFirstPanel->Tag),
+                L"Compiled binding should propagate when DataContext is set first");
+
+            auto bindingFirstPanel = ref new StackPanel;
+            auto bindingFirstSource = CreateInpcDataSource();
+
+            bindingFirstPanel->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+
+            VERIFY_IS_NULL(bindingFirstPanel->Tag, L"Compiled binding without DataContext should preserve the default value");
+
+            bindingFirstPanel->DataContext = bindingFirstSource;
+
+            VERIFY_ARE_EQUAL(
+                bindingFirstSource->StringProperty,
+                safe_cast<String^>(bindingFirstPanel->Tag),
+                L"Compiled binding should propagate when the binding is set first");
+
+            dataContextFirstSource->StringProperty = L"Updated after binding";
+            VERIFY_ARE_EQUAL(
+                dataContextFirstSource->StringProperty,
+                safe_cast<String^>(dataContextFirstPanel->Tag),
+                L"Compiled binding should update when its source raises PropertyChanged");
+
+            bindingFirstSource->StringProperty = L"Also updated after binding";
+            VERIFY_ARE_EQUAL(
+                bindingFirstSource->StringProperty,
+                safe_cast<String^>(bindingFirstPanel->Tag),
+                L"Compiled binding should update when its source raises PropertyChanged");
+
+            dataContextFirstPanel->ClearValue(Panel::DataContextProperty);
+            bindingFirstPanel->ClearValue(Panel::DataContextProperty);
+
+            VERIFY_IS_NULL(dataContextFirstPanel->Tag, L"Clearing DataContext should restore the target property's default");
+            VERIFY_IS_NULL(bindingFirstPanel->Tag, L"Clearing DataContext should restore the target property's default");
+        });
+    }
+
+    void BindingIntegrationTests::CanSetDataContextViaSetValueForCompiledBinding()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto dataContextFirstPanel = ref new StackPanel;
+            auto dataContextFirstSource = CreateInpcDataSource();
+            dataContextFirstPanel->SetValue(Panel::DataContextProperty, dataContextFirstSource);
+
+            dataContextFirstPanel->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+
+            VERIFY_ARE_EQUAL(
+                dataContextFirstSource->StringProperty,
+                safe_cast<String^>(dataContextFirstPanel->Tag),
+                L"Compiled binding should propagate when DataContext is set first");
+
+            auto bindingFirstPanel = ref new StackPanel;
+            auto bindingFirstSource = CreateInpcDataSource();
+
+            bindingFirstPanel->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+
+            VERIFY_IS_NULL(bindingFirstPanel->Tag, L"Compiled binding without DataContext should preserve the default value");
+
+            bindingFirstPanel->SetValue(Panel::DataContextProperty, bindingFirstSource);
+
+            VERIFY_ARE_EQUAL(
+                bindingFirstSource->StringProperty,
+                safe_cast<String^>(bindingFirstPanel->Tag),
+                L"Compiled binding should propagate when the binding is set first");
+
+            dataContextFirstPanel->ClearValue(Panel::DataContextProperty);
+            bindingFirstPanel->ClearValue(Panel::DataContextProperty);
+        });
+    }
+
+    void BindingIntegrationTests::CanSetCompiledBindingDataContextAtMultipleLevels()
+    {
+        TestCleanupWrapper cleanup;
+        auto rootPanel = safe_cast<Panel^>(LoadXamlFileOnUIThread(GetFilePath() + L"MultipleLevels.xaml"));
+        RunOnUIThread([&]()
+        {
+            auto textBlock1 = safe_cast<TextBlock^>(rootPanel->FindName(L"textBlock1"));
+            auto panel2 = safe_cast<Panel^>(rootPanel->FindName(L"panel2"));
+            auto textBlock2_1 = safe_cast<TextBlock^>(rootPanel->FindName(L"textBlock2_1"));
+            auto canvas2_2 = safe_cast<Canvas^>(rootPanel->FindName(L"canvas2_2"));
+            auto panel3 = safe_cast<Panel^>(rootPanel->FindName(L"panel3"));
+            auto panel3_1 = safe_cast<Panel^>(rootPanel->FindName(L"panel3_1"));
+
+            VERIFY_IS_NOT_NULL(textBlock1);
+            VERIFY_IS_NOT_NULL(panel2);
+            VERIFY_IS_NOT_NULL(textBlock2_1);
+            VERIFY_IS_NOT_NULL(canvas2_2);
+            VERIFY_IS_NOT_NULL(panel3);
+            VERIFY_IS_NOT_NULL(panel3_1);
+
+            auto stringGetter = ref new CompiledBindingGetter([](Object^ source) -> Object^
+            {
+                return safe_cast<InpcDataSource^>(source)->StringProperty;
+            });
+            auto intGetter = ref new CompiledBindingGetter([](Object^ source) -> Object^
+            {
+                return safe_cast<InpcDataSource^>(source)->Int32Property.ToString();
+            });
+            auto nestedStringGetter = ref new CompiledBindingGetter([](Object^ source) -> Object^
+            {
+                return safe_cast<InpcDataSource^>(source)->InpcDataSourceProperty->StringProperty;
+            });
+
+            rootPanel->SetCompiledBinding(Panel::TagProperty, nestedStringGetter);
+            textBlock1->SetCompiledBinding(TextBlock::TextProperty, stringGetter);
+            panel2->SetCompiledBinding(Panel::TagProperty, stringGetter);
+            textBlock2_1->SetCompiledBinding(TextBlock::TextProperty, intGetter);
+            canvas2_2->SetCompiledBinding(Canvas::TagProperty, stringGetter);
+            panel3->SetCompiledBinding(Panel::TagProperty, stringGetter);
+            panel3_1->SetCompiledBinding(Panel::TagProperty, nestedStringGetter);
+
+            VERIFY_IS_NULL(rootPanel->Tag, L"Compiled binding without DataContext should preserve the default value");
+            VERIFY_IS_TRUE(textBlock1->Text->IsEmpty(), L"Compiled binding without DataContext should preserve the default value");
+            VERIFY_IS_NULL(panel2->Tag, L"Compiled binding without DataContext should preserve the default value");
+            VERIFY_IS_TRUE(textBlock2_1->Text->IsEmpty(), L"Compiled binding without DataContext should preserve the default value");
+            VERIFY_IS_NULL(canvas2_2->Tag, L"Compiled binding without DataContext should preserve the default value");
+            VERIFY_IS_NULL(panel3->Tag, L"Compiled binding without DataContext should preserve the default value");
+            VERIFY_IS_NULL(panel3_1->Tag, L"Compiled binding without DataContext should preserve the default value");
+
+            auto dataSource1 = CreateInpcDataSource();
+            auto dataSource2 = CreateInpcDataSource();
+            dataSource2->StringProperty = L"Test string 2";
+            dataSource2->InpcDataSourceProperty->StringProperty = L"Nested test string 2";
+
+            panel2->DataContext = dataSource1;
+            panel3_1->DataContext = dataSource2;
+
+            VERIFY_IS_NULL(rootPanel->Tag, L"Unrelated compiled binding should remain unchanged");
+            VERIFY_IS_TRUE(textBlock1->Text->IsEmpty(), L"Unrelated compiled binding should remain unchanged");
+            VERIFY_ARE_EQUAL(dataSource1->StringProperty, safe_cast<String^>(panel2->Tag), L"Local DataContext should update compiled binding");
+            VERIFY_ARE_EQUAL(dataSource1->Int32Property.ToString(), textBlock2_1->Text, L"Inherited DataContext should update compiled binding");
+            VERIFY_ARE_EQUAL(dataSource1->StringProperty, safe_cast<String^>(canvas2_2->Tag), L"Inherited DataContext should update compiled binding");
+            VERIFY_IS_NULL(panel3->Tag, L"Unrelated compiled binding should remain unchanged");
+            VERIFY_ARE_EQUAL(dataSource2->InpcDataSourceProperty->StringProperty, safe_cast<String^>(panel3_1->Tag), L"Local DataContext should update compiled binding");
+
+            panel2->ClearValue(Panel::DataContextProperty);
+            panel3_1->ClearValue(Panel::DataContextProperty);
+
+            VERIFY_IS_NULL(rootPanel->Tag, L"Clearing DataContext should restore the default value");
+            VERIFY_IS_TRUE(textBlock1->Text->IsEmpty(), L"Clearing DataContext should restore the default value");
+            VERIFY_IS_NULL(panel2->Tag, L"Clearing DataContext should restore the default value");
+            VERIFY_IS_TRUE(textBlock2_1->Text->IsEmpty(), L"Clearing inherited DataContext should restore the default value");
+            VERIFY_IS_NULL(canvas2_2->Tag, L"Clearing inherited DataContext should restore the default value");
+            VERIFY_IS_NULL(panel3->Tag, L"Clearing DataContext should restore the default value");
+            VERIFY_IS_NULL(panel3_1->Tag, L"Clearing DataContext should restore the default value");
+        });
+    }
+
+    void BindingIntegrationTests::CanLocalValueOverrideCompiledBinding()
+    {
+        TestCleanupWrapper cleanup;
+        auto rootPanel = safe_cast<Panel^>(LoadXamlFileOnUIThread(GetFilePath() + L"MultipleLevels.xaml"));
+        RunOnUIThread([&]()
+        {
+            auto textBlock1 = safe_cast<TextBlock^>(rootPanel->FindName(L"textBlock1"));
+            VERIFY_IS_NOT_NULL(textBlock1);
+
+            auto dataSource1 = CreateInpcDataSource();
+            rootPanel->DataContext = dataSource1;
+
+            textBlock1->SetCompiledBinding(
+                TextBlock::TextProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+
+            auto explicitValue = ref new String(L"Local test value");
+            textBlock1->Text = explicitValue;
+
+            auto dataSource2 = CreateInpcDataSource();
+            dataSource2->StringProperty = L"Test string 2";
+            rootPanel->DataContext = dataSource2;
+            VERIFY_ARE_EQUAL(explicitValue, textBlock1->Text, L"Local value should remain after changing DataContext");
+
+            dataSource2->StringProperty = L"Test update string";
+            VERIFY_ARE_EQUAL(explicitValue, textBlock1->Text, L"Local value should remain after changing the source");
+
+            rootPanel->ClearValue(Panel::DataContextProperty);
+        });
+    }
+
+    void BindingIntegrationTests::CanOverwriteClassicAndCompiledBindings()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto target = ref new StackPanel;
+            auto dataSource = CreateInpcDataSource();
+            dataSource->ObjectProperty = ref new String(L"Classic binding value 1");
+            dataSource->StringProperty = L"Compiled binding value";
+            dataSource->InpcDataSourceProperty->StringProperty = L"Classic binding value 2";
+            target->DataContext = dataSource;
+
+            auto firstClassicBinding = ref new Binding;
+            firstClassicBinding->Path = ref new PropertyPath(L"ObjectProperty");
+            target->SetBinding(Panel::TagProperty, firstClassicBinding);
+
+            VERIFY_ARE_EQUAL(dataSource->ObjectProperty, target->Tag, L"First classic binding should propagate");
+
+            target->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+
+            VERIFY_ARE_EQUAL(dataSource->StringProperty, safe_cast<String^>(target->Tag), L"Compiled binding should replace the classic binding");
+
+            dataSource->ObjectProperty = ref new String(L"Superseded classic binding update");
+            VERIFY_ARE_EQUAL(dataSource->StringProperty, safe_cast<String^>(target->Tag), L"Superseded classic binding should not update the target");
+
+            auto secondClassicBinding = ref new Binding;
+            secondClassicBinding->Path = ref new PropertyPath(L"InpcDataSourceProperty.StringProperty");
+            target->SetBinding(Panel::TagProperty, secondClassicBinding);
+
+            VERIFY_ARE_EQUAL(
+                dataSource->InpcDataSourceProperty->StringProperty,
+                safe_cast<String^>(target->Tag),
+                L"Second classic binding should replace the compiled binding");
+
+            dataSource->StringProperty = L"Superseded compiled binding update";
+            VERIFY_ARE_EQUAL(
+                dataSource->InpcDataSourceProperty->StringProperty,
+                safe_cast<String^>(target->Tag),
+                L"Superseded compiled binding should not update the target");
+
+            dataSource->InpcDataSourceProperty->StringProperty = L"Classic binding update";
+            VERIFY_ARE_EQUAL(
+                dataSource->InpcDataSourceProperty->StringProperty,
+                safe_cast<String^>(target->Tag),
+                L"Current classic binding should continue to update the target");
+
+            target->ClearValue(Panel::DataContextProperty);
+        });
+    }
+
     void BindingIntegrationTests::CanContentPresenterUpdateContentBinding()
     {
         TestCleanupWrapper cleanup;
@@ -1466,6 +1738,32 @@ namespace Framework { namespace DataBinding {
                     }
                 }
             }
+        });
+    }
+
+    void BindingIntegrationTests::CanGetBindingExpressionForCompiledBinding()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto target = ref new CustomControl;
+            auto dataSource = ref new InpcDataSource;
+            dataSource->ObjectProperty = ref new String(L"Initial source value");
+            target->DataContext = dataSource;
+
+            VERIFY_IS_NULL(target->GetBindingExpression(CustomControl::WorkingTagProperty));
+
+            target->SetCompiledBinding(
+                CustomControl::WorkingTagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->ObjectProperty;
+                }));
+
+            VERIFY_ARE_EQUAL(dataSource->ObjectProperty, target->WorkingTag, L"Compiled binding should propagate");
+            VERIFY_IS_NULL(
+                target->GetBindingExpression(CustomControl::WorkingTagProperty),
+                L"GetBindingExpression should not expose a compiled binding");
         });
     }
 

--- a/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
+++ b/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
@@ -812,6 +812,76 @@ namespace Framework { namespace DataBinding {
         });
     }
 
+    void BindingIntegrationTests::CanChangeDataContextForCompiledBinding()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto target = ref new StackPanel;
+            auto firstSource = CreateInpcDataSource();
+            firstSource->StringProperty = L"First source value";
+            target->DataContext = firstSource;
+
+            target->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+
+            VERIFY_ARE_EQUAL(firstSource->StringProperty, safe_cast<String^>(target->Tag));
+
+            auto secondSource = CreateInpcDataSource();
+            secondSource->StringProperty = L"Second source value";
+            target->DataContext = secondSource;
+
+            VERIFY_ARE_EQUAL(
+                secondSource->StringProperty,
+                safe_cast<String^>(target->Tag),
+                L"Compiled binding should follow the new DataContext");
+
+            firstSource->StringProperty = L"First source update";
+            VERIFY_ARE_EQUAL(
+                secondSource->StringProperty,
+                safe_cast<String^>(target->Tag),
+                L"Changes from the old DataContext should not update the target");
+
+            secondSource->StringProperty = L"Second source update";
+            VERIFY_ARE_EQUAL(
+                secondSource->StringProperty,
+                safe_cast<String^>(target->Tag),
+                L"Changes from the new DataContext should update the target");
+
+            target->ClearValue(Panel::DataContextProperty);
+        });
+    }
+
+    void BindingIntegrationTests::CannotChangeDataContextDuringCompiledBindingEvaluation()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto target = ref new StackPanel;
+            auto initialSource = CreateInpcDataSource();
+            auto replacementSource = CreateInpcDataSource();
+            target->DataContext = initialSource;
+
+            VERIFY_THROWS_SPECIFIC_CX(
+                target->SetCompiledBinding(
+                    Panel::TagProperty,
+                    ref new CompiledBindingGetter([target, replacementSource](Object^ source) -> Object^
+                    {
+                        target->DataContext = replacementSource;
+                        return safe_cast<InpcDataSource^>(source)->StringProperty;
+                    })),
+                Platform::Exception,
+                [](Platform::Exception^ exception)
+                {
+                    return exception->HResult == E_INVALID_OPERATION;
+                });
+        });
+    }
+
     void BindingIntegrationTests::CanSetDataContextViaSetValueForCompiledBinding()
     {
         TestCleanupWrapper cleanup;
@@ -912,13 +982,14 @@ namespace Framework { namespace DataBinding {
             dataSource2->InpcDataSourceProperty->StringProperty = L"Nested test string 2";
 
             panel2->DataContext = dataSource1;
+            canvas2_2->DataContext = dataSource2;
             panel3_1->DataContext = dataSource2;
 
             VERIFY_IS_NULL(rootPanel->Tag, L"Unrelated compiled binding should remain unchanged");
             VERIFY_IS_TRUE(textBlock1->Text->IsEmpty(), L"Unrelated compiled binding should remain unchanged");
             VERIFY_ARE_EQUAL(dataSource1->StringProperty, safe_cast<String^>(panel2->Tag), L"Local DataContext should update compiled binding");
             VERIFY_ARE_EQUAL(dataSource1->Int32Property.ToString(), textBlock2_1->Text, L"Inherited DataContext should update compiled binding");
-            VERIFY_ARE_EQUAL(dataSource1->StringProperty, safe_cast<String^>(canvas2_2->Tag), L"Inherited DataContext should update compiled binding");
+            VERIFY_ARE_EQUAL(dataSource2->StringProperty, safe_cast<String^>(canvas2_2->Tag), L"Local DataContext should take precedence over inherited DataContext");
             VERIFY_IS_NULL(panel3->Tag, L"Unrelated compiled binding should remain unchanged");
             VERIFY_ARE_EQUAL(dataSource2->InpcDataSourceProperty->StringProperty, safe_cast<String^>(panel3_1->Tag), L"Local DataContext should update compiled binding");
 
@@ -929,9 +1000,12 @@ namespace Framework { namespace DataBinding {
             VERIFY_IS_TRUE(textBlock1->Text->IsEmpty(), L"Clearing DataContext should restore the default value");
             VERIFY_IS_NULL(panel2->Tag, L"Clearing DataContext should restore the default value");
             VERIFY_IS_TRUE(textBlock2_1->Text->IsEmpty(), L"Clearing inherited DataContext should restore the default value");
-            VERIFY_IS_NULL(canvas2_2->Tag, L"Clearing inherited DataContext should restore the default value");
+            VERIFY_ARE_EQUAL(dataSource2->StringProperty, safe_cast<String^>(canvas2_2->Tag), L"Clearing inherited DataContext should not affect a local DataContext");
             VERIFY_IS_NULL(panel3->Tag, L"Clearing DataContext should restore the default value");
             VERIFY_IS_NULL(panel3_1->Tag, L"Clearing DataContext should restore the default value");
+
+            canvas2_2->ClearValue(Canvas::DataContextProperty);
+            VERIFY_IS_NULL(canvas2_2->Tag, L"Clearing local DataContext should restore the default value");
         });
     }
 

--- a/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
+++ b/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
@@ -877,7 +877,7 @@ namespace Framework { namespace DataBinding {
                 Platform::Exception,
                 [](Platform::Exception^ exception)
                 {
-                    return exception->HResult == E_INVALID_OPERATION;
+                    return exception->HResult == HRESULT_FROM_WIN32(ERROR_INVALID_OPERATION);
                 });
         });
     }

--- a/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
+++ b/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.cpp
@@ -294,6 +294,11 @@ namespace Framework { namespace DataBinding {
 
             bindingTarget->Text = L"8.0";
             VERIFY_ARE_EQUAL(16.0, bindingSource->Width, L"Invalid value of source property after changing target");
+
+            bindingSource->Width = 10.0;
+            VERIFY_IS_TRUE(
+                L"5" == bindingTarget->Text,
+                L"Two-way binding should remain installed and update the target after changing the source");
         });
     }
 
@@ -735,6 +740,10 @@ namespace Framework { namespace DataBinding {
             rootPanel->DataContext = dataSource1;
 
             SetBinding(textBlock1, TextBlock::TextProperty, L"StringProperty");
+            VERIFY_ARE_EQUAL(
+                dataSource1->StringProperty,
+                textBlock1->Text,
+                L"Binding should update the target before being replaced by a local value");
 
             auto explicitValue = ref new String(L"Explicit value");
             textBlock1->Text = explicitValue;
@@ -809,6 +818,129 @@ namespace Framework { namespace DataBinding {
 
             VERIFY_IS_NULL(dataContextFirstPanel->Tag, L"Clearing DataContext should restore the target property's default");
             VERIFY_IS_NULL(bindingFirstPanel->Tag, L"Clearing DataContext should restore the target property's default");
+        });
+    }
+
+    void BindingIntegrationTests::CanUpdateTwoWayCompiledBinding()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto target = ref new StackPanel;
+            auto firstSource = CreateInpcDataSource();
+            firstSource->StringProperty = L"Initial value";
+            target->DataContext = firstSource;
+
+            int getterInvocationCount = 0;
+            int setterInvocationCount = 0;
+            target->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([&getterInvocationCount](Object^ source) -> Object^
+                {
+                    ++getterInvocationCount;
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }),
+                ref new CompiledBindingSetter([&setterInvocationCount](Object^ source, Object^ value)
+                {
+                    ++setterInvocationCount;
+                    safe_cast<InpcDataSource^>(source)->StringProperty =
+                        Platform::String::Concat(L"Coerced ", safe_cast<String^>(value));
+                }));
+
+            VERIFY_ARE_EQUAL(firstSource->StringProperty, safe_cast<String^>(target->Tag));
+            VERIFY_ARE_EQUAL(1, getterInvocationCount, L"Installing the binding should invoke the getter once");
+            VERIFY_ARE_EQUAL(0, setterInvocationCount, L"Installing the binding should not invoke the setter");
+
+            target->Tag = L"target value";
+
+            VERIFY_ARE_EQUAL(2, getterInvocationCount, L"Source notification from the setter should invoke the getter once");
+            VERIFY_ARE_EQUAL(1, setterInvocationCount, L"A target change should invoke the setter once");
+            VERIFY_ARE_EQUAL(ref new String(L"Coerced target value"), firstSource->StringProperty);
+            VERIFY_ARE_EQUAL(
+                firstSource->StringProperty,
+                safe_cast<String^>(target->Tag),
+                L"PropertyChanged raised by the setter should refresh a coerced source value without invoking the setter again");
+
+            auto secondSource = CreateInpcDataSource();
+            secondSource->StringProperty = L"Second source";
+            target->DataContext = secondSource;
+            VERIFY_ARE_EQUAL(3, getterInvocationCount, L"Changing DataContext should invoke the getter once");
+
+            target->Tag = L"new target value";
+
+            VERIFY_ARE_EQUAL(4, getterInvocationCount, L"Source notification from the second setter call should invoke the getter once");
+            VERIFY_ARE_EQUAL(2, setterInvocationCount);
+            VERIFY_ARE_EQUAL(ref new String(L"Coerced new target value"), secondSource->StringProperty);
+            VERIFY_ARE_EQUAL(
+                ref new String(L"Coerced target value"),
+                firstSource->StringProperty,
+                L"Write-back should use the current DataContext");
+
+            target->ClearValue(Panel::DataContextProperty);
+            target->Tag = L"value without a source";
+            VERIFY_ARE_EQUAL(4, getterInvocationCount, L"A null DataContext should suppress getter invocation");
+            VERIFY_ARE_EQUAL(2, setterInvocationCount, L"A null DataContext should suppress setter invocation");
+
+            target->ClearValue(Panel::TagProperty);
+            target->DataContext = secondSource;
+            target->Tag = L"value after clearing the binding";
+            VERIFY_ARE_EQUAL(4, getterInvocationCount, L"Clearing the binding should prevent further getter invocation");
+            VERIFY_ARE_EQUAL(2, setterInvocationCount, L"Clearing the binding should detach its target listener");
+        });
+    }
+
+    void BindingIntegrationTests::CanReplaceTwoWayCompiledBindingWithOneWay()
+    {
+        TestCleanupWrapper cleanup;
+        RunOnUIThread([]()
+        {
+            auto target = ref new StackPanel;
+            auto source = CreateInpcDataSource();
+            source->StringProperty = L"Initial value";
+            target->DataContext = source;
+
+            int setterInvocationCount = 0;
+            target->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }),
+                ref new CompiledBindingSetter([&setterInvocationCount](Object^ source, Object^ value)
+                {
+                    ++setterInvocationCount;
+                    safe_cast<InpcDataSource^>(source)->StringProperty = safe_cast<String^>(value);
+                }));
+
+            target->Tag = L"TwoWay target value";
+            VERIFY_ARE_EQUAL(1, setterInvocationCount);
+            VERIFY_ARE_EQUAL(ref new String(L"TwoWay target value"), source->StringProperty);
+
+            target->SetCompiledBinding(
+                Panel::TagProperty,
+                ref new CompiledBindingGetter([](Object^ source) -> Object^
+                {
+                    return safe_cast<InpcDataSource^>(source)->StringProperty;
+                }));
+            source->StringProperty = L"OneWay source value";
+
+            VERIFY_ARE_EQUAL(source->StringProperty, safe_cast<String^>(target->Tag));
+
+            target->Tag = L"Local value";
+            VERIFY_ARE_EQUAL(
+                1,
+                setterInvocationCount,
+                L"Replacing a TwoWay compiled binding should detach its setter");
+            VERIFY_ARE_EQUAL(
+                ref new String(L"OneWay source value"),
+                source->StringProperty,
+                L"Changing the target of the replacement OneWay binding should not update the source");
+
+            source->StringProperty = L"Source update after local value";
+            VERIFY_ARE_EQUAL(
+                ref new String(L"Local value"),
+                safe_cast<String^>(target->Tag),
+                L"Changing the target should replace the getter-only compiled binding");
         });
     }
 
@@ -1060,6 +1192,9 @@ namespace Framework { namespace DataBinding {
             target->SetBinding(Panel::TagProperty, firstClassicBinding);
 
             VERIFY_ARE_EQUAL(dataSource->ObjectProperty, target->Tag, L"First classic binding should propagate");
+            VERIFY_IS_NOT_NULL(
+                target->GetBindingExpression(Panel::TagProperty),
+                L"GetBindingExpression should return the classic binding expression");
 
             target->SetCompiledBinding(
                 Panel::TagProperty,
@@ -1069,6 +1204,9 @@ namespace Framework { namespace DataBinding {
                 }));
 
             VERIFY_ARE_EQUAL(dataSource->StringProperty, safe_cast<String^>(target->Tag), L"Compiled binding should replace the classic binding");
+            VERIFY_IS_NULL(
+                target->GetBindingExpression(Panel::TagProperty),
+                L"GetBindingExpression should not expose the compiled binding expression");
 
             dataSource->ObjectProperty = ref new String(L"Superseded classic binding update");
             VERIFY_ARE_EQUAL(dataSource->StringProperty, safe_cast<String^>(target->Tag), L"Superseded classic binding should not update the target");
@@ -1081,6 +1219,9 @@ namespace Framework { namespace DataBinding {
                 dataSource->InpcDataSourceProperty->StringProperty,
                 safe_cast<String^>(target->Tag),
                 L"Second classic binding should replace the compiled binding");
+            VERIFY_IS_NOT_NULL(
+                target->GetBindingExpression(Panel::TagProperty),
+                L"GetBindingExpression should return the replacement classic binding expression");
 
             dataSource->StringProperty = L"Superseded compiled binding update";
             VERIFY_ARE_EQUAL(

--- a/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.h
+++ b/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.h
@@ -108,6 +108,31 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
                     L"Create a tree set data context on root, create a binding on the leaf, then override that binding and verify the explicit value sticks")
             END_TEST_METHOD()
 
+            BEGIN_TEST_METHOD(CanSetDataContextForCompiledBinding)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Set a compiled binding before and after setting DataContext and verify the value propagates")
+            END_TEST_METHOD()
+
+            BEGIN_TEST_METHOD(CanSetDataContextViaSetValueForCompiledBinding)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Set a compiled binding before and after setting DataContext via SetValue and verify the value propagates")
+            END_TEST_METHOD()
+
+            BEGIN_TEST_METHOD(CanSetCompiledBindingDataContextAtMultipleLevels)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Verify compiled bindings follow local and inherited DataContext changes at multiple levels")
+            END_TEST_METHOD()
+
+            BEGIN_TEST_METHOD(CanLocalValueOverrideCompiledBinding)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Override a compiled binding with a local value and verify later source changes do not replace it")
+            END_TEST_METHOD()
+
+            BEGIN_TEST_METHOD(CanOverwriteClassicAndCompiledBindings)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Verify classic and compiled bindings replace one another on the same target property")
+            END_TEST_METHOD()
+
             BEGIN_TEST_METHOD(CanContentPresenterUpdateContentBinding)
                 TEST_METHOD_PROPERTY(L"Description",
                     L"Create a Binding for ContentPresenter.Content and ensure that the Content template is created on first layout.")
@@ -186,6 +211,11 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
             BEGIN_TEST_METHOD(CanGetBindingExpressionGetBinding)
                 TEST_METHOD_PROPERTY(L"Description",
                     L"Verify that GetBindingExpression returns non-null when a binding is set")
+            END_TEST_METHOD()
+
+            BEGIN_TEST_METHOD(CanGetBindingExpressionForCompiledBinding)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Verify that GetBindingExpression does not expose a compiled binding")
             END_TEST_METHOD()
 
             BEGIN_TEST_METHOD(CanBindToCollectionIndexer)

--- a/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.h
+++ b/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.h
@@ -113,6 +113,16 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
                     L"Set a compiled binding before and after setting DataContext and verify the value propagates")
             END_TEST_METHOD()
 
+            BEGIN_TEST_METHOD(CanChangeDataContextForCompiledBinding)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Change a compiled binding's DataContext object and verify it follows the new source")
+            END_TEST_METHOD()
+
+            BEGIN_TEST_METHOD(CannotChangeDataContextDuringCompiledBindingEvaluation)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Verify changing DataContext from a compiled binding getter fails with an invalid operation")
+            END_TEST_METHOD()
+
             BEGIN_TEST_METHOD(CanSetDataContextViaSetValueForCompiledBinding)
                 TEST_METHOD_PROPERTY(L"Description",
                     L"Set a compiled binding before and after setting DataContext via SetValue and verify the value propagates")

--- a/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.h
+++ b/dxaml/test/native/external/framework/dataBinding/tests/BindingIntegrationTests.h
@@ -113,6 +113,16 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
                     L"Set a compiled binding before and after setting DataContext and verify the value propagates")
             END_TEST_METHOD()
 
+            BEGIN_TEST_METHOD(CanUpdateTwoWayCompiledBinding)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Verify a compiled binding setter writes target changes to the current DataContext without recursive updates")
+            END_TEST_METHOD()
+
+            BEGIN_TEST_METHOD(CanReplaceTwoWayCompiledBindingWithOneWay)
+                TEST_METHOD_PROPERTY(L"Description",
+                    L"Verify a getter-only compiled binding replaces and detaches an existing TwoWay compiled binding")
+            END_TEST_METHOD()
+
             BEGIN_TEST_METHOD(CanChangeDataContextForCompiledBinding)
                 TEST_METHOD_PROPERTY(L"Description",
                     L"Change a compiled binding's DataContext object and verify it follows the new source")

--- a/dxaml/xcp/components/metadata/inc/Indexes.g.h
+++ b/dxaml/xcp/components/metadata/inc/Indexes.g.h
@@ -3114,6 +3114,7 @@ enum class KnownMethodIndex: UINT16
     FrameworkElement_DeferTree,
     FrameworkElement_SetBinding,
     FrameworkElement_SetThemeResourceBinding,
+    FrameworkElement_SetCompiledBinding,
     FrameworkElement_GoToElementStateCore,
     FrameworkElement_GetBindingExpression,
     FrameworkElement_InvalidateViewport,

--- a/dxaml/xcp/components/metadata/inc/Indexes.g.h
+++ b/dxaml/xcp/components/metadata/inc/Indexes.g.h
@@ -3115,6 +3115,7 @@ enum class KnownMethodIndex: UINT16
     FrameworkElement_SetBinding,
     FrameworkElement_SetThemeResourceBinding,
     FrameworkElement_SetCompiledBinding,
+    FrameworkElement_SetCompiledBindingWithSetter,
     FrameworkElement_GoToElementStateCore,
     FrameworkElement_GetBindingExpression,
     FrameworkElement_InvalidateViewport,

--- a/dxaml/xcp/dxaml/idl/winrt/controls/microsoft.ui.xaml.controls.controls.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/controls/microsoft.ui.xaml.controls.controls.idl
@@ -581,7 +581,7 @@ namespace Microsoft.UI.Xaml
 {
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface IDataTemplateExtension
+    interface IDataTemplateExtension 
     {
         void ResetTemplate();
         Boolean ProcessBinding(UInt32 phase);
@@ -600,7 +600,7 @@ namespace Microsoft.UI.Xaml
         static Microsoft.UI.Xaml.DependencyProperty ExtensionInstanceProperty{ get; };
         static Microsoft.UI.Xaml.IDataTemplateExtension GetExtensionInstance(Microsoft.UI.Xaml.FrameworkElement element);
         static void SetExtensionInstance(Microsoft.UI.Xaml.FrameworkElement element, Microsoft.UI.Xaml.IDataTemplateExtension value);
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 12)]
         [feature(Feature_ExperimentalApi)]
         [constructor_name("Microsoft.UI.Xaml.IDataTemplateFactoryFeature_ExperimentalApi")]
@@ -984,14 +984,14 @@ namespace Microsoft.UI.Xaml.Controls
 {
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface IInsertionPanel
+    interface IInsertionPanel 
     {
         void GetInsertionIndexes(Windows.Foundation.Point position, out Int32 first, out Int32 second);
     };
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface IItemContainerMapping
+    interface IItemContainerMapping 
     {
         Object ItemFromContainer(Microsoft.UI.Xaml.DependencyObject container);
         Microsoft.UI.Xaml.DependencyObject ContainerFromItem(Object item);
@@ -1001,14 +1001,14 @@ namespace Microsoft.UI.Xaml.Controls
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface INavigate
+    interface INavigate 
     {
         Boolean Navigate(Windows.UI.Xaml.Interop.TypeName sourcePageType);
     };
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface IScrollAnchorProvider
+    interface IScrollAnchorProvider 
     {
         Microsoft.UI.Xaml.UIElement CurrentAnchor{ get; };
         void RegisterAnchorCandidate(Microsoft.UI.Xaml.UIElement element);
@@ -1017,7 +1017,7 @@ namespace Microsoft.UI.Xaml.Controls
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface ISemanticZoomInformation
+    interface ISemanticZoomInformation 
     {
         Microsoft.UI.Xaml.Controls.SemanticZoom SemanticZoomOwner;
         Boolean IsActiveView;
@@ -1565,7 +1565,7 @@ namespace Microsoft.UI.Xaml.Controls
         static Microsoft.UI.Xaml.DependencyProperty BackgroundProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty IsItemsHostProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty ChildrenTransitionsProperty{ get; };
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
         [feature(Feature_WUXCPreviewTypes)]
         [protected_name("Microsoft.UI.Xaml.Controls.IPanelProtectedFeature_WUXCPreviewTypes")]
@@ -2003,7 +2003,7 @@ namespace Microsoft.UI.Xaml.Controls
         static Microsoft.UI.Xaml.DependencyProperty CanPasteClipboardContentProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty SelectionFlyoutProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty DescriptionProperty{ get; };
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
         [feature(Feature_HeaderPlacement)]
         [static_name("Microsoft.UI.Xaml.Controls.IPasswordBoxStaticsFeature_HeaderPlacement")]
@@ -2217,7 +2217,7 @@ namespace Microsoft.UI.Xaml.Controls
         static Microsoft.UI.Xaml.DependencyProperty DescriptionProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty DesiredCandidateWindowAlignmentProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty TextReadingOrderProperty{ get; };
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
         [feature(Feature_HeaderPlacement)]
         [static_name("Microsoft.UI.Xaml.Controls.ITextBoxStaticsFeature_HeaderPlacement")]
@@ -2255,7 +2255,7 @@ namespace Microsoft.UI.Xaml.Controls
         overridable void OnOnContentChanged(Object oldContent, Object newContent);
         overridable void OnOffContentChanged(Object oldContent, Object newContent);
         overridable void OnHeaderChanged(Object oldContent, Object newContent);
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
         [feature(Feature_HeaderPlacement)]
         [static_name("Microsoft.UI.Xaml.Controls.IToggleSwitchStaticsFeature_HeaderPlacement")]
@@ -2364,7 +2364,7 @@ namespace Microsoft.UI.Xaml.Controls
         static Microsoft.UI.Xaml.DependencyProperty ThumbToolTipValueConverterProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty HeaderProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty HeaderTemplateProperty{ get; };
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
         [feature(Feature_HeaderPlacement)]
         [static_name("Microsoft.UI.Xaml.Controls.ISliderStaticsFeature_HeaderPlacement")]
@@ -2450,7 +2450,7 @@ namespace Microsoft.UI.Xaml.Controls
         static Microsoft.UI.Xaml.DependencyProperty DescriptionProperty{ get; };
         overridable void OnDropDownClosed(Object e);
         overridable void OnDropDownOpened(Object e);
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
         [feature(Feature_HeaderPlacement)]
         [static_name("Microsoft.UI.Xaml.Controls.IComboBoxStaticsFeature_HeaderPlacement")]
@@ -2634,7 +2634,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
 {
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface IScrollSnapPointsInfo
+    interface IScrollSnapPointsInfo 
     {
         Boolean AreHorizontalSnapPointsRegular{ get; };
         Boolean AreVerticalSnapPointsRegular{ get; };
@@ -2801,7 +2801,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
         static Microsoft.UI.Xaml.DependencyProperty IsLightDismissEnabledProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty{ get; };
         static Microsoft.UI.Xaml.DependencyProperty ShouldConstrainToRootBoundsProperty{ get; };
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 2)]
         {
             Microsoft.UI.Xaml.FrameworkElement PlacementTarget;
@@ -2811,7 +2811,7 @@ namespace Microsoft.UI.Xaml.Controls.Primitives
             static Microsoft.UI.Xaml.DependencyProperty PlacementTargetProperty{ get; };
             static Microsoft.UI.Xaml.DependencyProperty DesiredPlacementProperty{ get; };
         }
-
+    
         [contract(Microsoft.UI.Xaml.WinUIContract, 5)]
         {
             Microsoft.UI.Xaml.Media.SystemBackdrop SystemBackdrop;
@@ -3474,7 +3474,7 @@ namespace Microsoft.UI.Xaml.Interop
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [uuid(036d2c08-df29-41af-8aa2-d774be62ba6f)]
     [webhosthidden]
-    interface IBindableIterable
+    interface IBindableIterable 
     {
         Microsoft.UI.Xaml.Interop.IBindableIterator First();
     };
@@ -3482,7 +3482,7 @@ namespace Microsoft.UI.Xaml.Interop
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [uuid(6a1d6c07-076d-49f2-8314-f52c9c9a8331)]
     [webhosthidden]
-    interface IBindableIterator
+    interface IBindableIterator 
     {
         Object Current{ get; };
         Boolean HasCurrent{ get; };
@@ -3526,7 +3526,7 @@ namespace Microsoft.UI.Xaml.Interop
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
-    interface INotifyCollectionChanged
+    interface INotifyCollectionChanged 
     {
         event Microsoft.UI.Xaml.Interop.NotifyCollectionChangedEventHandler CollectionChanged;
     };

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes.idl
@@ -1566,6 +1566,10 @@ namespace Microsoft.UI.Xaml.Data
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
+    delegate Object CompiledBindingGetter(Object source);
+
+    [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
+    [webhosthidden]
     delegate void CurrentChangingEventHandler(Object sender, Microsoft.UI.Xaml.Data.CurrentChangingEventArgs e);
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
@@ -2556,6 +2560,7 @@ namespace Microsoft.UI.Xaml
         [interface_name("Microsoft.UI.Xaml.IFrameworkElementFeature_ExperimentalApi")]
         {
             void SetThemeResourceBinding(Microsoft.UI.Xaml.DependencyProperty property, String resourceKey);
+            void SetCompiledBinding(Microsoft.UI.Xaml.DependencyProperty dp, Microsoft.UI.Xaml.Data.CompiledBindingGetter getter);
         }
     };
 

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes.idl
@@ -1570,6 +1570,10 @@ namespace Microsoft.UI.Xaml.Data
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
     [webhosthidden]
+    delegate void CompiledBindingSetter(Object source, Object value);
+
+    [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
+    [webhosthidden]
     delegate void CurrentChangingEventHandler(Object sender, Microsoft.UI.Xaml.Data.CurrentChangingEventArgs e);
 
     [contract(Microsoft.UI.Xaml.WinUIContract, 1)]
@@ -2560,7 +2564,8 @@ namespace Microsoft.UI.Xaml
         [interface_name("Microsoft.UI.Xaml.IFrameworkElementFeature_ExperimentalApi")]
         {
             void SetThemeResourceBinding(Microsoft.UI.Xaml.DependencyProperty property, String resourceKey);
-            void SetCompiledBinding(Microsoft.UI.Xaml.DependencyProperty dp, Microsoft.UI.Xaml.Data.CompiledBindingGetter getter);
+            [method_name("SetCompiledBinding")] void SetCompiledBinding(Microsoft.UI.Xaml.DependencyProperty dp, Microsoft.UI.Xaml.Data.CompiledBindingGetter getter);
+            [method_name("SetCompiledBindingWithSetter")] void SetCompiledBinding(Microsoft.UI.Xaml.DependencyProperty dp, Microsoft.UI.Xaml.Data.CompiledBindingGetter getter, Microsoft.UI.Xaml.Data.CompiledBindingSetter setter);
         }
     };
 

--- a/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
+++ b/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
@@ -1,0 +1,340 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//  Abstract:
+//      Expression used to evaluate a programmatic compiled binding by invoking an
+//      app-supplied getter delegate against a source object.
+
+#include "precomp.h"
+#include "FrameworkElement.g.h"
+#include "CompiledBindingExpression.h"
+
+using namespace DirectUI;
+using namespace DirectUISynonyms;
+
+class DirectUI::CompiledBindingExpressionDataContextChangedHandler final :
+    public ctl::implements<IDataContextChangedHandler>
+{
+public:
+    explicit CompiledBindingExpressionDataContextChangedHandler(_In_ CompiledBindingExpression* pExpression)
+    {
+        VERIFYHR(ctl::AsWeak(pExpression, &m_spWeakRef));
+    }
+
+    _Check_return_ HRESULT Invoke(
+        _In_ DependencyObject* pSender,
+        _In_ const DataContextChangedParams* pArgs) override
+    {
+        ctl::ComPtr<xaml_data::IBindingExpressionBase> spExpressionInterface;
+        IFC_RETURN(m_spWeakRef.As(&spExpressionInterface));
+
+        auto pExpression = spExpressionInterface.Cast<CompiledBindingExpression>();
+        auto pegClass = ctl::try_make_autopeg(pExpression);
+        if (pegClass)
+        {
+            IFC_RETURN(pExpression->OnDataContextChanged(pSender, pArgs));
+        }
+
+        return S_OK;
+    }
+
+private:
+    ctl::WeakRefPtr m_spWeakRef;
+};
+
+CompiledBindingExpression::~CompiledBindingExpression()
+{
+    m_spSourceRef.Reset();
+    m_spGetter.Reset();
+    m_spDataContextChangedHandler.Reset();
+    m_pTarget = nullptr;
+}
+
+// Factory method modeled after DirectSourceBindingExpression::Create.
+_Check_return_ HRESULT CompiledBindingExpression::Create(
+    _In_opt_ IInspectable* pSource,
+    _In_ xaml_data::ICompiledBindingGetter* pGetter,
+    _Out_ CompiledBindingExpression** ppExpression)
+{
+    IFCPTR_RETURN(pGetter);
+    IFCPTR_RETURN(ppExpression);
+
+    ctl::ComPtr<CompiledBindingExpression> spExpression;
+    IFC_RETURN(ctl::ComObject<CompiledBindingExpression>::CreateInstance(spExpression.ReleaseAndGetAddressOf()));
+
+    IFC_RETURN(spExpression->SetSource(pSource));
+
+    // Strong reference to the getter delegate: this is what keeps the app's lambda (and its
+    // captured state) alive for the lifetime of the binding.
+    spExpression->m_spGetter = pGetter;
+
+    *ppExpression = spExpression.Detach();
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::GetCanSetValue(_Out_ bool *pValue)
+{
+    // OneWay only: setting a local value replaces (removes) the expression, and there is no
+    // write-back path to the source.
+    *pValue = false;
+    return S_OK;
+}
+
+bool CompiledBindingExpression::GetIsAssociated()
+{
+    return !!m_pTarget;
+}
+
+// Attach lifecycle follows the same pattern as DirectSourceBindingExpression::OnAttach.
+_Check_return_ HRESULT CompiledBindingExpression::OnAttach(
+    _In_ DependencyObject* pTarget,
+    _In_ const CDependencyProperty* pTargetProperty)
+{
+    IFCPTR_RETURN(pTarget);
+    IFCPTR_RETURN(pTargetProperty);
+    IFCEXPECT_RETURN(!m_bRegisteredForSourceChanges);
+
+    m_pTarget = pTarget;    // No reference
+    m_pTargetProperty = pTargetProperty;
+
+    auto attachCleanupGuard = wil::scope_exit([this]
+    {
+        VERIFYHR(OnDetach());
+    });
+
+    auto spTargetAsFrameworkElementInterface = ctl::query_interface_cast<xaml::IFrameworkElement>(pTarget);
+    auto spTargetAsFrameworkElement = spTargetAsFrameworkElementInterface.AsOrNull<FrameworkElement>();
+    if (spTargetAsFrameworkElement)
+    {
+        ctl::ComPtr<IDataContextChangedEventSource> spEventSource;
+        ctl::ComPtr<CompiledBindingExpressionDataContextChangedHandler> spHandler;
+        spHandler.Attach(new CompiledBindingExpressionDataContextChangedHandler(this));
+        m_spDataContextChangedHandler = spHandler;
+
+        IFC_RETURN(spTargetAsFrameworkElement->GetDataContextChangedSource(&spEventSource));
+        IFC_RETURN(spEventSource->AddHandler(m_spDataContextChangedHandler.Get()));
+        m_bRegisteredForDataContextChanges = true;
+    }
+
+    // Resolve the source and, if it supports change notification, register for it.
+    ctl::ComPtr<IInspectable> spSource;
+    IFC_RETURN(GetSource(&spSource));
+
+    if (spSource)
+    {
+        IFC_RETURN(AttachSourceChangedHandler(spSource.Get()));
+    }
+
+    attachCleanupGuard.release();
+    return S_OK;
+}
+
+// Detach lifecycle follows the same pattern as DirectSourceBindingExpression::OnDetach.
+_Check_return_ HRESULT CompiledBindingExpression::OnDetach()
+{
+    if (m_pTarget == nullptr && m_pTargetProperty == nullptr)
+    {
+        // Already detached
+        ASSERT(!m_bRegisteredForSourceChanges);
+        return S_OK;
+    }
+
+    if (m_bRegisteredForDataContextChanges)
+    {
+        auto spTargetAsFrameworkElementInterface = ctl::query_interface_cast<xaml::IFrameworkElement>(m_pTarget);
+        auto spTargetAsFrameworkElement = spTargetAsFrameworkElementInterface.AsOrNull<FrameworkElement>();
+        if (spTargetAsFrameworkElement)
+        {
+            ctl::ComPtr<IDataContextChangedEventSource> spEventSource;
+            IFC_RETURN(spTargetAsFrameworkElement->GetDataContextChangedSource(&spEventSource));
+            IFC_RETURN(spEventSource->RemoveHandler(m_spDataContextChangedHandler.Get()));
+        }
+        m_bRegisteredForDataContextChanges = false;
+        m_spDataContextChangedHandler.Reset();
+    }
+
+    // Unregister from source change notifications.
+    if (m_bRegisteredForSourceChanges)
+    {
+        ctl::ComPtr<IInspectable> spSource;
+        if (SUCCEEDED(GetSource(&spSource)) && spSource)
+        {
+            IFC_RETURN(DetachSourceChangedHandler(spSource.Get()));
+        }
+        m_bRegisteredForSourceChanges = false;
+    }
+
+    m_pTarget = nullptr;
+    m_pTargetProperty = nullptr;
+
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::GetValue(
+    _In_ DependencyObject* pObject,
+    _In_ const CDependencyProperty* pProperty,
+    _Out_ IInspectable** ppValue)
+{
+    IFCPTR_RETURN(ppValue);
+    IFCEXPECT_RETURN(m_pTarget);
+    IFCEXPECT_RETURN(m_pTargetProperty);
+
+    // A getter can synchronously change DataContext. Re-evaluate against the replacement source
+    // before returning so the outer property-system update cannot overwrite the refreshed value.
+    m_ignoreSourceChanges = true;
+    auto ignoreSourceChangesGuard = wil::scope_exit([&]
+    {
+        m_ignoreSourceChanges = false;
+    });
+
+    ctl::ComPtr<IInspectable> spValue;
+    do
+    {
+        m_pendingDataContextChange = false;
+
+        ctl::ComPtr<IInspectable> spSource;
+        IFC_RETURN(GetSource(&spSource));
+        spValue.Reset();
+
+        if (spSource == nullptr)
+        {
+            IFC_RETURN(m_pTarget->GetDefaultValueInternal(
+                m_pTargetProperty,
+                spValue.ReleaseAndGetAddressOf()));
+        }
+        else
+        {
+            // SYNC_CALL_TO_APP DIRECT - This next line may directly call out to app code.
+            IFC_RETURN(m_spGetter->Invoke(spSource.Get(), spValue.ReleaseAndGetAddressOf()));
+        }
+    }
+    while (m_pendingDataContextChange);
+
+    *ppValue = spValue.Detach();
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::OnSourceChanged()
+{
+    if (!m_ignoreSourceChanges)
+    {
+        IFCEXPECT_RETURN(m_pTarget);
+        IFCEXPECT_RETURN(m_pTargetProperty);
+
+        // Re-pull the value; RefreshExpression calls back into GetValue, which re-invokes the getter.
+        IFC_RETURN(m_pTarget->RefreshExpression(m_pTargetProperty));
+    }
+
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::AttachSourceChangedHandler(_In_ IInspectable* pSource)
+{
+    IFCEXPECT_RETURN(!m_bRegisteredForSourceChanges);
+
+    // Only sources that raise INotifyPropertyChanged can update the binding. A source without it
+    // yields a single evaluation at attach time (equivalent to OneTime), which is acceptable.
+    ctl::ComPtr<xaml_data::INotifyPropertyChanged> spINPC;
+    if ((spINPC = ctl::query_interface_cast<xaml_data::INotifyPropertyChanged>(pSource)))
+    {
+        // Unlike INPCListenerBase, the getter is opaque, so we cannot filter by PropertyName -
+        // we re-evaluate on EVERY notification (including the empty/null "everything changed"
+        // name). This mirrors how {x:Bind} re-runs a function binding it cannot decompose.
+        IFC_RETURN(m_epSourceChangedHandler.AttachEventHandler(spINPC.Get(),
+            [this](IInspectable*, xaml_data::IPropertyChangedEventArgs*)
+            {
+                return OnSourceChanged();
+            }));
+        m_bRegisteredForSourceChanges = true;
+    }
+
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::DetachSourceChangedHandler(_In_ IInspectable* pSource)
+{
+    if (m_epSourceChangedHandler)
+    {
+        IFC_RETURN(m_epSourceChangedHandler.DetachEventHandler(pSource));
+    }
+
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::GetSource(
+    _Outptr_result_maybenull_ IInspectable** ppSource)
+{
+    IFCPTR_RETURN(ppSource);
+    *ppSource = nullptr;
+
+    if (!DXamlCore::GetCurrent()->IsShuttingDown())
+    {
+        if (m_spSourceRef)
+        {
+            IFC_RETURN(ctl::resolve_weakref(m_spSourceRef.Get(), *ppSource));
+        }
+    }
+
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::SetSource(_In_opt_ IInspectable* pSource)
+{
+    if (m_bRegisteredForSourceChanges)
+    {
+        ctl::ComPtr<IInspectable> spOldSource;
+        IFC_RETURN(GetSource(&spOldSource));
+        if (spOldSource)
+        {
+            IFC_RETURN(DetachSourceChangedHandler(spOldSource.Get()));
+        }
+        m_bRegisteredForSourceChanges = false;
+    }
+
+    m_spSourceRef.Reset();
+    if (pSource)
+    {
+        IWeakReference* pSourceRef = nullptr;
+        IFC_RETURN(ctl::as_weakref(pSourceRef, pSource));
+        m_spSourceRef.Attach(pSourceRef);
+
+        if (m_pTarget)
+        {
+            IFC_RETURN(AttachSourceChangedHandler(pSource));
+        }
+    }
+
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::OnDataContextChanged(
+    _In_ DependencyObject* pSender,
+    _In_ const DataContextChangedParams* pArgs)
+{
+    IFCPTR_RETURN(pSender);
+    IFCPTR_RETURN(pArgs);
+
+    ctl::ComPtr<IInspectable> spDataContext;
+    auto spFrameworkElementInterface = ctl::query_interface_cast<xaml::IFrameworkElement>(pSender);
+    auto spFrameworkElement = spFrameworkElementInterface.AsOrNull<FrameworkElement>();
+    IFCEXPECT_RETURN(spFrameworkElement);
+
+    if (pArgs->m_fResolvedNewDataContext && !spFrameworkElement->IsDataContextBound())
+    {
+        IFC_RETURN(pArgs->GetNewDataContext(&spDataContext));
+    }
+    else
+    {
+        IFC_RETURN(spFrameworkElement->get_DataContext(&spDataContext));
+    }
+
+    IFC_RETURN(SetSource(spDataContext.Get()));
+
+    if (m_ignoreSourceChanges)
+    {
+        m_pendingDataContextChange = true;
+        return S_OK;
+    }
+
+    return OnSourceChanged();
+}

--- a/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
+++ b/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
@@ -179,36 +179,34 @@ _Check_return_ HRESULT CompiledBindingExpression::GetValue(
     IFCEXPECT_RETURN(m_pTarget);
     IFCEXPECT_RETURN(m_pTargetProperty);
 
-    // A getter can synchronously change DataContext. Re-evaluate against the replacement source
-    // before returning so the outer property-system update cannot overwrite the refreshed value.
     m_ignoreSourceChanges = true;
     auto ignoreSourceChangesGuard = wil::scope_exit([&]
     {
         m_ignoreSourceChanges = false;
     });
 
+    m_dataContextChangedDuringEvaluation = false;
+
+    ctl::ComPtr<IInspectable> spSource;
+    IFC_RETURN(GetSource(&spSource));
+
     ctl::ComPtr<IInspectable> spValue;
-    do
+    if (spSource == nullptr)
     {
-        m_pendingDataContextChange = false;
-
-        ctl::ComPtr<IInspectable> spSource;
-        IFC_RETURN(GetSource(&spSource));
-        spValue.Reset();
-
-        if (spSource == nullptr)
-        {
-            IFC_RETURN(m_pTarget->GetDefaultValueInternal(
-                m_pTargetProperty,
-                spValue.ReleaseAndGetAddressOf()));
-        }
-        else
-        {
-            // SYNC_CALL_TO_APP DIRECT - This next line may directly call out to app code.
-            IFC_RETURN(m_spGetter->Invoke(spSource.Get(), spValue.ReleaseAndGetAddressOf()));
-        }
+        IFC_RETURN(m_pTarget->GetDefaultValueInternal(
+            m_pTargetProperty,
+            spValue.ReleaseAndGetAddressOf()));
     }
-    while (m_pendingDataContextChange);
+    else
+    {
+        // SYNC_CALL_TO_APP DIRECT - This next line may directly call out to app code.
+        IFC_RETURN(m_spGetter->Invoke(spSource.Get(), spValue.ReleaseAndGetAddressOf()));
+    }
+
+    if (m_dataContextChangedDuringEvaluation)
+    {
+        return E_INVALID_OPERATION;
+    }
 
     *ppValue = spValue.Detach();
     return S_OK;
@@ -332,7 +330,7 @@ _Check_return_ HRESULT CompiledBindingExpression::OnDataContextChanged(
 
     if (m_ignoreSourceChanges)
     {
-        m_pendingDataContextChange = true;
+        m_dataContextChangedDuringEvaluation = true;
         return S_OK;
     }
 

--- a/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
+++ b/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
@@ -42,11 +42,43 @@ private:
     ctl::WeakRefPtr m_spWeakRef;
 };
 
+class DirectUI::CompiledBindingExpressionDPChangedHandler final :
+    public ctl::implements<IDPChangedEventHandler>
+{
+public:
+    explicit CompiledBindingExpressionDPChangedHandler(_In_ CompiledBindingExpression* pExpression)
+    {
+        VERIFYHR(ctl::AsWeak(pExpression, &m_spWeakRef));
+    }
+
+    _Check_return_ HRESULT Invoke(
+        _In_ xaml::IDependencyObject*,
+        _In_ const CDependencyProperty* pDP) override
+    {
+        ctl::ComPtr<xaml_data::IBindingExpressionBase> spExpressionInterface;
+        IFC_RETURN(m_spWeakRef.As(&spExpressionInterface));
+
+        auto pExpression = spExpressionInterface.Cast<CompiledBindingExpression>();
+        auto pegClass = ctl::try_make_autopeg(pExpression);
+        if (pegClass && pDP->GetIndex() == pExpression->m_pTargetProperty->GetIndex())
+        {
+            IFC_RETURN(pExpression->OnTargetChanged());
+        }
+
+        return S_OK;
+    }
+
+private:
+    ctl::WeakRefPtr m_spWeakRef;
+};
+
 CompiledBindingExpression::~CompiledBindingExpression()
 {
     m_spSourceRef.Reset();
     m_spGetter.Reset();
+    m_spSetter.Reset();
     m_spDataContextChangedHandler.Reset();
+    m_spTargetChangedHandler.Reset();
     m_pTarget = nullptr;
 }
 
@@ -54,6 +86,7 @@ CompiledBindingExpression::~CompiledBindingExpression()
 _Check_return_ HRESULT CompiledBindingExpression::Create(
     _In_opt_ IInspectable* pSource,
     _In_ xaml_data::ICompiledBindingGetter* pGetter,
+    _In_opt_ xaml_data::ICompiledBindingSetter* pSetter,
     _Out_ CompiledBindingExpression** ppExpression)
 {
     IFCPTR_RETURN(pGetter);
@@ -67,6 +100,7 @@ _Check_return_ HRESULT CompiledBindingExpression::Create(
     // Strong reference to the getter delegate: this is what keeps the app's lambda (and its
     // captured state) alive for the lifetime of the binding.
     spExpression->m_spGetter = pGetter;
+    spExpression->m_spSetter = pSetter;
 
     *ppExpression = spExpression.Detach();
     return S_OK;
@@ -74,9 +108,7 @@ _Check_return_ HRESULT CompiledBindingExpression::Create(
 
 _Check_return_ HRESULT CompiledBindingExpression::GetCanSetValue(_Out_ bool *pValue)
 {
-    // OneWay only: setting a local value replaces (removes) the expression, and there is no
-    // write-back path to the source.
-    *pValue = false;
+    *pValue = !!m_spSetter;
     return S_OK;
 }
 
@@ -136,8 +168,18 @@ _Check_return_ HRESULT CompiledBindingExpression::OnDetach()
     {
         // Already detached
         ASSERT(!m_bRegisteredForSourceChanges);
+        ASSERT(!m_bRegisteredForTargetChanges);
         return S_OK;
     }
+
+    if (m_bRegisteredForTargetChanges)
+    {
+        ctl::ComPtr<IDPChangedEventSource> spEventSource;
+        IFC_RETURN(m_pTarget->GetDPChangedEventSource(&spEventSource));
+        IFC_RETURN(spEventSource->RemoveHandler(m_spTargetChangedHandler.Get()));
+        m_bRegisteredForTargetChanges = false;
+    }
+    m_spTargetChangedHandler.Reset();
 
     if (m_bRegisteredForDataContextChanges)
     {
@@ -214,13 +256,92 @@ _Check_return_ HRESULT CompiledBindingExpression::GetValue(
 
 _Check_return_ HRESULT CompiledBindingExpression::OnSourceChanged()
 {
+    if (m_updatingSource)
+    {
+        m_sourceChangedDuringUpdate = true;
+        return S_OK;
+    }
+
     if (!m_ignoreSourceChanges)
     {
-        IFCEXPECT_RETURN(m_pTarget);
-        IFCEXPECT_RETURN(m_pTargetProperty);
+        IFC_RETURN(RefreshTarget());
+    }
 
-        // Re-pull the value; RefreshExpression calls back into GetValue, which re-invokes the getter.
-        IFC_RETURN(m_pTarget->RefreshExpression(m_pTargetProperty));
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::RefreshTarget()
+{
+    IFCEXPECT_RETURN(m_pTarget);
+    IFCEXPECT_RETURN(m_pTargetProperty);
+
+    m_ignoreTargetChanges = true;
+    auto ignoreTargetChangesGuard = wil::scope_exit([this]
+    {
+        m_ignoreTargetChanges = false;
+    });
+
+    // Re-pull the value; RefreshExpression calls back into GetValue, which re-invokes the getter.
+    return m_pTarget->RefreshExpression(m_pTargetProperty);
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::ConnectToTargetChanges()
+{
+    IFCEXPECT_RETURN(m_spSetter);
+    IFCEXPECT_RETURN(m_pTarget);
+    IFCEXPECT_RETURN(!m_bRegisteredForTargetChanges);
+
+    ctl::ComPtr<IDPChangedEventSource> spEventSource;
+    ctl::ComPtr<CompiledBindingExpressionDPChangedHandler> spHandler;
+    spHandler.Attach(new CompiledBindingExpressionDPChangedHandler(this));
+
+    IFC_RETURN(m_pTarget->GetDPChangedEventSource(&spEventSource));
+    IFC_RETURN(spEventSource->AddHandler(spHandler.Get()));
+
+    m_spTargetChangedHandler = spHandler;
+    m_bRegisteredForTargetChanges = true;
+    return S_OK;
+}
+
+_Check_return_ HRESULT CompiledBindingExpression::OnTargetChanged()
+{
+    if (m_ignoreTargetChanges || m_updatingSource)
+    {
+        return S_OK;
+    }
+
+    IFCEXPECT_RETURN(m_spSetter);
+
+    ctl::ComPtr<IInspectable> spSource;
+    IFC_RETURN(GetSource(&spSource));
+    if (!spSource)
+    {
+        return S_OK;
+    }
+
+    ctl::ComPtr<IInspectable> spValue;
+    IFC_RETURN(m_pTarget->GetValue(m_pTargetProperty, &spValue));
+
+    m_updatingSource = true;
+    m_sourceChangedDuringUpdate = false;
+    auto updatingSourceGuard = wil::scope_exit([this]
+    {
+        m_updatingSource = false;
+    });
+
+    // SYNC_CALL_TO_APP DIRECT - This next line may directly call out to app code.
+    IFC_RETURN(m_spSetter->Invoke(spSource.Get(), spValue.Get()));
+
+    m_updatingSource = false;
+    updatingSourceGuard.release();
+
+    if (m_sourceChangedDuringUpdate)
+    {
+        m_sourceChangedDuringUpdate = false;
+        if (m_pTarget)
+        {
+            IFC_RETURN(RefreshTarget());
+        }
     }
 
     return S_OK;

--- a/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
+++ b/dxaml/xcp/dxaml/lib/CompiledBindingExpression.cpp
@@ -51,7 +51,7 @@ public:
         VERIFYHR(ctl::AsWeak(pExpression, &m_spWeakRef));
     }
 
-    _Check_return_ HRESULT Invoke(
+    IFACEMETHODIMP Invoke(
         _In_ xaml::IDependencyObject*,
         _In_ const CDependencyProperty* pDP) override
     {
@@ -296,9 +296,9 @@ _Check_return_ HRESULT CompiledBindingExpression::ConnectToTargetChanges()
     spHandler.Attach(new CompiledBindingExpressionDPChangedHandler(this));
 
     IFC_RETURN(m_pTarget->GetDPChangedEventSource(&spEventSource));
-    IFC_RETURN(spEventSource->AddHandler(spHandler.Get()));
+    IFC_RETURN(spHandler.As(&m_spTargetChangedHandler));
+    IFC_RETURN(spEventSource->AddHandler(m_spTargetChangedHandler.Get()));
 
-    m_spTargetChangedHandler = spHandler;
     m_bRegisteredForTargetChanges = true;
     return S_OK;
 }

--- a/dxaml/xcp/dxaml/lib/CompiledBindingExpression.h
+++ b/dxaml/xcp/dxaml/lib/CompiledBindingExpression.h
@@ -86,7 +86,7 @@ namespace DirectUI
         bool m_bRegisteredForSourceChanges = false;                    // Flag indicating registration with source's PropertyChanged event
         bool m_bRegisteredForDataContextChanges = false;
         bool m_ignoreSourceChanges = false;                            // Flag to ignore source notifications while we are producing a value
-        bool m_pendingDataContextChange = false;
+        bool m_dataContextChangedDuringEvaluation = false;
 
         // Re-invoke the getter and push the value into the target when the source changes.
         _Check_return_ HRESULT OnSourceChanged();

--- a/dxaml/xcp/dxaml/lib/CompiledBindingExpression.h
+++ b/dxaml/xcp/dxaml/lib/CompiledBindingExpression.h
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+//  Abstract:
+//      Expression used to evaluate a programmatic compiled binding: the value is
+//      produced by invoking an app-supplied getter delegate against a source object,
+//      rather than by walking a property path.
+//
+//      This is the runtime primitive behind a programmatic "compiled binding" - the
+//      code-behind analog of {x:Bind}. The app supplies a delegate that maps the
+//      source object to the target value (for example, a lambda that reads and
+//      combines properties off a view model). The expression keeps the delegate
+//      alive, re-invokes it whenever the source raises INotifyPropertyChanged, and
+//      writes the result into the target dependency property.
+//
+//      Modeled on DirectSourceBindingExpression (which is itself modeled on
+//      TemplateBindingExpression). The member layout, attach/detach lifecycle, weak
+//      source / no-ref target ownership model, and reentrancy guard are all the same.
+//      The two deliberate differences are:
+//        1. Source change tracking uses INotifyPropertyChanged rather than a single
+//           source dependency property. Because the getter is opaque, the expression
+//           cannot know which source property the value depends on, so it re-evaluates
+//           on EVERY notification from the source (including the "all properties
+//           changed" empty/null PropertyName), matching what {x:Bind} does when it
+//           binds a function against a receiver it cannot decompose.
+//        2. GetValue invokes the getter delegate instead of reading a source property.
+//
+//      Limited to OneWay:
+//        - OneTime would be a plain property set from app code, so it needs no
+//          expression at all.
+//        - TwoWay would require a second (setter) delegate plus an
+//          UpdateSourceTrigger / reentrancy-loop story, which is more than a single
+//          getter delegate can express. See BindingExpression for the full TwoWay
+//          engine.
+
+#pragma once
+
+#include "BindingExpressionBase.g.h"
+// PropertyChangedEventCallback (from EventCallbacks.h) and the projected xaml_data types are
+// provided via precomp.h, which every consuming translation unit includes first - matching how
+// INPCListenerBase.h declares its EventPtr<PropertyChangedEventCallback> member.
+
+namespace DirectUI
+{
+    class CompiledBindingExpressionDataContextChangedHandler;
+
+    // Lightweight binding expression for a programmatic compiled binding: an app-supplied
+    // getter delegate produces the value from a source object, and the expression
+    // re-evaluates whenever the source raises INotifyPropertyChanged.
+    //
+    // Reference ownership notes (same model as DirectSourceBindingExpression):
+    // - Source: The expression holds a weak reference (IWeakReference) to the source to
+    //   avoid cycles, since the source's PropertyChanged event holds a strong reference
+    //   to this expression's handler.
+    // - Getter: The expression holds a STRONG reference to the getter delegate. The
+    //   target owns the expression (via EffectiveValueEntry), the expression owns the
+    //   getter, and the getter is what keeps the app's lambda (and its captures) alive
+    //   for the lifetime of the binding. This is not a cycle: the getter does not
+    //   reference the target. When the target tears the expression down (OnDetach ->
+    //   release), the getter - and the lambda it wraps - is released with it.
+    // - Target: The expression holds a no-ref raw pointer to the target. This is safe
+    //   because the target owns this expression. The expression cannot outlive the
+    //   target - OnDetach is always called before the expression is released, which
+    //   clears m_pTarget.
+    class CompiledBindingExpression :
+        public BindingExpressionBase
+    {
+
+    protected:
+        CompiledBindingExpression() = default;
+        ~CompiledBindingExpression() override;
+
+        // Non-copyable, non-movable (pointers and registration state are not safe to duplicate)
+        CompiledBindingExpression(const CompiledBindingExpression&) = delete;
+        CompiledBindingExpression& operator=(const CompiledBindingExpression&) = delete;
+        CompiledBindingExpression(CompiledBindingExpression&&) = delete;
+        CompiledBindingExpression& operator=(CompiledBindingExpression&&) = delete;
+
+    private:
+        ctl::ComPtr<IWeakReference> m_spSourceRef;                       // Weak reference to source object
+        ctl::ComPtr<xaml_data::ICompiledBindingGetter> m_spGetter;      // Strong ref: app getter delegate (keeps the lambda alive)
+        DependencyObject* m_pTarget = nullptr;                          // The target instance (no-ref, kept valid by attach/detach lifecycle)
+        const CDependencyProperty* m_pTargetProperty = nullptr;         // The target property
+        ctl::EventPtr<PropertyChangedEventCallback> m_epSourceChangedHandler; // INPC subscription on the source
+        ctl::ComPtr<IDataContextChangedHandler> m_spDataContextChangedHandler;
+        bool m_bRegisteredForSourceChanges = false;                    // Flag indicating registration with source's PropertyChanged event
+        bool m_bRegisteredForDataContextChanges = false;
+        bool m_ignoreSourceChanges = false;                            // Flag to ignore source notifications while we are producing a value
+        bool m_pendingDataContextChange = false;
+
+        // Re-invoke the getter and push the value into the target when the source changes.
+        _Check_return_ HRESULT OnSourceChanged();
+
+        // Resolves the (weakly-held) source object; may be null if it has been collected.
+        _Check_return_ HRESULT GetSource(_Outptr_result_maybenull_ IInspectable** ppSource);
+
+        // Attaches / detaches the INotifyPropertyChanged handler on the source.
+        _Check_return_ HRESULT AttachSourceChangedHandler(_In_ IInspectable* pSource);
+        _Check_return_ HRESULT DetachSourceChangedHandler(_In_ IInspectable* pSource);
+
+        _Check_return_ HRESULT SetSource(_In_opt_ IInspectable* pSource);
+        _Check_return_ HRESULT OnDataContextChanged(
+            _In_ DependencyObject* pSender,
+            _In_ const DataContextChangedParams* pArgs);
+
+        friend class CompiledBindingExpressionDataContextChangedHandler;
+
+    public:
+        // Creates a new instance of CompiledBindingExpression.
+        // pSource: The source object the getter reads from (typically the DataContext). May be null and may implement
+        //          INotifyPropertyChanged; if it does not, the binding evaluates once and never updates.
+        // pGetter: The app-supplied getter delegate that maps the source to the target value. Required.
+        static _Check_return_ HRESULT Create(
+            _In_opt_ IInspectable* pSource,
+            _In_ xaml_data::ICompiledBindingGetter* pGetter,
+            _Out_ CompiledBindingExpression** ppExpression);
+
+    // BindingExpressionBase members
+        _Check_return_ HRESULT GetCanSetValue(_Out_ bool *pValue) override;
+        bool GetIsAssociated() override;
+        _Check_return_ HRESULT OnAttach(
+            _In_ DependencyObject* pTarget,
+            _In_ const CDependencyProperty* pTargetProperty) override;
+        _Check_return_ HRESULT OnDetach() override;
+        _Check_return_ HRESULT GetValue(
+            _In_ DependencyObject* pObject,
+            _In_ const CDependencyProperty* pProperty,
+            _Out_ IInspectable** ppValue) override;
+    };
+}

--- a/dxaml/xcp/dxaml/lib/CompiledBindingExpression.h
+++ b/dxaml/xcp/dxaml/lib/CompiledBindingExpression.h
@@ -2,9 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 //  Abstract:
-//      Expression used to evaluate a programmatic compiled binding: the value is
-//      produced by invoking an app-supplied getter delegate against a source object,
-//      rather than by walking a property path.
+//      Expression used to evaluate a programmatic compiled binding: a getter produces
+//      the target value and an optional setter writes target changes back to the source.
 //
 //      This is the runtime primitive behind a programmatic "compiled binding" - the
 //      code-behind analog of {x:Bind}. The app supplies a delegate that maps the
@@ -25,13 +24,8 @@
 //           binds a function against a receiver it cannot decompose.
 //        2. GetValue invokes the getter delegate instead of reading a source property.
 //
-//      Limited to OneWay:
-//        - OneTime would be a plain property set from app code, so it needs no
-//          expression at all.
-//        - TwoWay would require a second (setter) delegate plus an
-//          UpdateSourceTrigger / reentrancy-loop story, which is more than a single
-//          getter delegate can express. See BindingExpression for the full TwoWay
-//          engine.
+//      A getter-only expression is OneWay. Supplying a setter makes it TwoWay with
+//      immediate target-to-source updates.
 
 #pragma once
 
@@ -43,6 +37,7 @@
 namespace DirectUI
 {
     class CompiledBindingExpressionDataContextChangedHandler;
+    class CompiledBindingExpressionDPChangedHandler;
 
     // Lightweight binding expression for a programmatic compiled binding: an app-supplied
     // getter delegate produces the value from a source object, and the expression
@@ -79,17 +74,40 @@ namespace DirectUI
     private:
         ctl::ComPtr<IWeakReference> m_spSourceRef;                       // Weak reference to source object
         ctl::ComPtr<xaml_data::ICompiledBindingGetter> m_spGetter;      // Strong ref: app getter delegate (keeps the lambda alive)
+        ctl::ComPtr<xaml_data::ICompiledBindingSetter> m_spSetter;      // Strong ref: optional app setter delegate
         DependencyObject* m_pTarget = nullptr;                          // The target instance (no-ref, kept valid by attach/detach lifecycle)
         const CDependencyProperty* m_pTargetProperty = nullptr;         // The target property
         ctl::EventPtr<PropertyChangedEventCallback> m_epSourceChangedHandler; // INPC subscription on the source
         ctl::ComPtr<IDataContextChangedHandler> m_spDataContextChangedHandler;
+        ctl::ComPtr<IDPChangedEventHandler> m_spTargetChangedHandler;
         bool m_bRegisteredForSourceChanges = false;                    // Flag indicating registration with source's PropertyChanged event
         bool m_bRegisteredForDataContextChanges = false;
-        bool m_ignoreSourceChanges = false;                            // Flag to ignore source notifications while we are producing a value
+        bool m_bRegisteredForTargetChanges = false;
+
+        // Flags to ignore loops between getter delegates and setter delegates
+
+        // If calling the getter delegate causes another source.PropertyChanged event, ignore the second one(s) to avoid infinite loops
+        bool m_ignoreSourceChanges = false;
+
+        // When updating the target, ignore further target changes so we don't write back to the source for a TwoWay binding
+        bool m_ignoreTargetChanges = false;
+
+        // Set while writing back to the source during a target change for a TwoWay binding. Defer further source changes
+        // until the write is done. Ignore further (reentrant) target changes.
+        bool m_updatingSource = false;
+
+        // During a TwoWay write back to the source, if something would trigger another target update (the source raises PropertyChanged,
+        // a new source is set, or the effective DataContext changes), then update the target once after the write is complete.
+        // Ignore further target changes during that update to prevent writing back to the source again.
+        bool m_sourceChangedDuringUpdate = false;
+
+        // If the DataContext changes while we're calling the getter delegate, return an error.
         bool m_dataContextChangedDuringEvaluation = false;
 
         // Re-invoke the getter and push the value into the target when the source changes.
         _Check_return_ HRESULT OnSourceChanged();
+        _Check_return_ HRESULT OnTargetChanged();
+        _Check_return_ HRESULT RefreshTarget();
 
         // Resolves the (weakly-held) source object; may be null if it has been collected.
         _Check_return_ HRESULT GetSource(_Outptr_result_maybenull_ IInspectable** ppSource);
@@ -104,6 +122,7 @@ namespace DirectUI
             _In_ const DataContextChangedParams* pArgs);
 
         friend class CompiledBindingExpressionDataContextChangedHandler;
+        friend class CompiledBindingExpressionDPChangedHandler;
 
     public:
         // Creates a new instance of CompiledBindingExpression.
@@ -113,7 +132,12 @@ namespace DirectUI
         static _Check_return_ HRESULT Create(
             _In_opt_ IInspectable* pSource,
             _In_ xaml_data::ICompiledBindingGetter* pGetter,
+            _In_opt_ xaml_data::ICompiledBindingSetter* pSetter,
             _Out_ CompiledBindingExpression** ppExpression);
+
+        // Called after the expression is installed so initial getter evaluation cannot
+        // be observed as a target edit.
+        _Check_return_ HRESULT ConnectToTargetChanges();
 
     // BindingExpressionBase members
         _Check_return_ HRESULT GetCanSetValue(_Out_ bool *pValue) override;

--- a/dxaml/xcp/dxaml/lib/DXamlCore.cpp
+++ b/dxaml/xcp/dxaml/lib/DXamlCore.cpp
@@ -92,6 +92,7 @@
 #include "BindingExpression.g.h"
 #include "PropertyPath.g.h"
 #include "DirectSourceBindingExpression.h"
+#include "CompiledBindingExpression.h"
 #include "Callback.h"
 #include "DxamlCoreTestHooks.g.h"
 #include "NullKeyedResource.g.h"
@@ -4707,6 +4708,26 @@ bool DXamlCore::TryGetXamlIslandBoundsForElement(_In_opt_ CDependencyObject* dep
         source,
         pSourceProperty,
         converter,
+        spExpression.ReleaseAndGetAddressOf()));
+
+    // Attach the expression to the target using the public SetExpressionCore method
+    IFC_RETURN(target->SetExpressionCore(pTargetProperty, spExpression.Get(), ::BaseValueSourceUnknown));
+
+    return S_OK;
+}
+
+/* static */ _Check_return_ HRESULT DXamlCore::SetCompiledBinding(
+    _In_ IInspectable* source,
+    _In_ xaml_data::ICompiledBindingGetter* getter,
+    _In_ DependencyObject* target,
+    KnownPropertyIndex targetPropertyIndex)
+{
+    const auto* pTargetProperty = MetadataAPI::GetDependencyPropertyByIndex(targetPropertyIndex);
+
+    ctl::ComPtr<CompiledBindingExpression> spExpression;
+    IFC_RETURN(CompiledBindingExpression::Create(
+        source,
+        getter,
         spExpression.ReleaseAndGetAddressOf()));
 
     // Attach the expression to the target using the public SetExpressionCore method

--- a/dxaml/xcp/dxaml/lib/DXamlCore.cpp
+++ b/dxaml/xcp/dxaml/lib/DXamlCore.cpp
@@ -4719,6 +4719,7 @@ bool DXamlCore::TryGetXamlIslandBoundsForElement(_In_opt_ CDependencyObject* dep
 /* static */ _Check_return_ HRESULT DXamlCore::SetCompiledBinding(
     _In_ IInspectable* source,
     _In_ xaml_data::ICompiledBindingGetter* getter,
+    _In_opt_ xaml_data::ICompiledBindingSetter* setter,
     _In_ DependencyObject* target,
     KnownPropertyIndex targetPropertyIndex)
 {
@@ -4728,10 +4729,21 @@ bool DXamlCore::TryGetXamlIslandBoundsForElement(_In_opt_ CDependencyObject* dep
     IFC_RETURN(CompiledBindingExpression::Create(
         source,
         getter,
+        setter,
         spExpression.ReleaseAndGetAddressOf()));
 
     // Attach the expression to the target using the public SetExpressionCore method
     IFC_RETURN(target->SetExpressionCore(pTargetProperty, spExpression.Get(), ::BaseValueSourceUnknown));
+
+    if (setter)
+    {
+        const HRESULT hr = spExpression->ConnectToTargetChanges();
+        if (FAILED(hr))
+        {
+            VERIFYHR(target->ClearValue(pTargetProperty));
+            return hr;
+        }
+    }
 
     return S_OK;
 }

--- a/dxaml/xcp/dxaml/lib/DXamlCore.h
+++ b/dxaml/xcp/dxaml/lib/DXamlCore.h
@@ -645,6 +645,16 @@ namespace DirectUI
             _In_ CDependencyObject* target,
             KnownPropertyIndex targetPropertyIndex);
 
+        // Programmatic OneWay compiled binding: installs a CompiledBindingExpression that produces
+        // the target property's value by invoking the app-supplied getter delegate against source,
+        // re-evaluating whenever source raises INotifyPropertyChanged. This is the runtime primitive
+        // behind a code-behind SetBinding(dp, getter) overload (the code analog of {x:Bind}).
+        static _Check_return_ HRESULT SetCompiledBinding(
+            _In_ IInspectable* source,
+            _In_ xaml_data::ICompiledBindingGetter* getter,
+            _In_ DependencyObject* target,
+            KnownPropertyIndex targetPropertyIndex);
+
         void RegisterForChangeVisualStateOnDynamicScrollbarsSettingChanged(_In_ Control* control);
         void UnregisterFromDynamicScrollbarsSettingChanged(_In_ Control* element);
         _Check_return_ HRESULT OnAutoHideScrollbarsChanged();

--- a/dxaml/xcp/dxaml/lib/DXamlCore.h
+++ b/dxaml/xcp/dxaml/lib/DXamlCore.h
@@ -652,6 +652,7 @@ namespace DirectUI
         static _Check_return_ HRESULT SetCompiledBinding(
             _In_ IInspectable* source,
             _In_ xaml_data::ICompiledBindingGetter* getter,
+            _In_opt_ xaml_data::ICompiledBindingSetter* setter,
             _In_ DependencyObject* target,
             KnownPropertyIndex targetPropertyIndex);
 

--- a/dxaml/xcp/dxaml/lib/FrameworkElement_Partial.h
+++ b/dxaml/xcp/dxaml/lib/FrameworkElement_Partial.h
@@ -207,6 +207,9 @@ namespace DirectUI
         _Check_return_ HRESULT IsViewportImpl(_Out_ BOOLEAN* returnValue);
         _Check_return_ HRESULT FindNameImpl(_In_ HSTRING name, _Outptr_ IInspectable** returnValue);
         _Check_return_ HRESULT SetBindingImpl(_In_ xaml::IDependencyProperty* dp, _In_ xaml_data::IBindingBase* binding);
+        _Check_return_ HRESULT SetCompiledBindingImpl(
+            _In_ xaml::IDependencyProperty* dp,
+            _In_ xaml_data::ICompiledBindingGetter* getter);
         _Check_return_ HRESULT SetThemeResourceBindingImpl(_In_ xaml::IDependencyProperty* property, _In_ HSTRING resourceKey);
         _Check_return_ HRESULT GetBindingExpressionImpl(_In_ xaml::IDependencyProperty* dp, _Outptr_ xaml_data::IBindingExpression** returnValue);
 

--- a/dxaml/xcp/dxaml/lib/FrameworkElement_Partial.h
+++ b/dxaml/xcp/dxaml/lib/FrameworkElement_Partial.h
@@ -210,6 +210,10 @@ namespace DirectUI
         _Check_return_ HRESULT SetCompiledBindingImpl(
             _In_ xaml::IDependencyProperty* dp,
             _In_ xaml_data::ICompiledBindingGetter* getter);
+        _Check_return_ HRESULT SetCompiledBindingWithSetterImpl(
+            _In_ xaml::IDependencyProperty* dp,
+            _In_ xaml_data::ICompiledBindingGetter* getter,
+            _In_ xaml_data::ICompiledBindingSetter* setter);
         _Check_return_ HRESULT SetThemeResourceBindingImpl(_In_ xaml::IDependencyProperty* property, _In_ HSTRING resourceKey);
         _Check_return_ HRESULT GetBindingExpressionImpl(_In_ xaml::IDependencyProperty* dp, _Outptr_ xaml_data::IBindingExpression** returnValue);
 

--- a/dxaml/xcp/dxaml/lib/FrameworkElement_partial.cpp
+++ b/dxaml/xcp/dxaml/lib/FrameworkElement_partial.cpp
@@ -87,6 +87,24 @@ Cleanup:
     RRETURN(hr);
 }
 
+_Check_return_ HRESULT
+FrameworkElement::SetCompiledBindingImpl(
+    _In_ IDependencyProperty* pDP,
+    _In_ xaml_data::ICompiledBindingGetter* getter)
+{
+    ctl::ComPtr<DependencyPropertyHandle> spDP;
+    ctl::ComPtr<IInspectable> spDataContext;
+
+    IFC_RETURN(ctl::do_query_interface(spDP, pDP));
+    IFC_RETURN(get_DataContext(&spDataContext));
+
+    return DXamlCore::SetCompiledBinding(
+        spDataContext.Get(),
+        getter,
+        this,
+        spDP->GetDP()->GetIndex());
+}
+
 // Exposes the markup-only {ThemeResource} mechanism to code. Resolves the key against the current
 // tree location using a non-diagnostics tree walk, then installs a live theme resource binding on the
 // target property so it re-resolves on theme changes - reusing the same engine as markup.

--- a/dxaml/xcp/dxaml/lib/FrameworkElement_partial.cpp
+++ b/dxaml/xcp/dxaml/lib/FrameworkElement_partial.cpp
@@ -101,6 +101,27 @@ FrameworkElement::SetCompiledBindingImpl(
     return DXamlCore::SetCompiledBinding(
         spDataContext.Get(),
         getter,
+        nullptr,
+        this,
+        spDP->GetDP()->GetIndex());
+}
+
+_Check_return_ HRESULT
+FrameworkElement::SetCompiledBindingWithSetterImpl(
+    _In_ IDependencyProperty* pDP,
+    _In_ xaml_data::ICompiledBindingGetter* getter,
+    _In_ xaml_data::ICompiledBindingSetter* setter)
+{
+    ctl::ComPtr<DependencyPropertyHandle> spDP;
+    ctl::ComPtr<IInspectable> spDataContext;
+
+    IFC_RETURN(ctl::do_query_interface(spDP, pDP));
+    IFC_RETURN(get_DataContext(&spDataContext));
+
+    return DXamlCore::SetCompiledBinding(
+        spDataContext.Get(),
+        getter,
+        setter,
         this,
         spDP->GetDP()->GetIndex());
 }

--- a/dxaml/xcp/dxaml/lib/winrtfoundation/wrtdxamlfoundation.vcxproj
+++ b/dxaml/xcp/dxaml/lib/winrtfoundation/wrtdxamlfoundation.vcxproj
@@ -93,6 +93,7 @@
         <ClCompile Include="..\LayoutInformation.cpp"/>
         <ClCompile Include="..\TemplateBindingExpression.cpp"/>
         <ClCompile Include="..\DirectSourceBindingExpression.cpp"/>
+        <ClCompile Include="..\CompiledBindingExpression.cpp"/>
         <ClCompile Include="..\ThemeResourceExpression.cpp"/>
         <ClCompile Include="..\KeyboardNavigation.cpp"/>
         <ClCompile Include="..\DefaultStyles.cpp"/>

--- a/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.cpp
+++ b/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.cpp
@@ -1178,6 +1178,27 @@ Cleanup:
     RRETURN(hr);
 }
 #if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
+_Check_return_ HRESULT STDMETHODCALLTYPE DirectUI::FrameworkElementGenerated::SetCompiledBinding(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter)
+{
+    HRESULT hr = S_OK;
+    if (EventEnabledApiFunctionCallStart())
+    {
+        XamlTelemetry::PublicApiCall(true, reinterpret_cast<uint64_t>(this), "FrameworkElement_SetCompiledBinding", 0);
+    }
+    ARG_NOTNULL(pDp, "dp");
+    ARG_NOTNULL(pGetter, "getter");
+    IFC(CheckThread());
+    IFC(DefaultStrictApiCheck(this));
+    IFC(static_cast<FrameworkElement*>(this)->SetCompiledBindingImpl(pDp, pGetter));
+Cleanup:
+    if (EventEnabledApiFunctionCallStop())
+    {
+        XamlTelemetry::PublicApiCall(false, reinterpret_cast<uint64_t>(this), "FrameworkElement_SetCompiledBinding", hr);
+    }
+    RRETURN(hr);
+}
+#endif
+#if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
 _Check_return_ HRESULT STDMETHODCALLTYPE DirectUI::FrameworkElementGenerated::SetThemeResourceBinding(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pProperty, _In_ HSTRING resourceKey)
 {
     HRESULT hr = S_OK;

--- a/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.cpp
+++ b/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.cpp
@@ -1199,6 +1199,28 @@ Cleanup:
 }
 #endif
 #if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
+_Check_return_ HRESULT STDMETHODCALLTYPE DirectUI::FrameworkElementGenerated::SetCompiledBindingWithSetter(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingSetter* pSetter)
+{
+    HRESULT hr = S_OK;
+    if (EventEnabledApiFunctionCallStart())
+    {
+        XamlTelemetry::PublicApiCall(true, reinterpret_cast<uint64_t>(this), "FrameworkElement_SetCompiledBindingWithSetter", 0);
+    }
+    ARG_NOTNULL(pDp, "dp");
+    ARG_NOTNULL(pGetter, "getter");
+    ARG_NOTNULL(pSetter, "setter");
+    IFC(CheckThread());
+    IFC(DefaultStrictApiCheck(this));
+    IFC(static_cast<FrameworkElement*>(this)->SetCompiledBindingWithSetterImpl(pDp, pGetter, pSetter));
+Cleanup:
+    if (EventEnabledApiFunctionCallStop())
+    {
+        XamlTelemetry::PublicApiCall(false, reinterpret_cast<uint64_t>(this), "FrameworkElement_SetCompiledBindingWithSetter", hr);
+    }
+    RRETURN(hr);
+}
+#endif
+#if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
 _Check_return_ HRESULT STDMETHODCALLTYPE DirectUI::FrameworkElementGenerated::SetThemeResourceBinding(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pProperty, _In_ HSTRING resourceKey)
 {
     HRESULT hr = S_OK;

--- a/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.h
+++ b/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.h
@@ -29,6 +29,7 @@ namespace ctl
         : public ctl::iinspectable_forwarder_base< ABI::Microsoft::UI::Xaml::IFrameworkElementFeature_ExperimentalApi, impl_type>
     {
         impl_type* This() { return this->This_helper<impl_type>(); }
+        IFACEMETHOD(SetCompiledBinding)(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter) override { return This()->SetCompiledBinding(pDp, pGetter); }
         IFACEMETHOD(SetThemeResourceBinding)(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pProperty, _In_ HSTRING resourceKey) override { return This()->SetThemeResourceBinding(pProperty, resourceKey); }
     };
 }
@@ -202,6 +203,9 @@ namespace DirectUI
         IFACEMETHOD(OnApplyTemplate)() override;
         _Check_return_ HRESULT OnApplyTemplateProtected();
         IFACEMETHOD(SetBinding)(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::IBindingBase* pBinding) override;
+#if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
+        _Check_return_ HRESULT STDMETHODCALLTYPE SetCompiledBinding(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter);
+#endif
 #if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
         _Check_return_ HRESULT STDMETHODCALLTYPE SetThemeResourceBinding(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pProperty, _In_ HSTRING resourceKey);
 #endif

--- a/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.h
+++ b/dxaml/xcp/dxaml/lib/winrtgeneratedclasses/FrameworkElement.g.h
@@ -30,6 +30,7 @@ namespace ctl
     {
         impl_type* This() { return this->This_helper<impl_type>(); }
         IFACEMETHOD(SetCompiledBinding)(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter) override { return This()->SetCompiledBinding(pDp, pGetter); }
+        IFACEMETHOD(SetCompiledBindingWithSetter)(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingSetter* pSetter) override { return This()->SetCompiledBindingWithSetter(pDp, pGetter, pSetter); }
         IFACEMETHOD(SetThemeResourceBinding)(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pProperty, _In_ HSTRING resourceKey) override { return This()->SetThemeResourceBinding(pProperty, resourceKey); }
     };
 }
@@ -205,6 +206,9 @@ namespace DirectUI
         IFACEMETHOD(SetBinding)(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::IBindingBase* pBinding) override;
 #if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
         _Check_return_ HRESULT STDMETHODCALLTYPE SetCompiledBinding(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter);
+#endif
+#if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
+        _Check_return_ HRESULT STDMETHODCALLTYPE SetCompiledBindingWithSetter(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pDp, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingGetter* pGetter, _In_ ABI::Microsoft::UI::Xaml::Data::ICompiledBindingSetter* pSetter);
 #endif
 #if WI_IS_FEATURE_PRESENT(Feature_ExperimentalApi)
         _Check_return_ HRESULT STDMETHODCALLTYPE SetThemeResourceBinding(_In_ ABI::Microsoft::UI::Xaml::IDependencyProperty* pProperty, _In_ HSTRING resourceKey);

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Data.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Data.cs
@@ -606,6 +606,13 @@ namespace Microsoft.UI.Xaml.Data
 
     public delegate void PropertyChangedEventHandler(Windows.Foundation.Object sender, Microsoft.UI.Xaml.Data.PropertyChangedEventArgs e);
 
+    // Getter for a programmatic compiled binding: maps a source object (typically the DataContext)
+    // to the value for the bound target property. Code-behind analog of an {x:Bind} expression's
+    // generated getter. Non-generic at the ABI (source and result are Object) because WinRT cannot
+    // express user-defined generic delegates; typed, boxing-free wrappers are layered on top in the
+    // language projections.
+    public delegate Windows.Foundation.Object CompiledBindingGetter(Windows.Foundation.Object source);
+
     [CodeGen(partial: true)]
     [DXamlIdlGroup("coretypes2")]
     [TypeFlags(IsCreateableFromXAML = false)]

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Data.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Data.cs
@@ -613,6 +613,10 @@ namespace Microsoft.UI.Xaml.Data
     // language projections.
     public delegate Windows.Foundation.Object CompiledBindingGetter(Windows.Foundation.Object source);
 
+    // Setter for a programmatic compiled binding: maps a value from the bound target property
+    // back to the source object (typically the DataContext).
+    public delegate void CompiledBindingSetter(Windows.Foundation.Object source, Windows.Foundation.Object value);
+
     [CodeGen(partial: true)]
     [DXamlIdlGroup("coretypes2")]
     [TypeFlags(IsCreateableFromXAML = false)]
@@ -706,4 +710,3 @@ namespace Microsoft.UI.Xaml.Data
         event Windows.Foundation.EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
     }
 }
-

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.cs
@@ -1913,6 +1913,13 @@ namespace Microsoft.UI.Xaml
         {
         }
 
+        [VelocityFeature("Feature_ExperimentalApi")]
+        [CodeGen(CodeGenLevel.IdlAndPartialStub)]
+        [NativeClassName("CFrameworkElement")]
+        public void SetCompiledBinding(Microsoft.UI.Xaml.DependencyProperty dp, Microsoft.UI.Xaml.Data.CompiledBindingGetter getter)
+        {
+        }
+
         [CodeGen(CodeGenLevel.IdlAndPartialStub)]
         [TypeTable(IsExcludedFromCore = true)]
         protected virtual Windows.Foundation.Boolean GoToElementStateCore(Windows.Foundation.String stateName, Windows.Foundation.Boolean useTransitions)
@@ -3776,15 +3783,15 @@ namespace Microsoft.UI.Xaml
     [DXamlIdlGroup("Controls")]
     [CodeGen(CodeGenLevel.LookupOnly)]
     [ReturnTypeParameterName("element")]
-    [Platform("Feature_ExperimentalApi", typeof(Microsoft.UI.Xaml.WinUIContract), Microsoft.UI.Xaml.WinUIContract.LatestVersion)]
+    [Platform("Feature_ExperimentalApi", typeof(Microsoft.UI.Xaml.WinUIContract), Microsoft.UI.Xaml.WinUIContract.Experimental)]
     public delegate Microsoft.UI.Xaml.UIElement DataTemplateElementFactory();
 
     [NativeName("CDataTemplate")]
     [Guids(ClassGuid = "2ba5f834-0618-4292-bb15-ea4f88f4ecd2")]
     [TypeTable(IsExcludedFromVisualTree = true)]
     [Implements(typeof(Microsoft.UI.Xaml.IElementFactory), 1)]
-    [Platform(2, typeof(Microsoft.UI.Xaml.WinUIContract), Microsoft.UI.Xaml.WinUIContract.LatestVersion)]
-    [Platform("Feature_ExperimentalApi", typeof(Microsoft.UI.Xaml.WinUIContract), Microsoft.UI.Xaml.WinUIContract.LatestVersion)]
+    [Platform(2, typeof(Microsoft.UI.Xaml.WinUIContract), Microsoft.UI.Xaml.WinUIContract.Experimental)]
+    [Platform("Feature_ExperimentalApi", typeof(Microsoft.UI.Xaml.WinUIContract), Microsoft.UI.Xaml.WinUIContract.Experimental)]
     [DXamlIdlGroup("Controls")]
     [CodeGen(partial: true)]
     public class DataTemplate

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.cs
@@ -1916,7 +1916,20 @@ namespace Microsoft.UI.Xaml
         [VelocityFeature("Feature_ExperimentalApi")]
         [CodeGen(CodeGenLevel.IdlAndPartialStub)]
         [NativeClassName("CFrameworkElement")]
+        [DXamlOverloadName("SetCompiledBinding")]
         public void SetCompiledBinding(Microsoft.UI.Xaml.DependencyProperty dp, Microsoft.UI.Xaml.Data.CompiledBindingGetter getter)
+        {
+        }
+
+        [VelocityFeature("Feature_ExperimentalApi")]
+        [CodeGen(CodeGenLevel.IdlAndPartialStub)]
+        [NativeClassName("CFrameworkElement")]
+        [DXamlName("SetCompiledBindingWithSetter")]
+        [DXamlOverloadName("SetCompiledBinding")]
+        public void SetCompiledBinding(
+            Microsoft.UI.Xaml.DependencyProperty dp,
+            Microsoft.UI.Xaml.Data.CompiledBindingGetter getter,
+            Microsoft.UI.Xaml.Data.CompiledBindingSetter setter)
         {
         }
 


### PR DESCRIPTION
## Fixes

Addresses #11755.

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

This change adds an _experimental_ `FrameworkElement.SetCompiledBinding` method that accepts a delegate from the app. WinUI calls the delegate when pulling the value for the binding. This API requires that a `DataContext` is set on the element. The `DataContext` will be provided as a param to the call to the delegate. WinUI will also listen for `INotifyPropertyChanged` on the `DataContext` object, and will update the binding (by calling the delegate again) in response to a change notification. There is an overload that takes two delegates, one to pull the value to the target and one to push an updated value back to the source.

This compiled binding is different from a classic `Binding`:
* It has no `Path` since the lambda provides the value.
* It has no `Source` to look up an `x:Name` since the source object is provided directly via the `DataContext`.
* It has no `Mode` since the overload makes it clear whether it's a `OneWay` binding (one lambda) or a `TwoWay` binding (two lambdas). (It doesn't support `OneTime` because then the app code can just set the value directly rather than via a binding.)

That suggests that no `Binding` objects should be involved in the API. `BindingExpression` is a single instance of a `Binding`, and should also be avoided. But we do want to take advantage of classic `Binding`' integration with the property system, including storing the binding as well as its value, pulling the value via `DependencyObject::RefreshExpression`, property layering, and replacement.

There is an internal precedent for these types of bindings - `DirectSourceBindingExpression`s are used by `CommandingHelpers` for internal classic `Binding`s that aren't exposed to the app. They also don't implement the internal `IBindingExpression` interface, which [`FrameworkElement::GetBindingExpression`](https://github.com/microsoft/microsoft-ui-xaml/blob/79646b4e5d4d85355f7478e0e0149b31e57d85f0/dxaml/xcp/dxaml/lib/FrameworkElement_partial.cpp#L203) uses to return an object to the caller. This means `DirectSourceBindingExpression`s _cannot be observed from `GetBindingExpression`_ and are hidden from public callers.

We copy the same pattern for compiled bindings. `CompiledBindingExpression` is a new class that can interop with WinUI's property system just like a classic Binding, yet is hidden from the outside world. The new `FrameworkElement.SetCompiledBinding` method creates and hooks up a `CompiledBindingExpression`.

The public API for `BindingExpressionBase` includes:
* `OnAttach` - called when attached to the target. The `DataContext` may not necessarily be set at this point. We register for `DataContextChanged` on the target, and if there's already a `DataContext` then we register for `INotifyPropertyChanged` notifications from it.
* `OnDetach` - called when detached from the target. Unregister for `DataContextChanged` and, if the `DataContext` already exists, `INotifyPropertyChanged`.
* `GetValue` - call out to the app-provided lambda, passing in the `DataContext` as the param.
  * If there's no `DataContext` then we don't call the lambda. This makes it easier to call `SetCompiledBinding` before setting (or inheriting) the `DataContext`, as the lambda won't be called until everything is ready. This also makes lambdas simpler by not requiring them to do null checks.
  * If the lambda somehow causes the `DataContext` to change, we return an invalid operation error. The function is expected to be a simple getter and is not expected to change the tree.
* `GetIsAssociated` - returns whether the BindingExpression is already attached to the tree.
* `GetCanSetValue` - returns whether this supports two-way bindings. It does not.

## Customer Impact

Apps without markup now have an easy and IL-trimming-safe way to use bindings via this new API.

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Existing tests pass locally