### PR TITLE
Gate PR validation on test failures

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTestPassOnPipeline-Job.yml
@@ -10,7 +10,6 @@ parameters:
   testSuite: 'DevTestSuite' # Can be: DevTestSuite, ScenarioTestSuite
   rerunPassesRequiredToAvoidFailure: 5
   testPayloadArtifactName: 'TestPayload'
-  failOnTestFailure: true
 # We run the bulk of our tests in Helix. But this Job runs tests directly on the Pipeline agents.
 # These Pipeline agents are running on a ni_release build of Windows which is not available in Helix.
 # This approach allows us to run tests on prerelease builds of Windows.
@@ -106,7 +105,7 @@ jobs:
       testResultsFiles: testResults-*.xml
       searchFolder: $(Build.SourcesDirectory)\build\PipelineScripts
       mergeTestResults: true
-      failTaskOnFailedTests: ${{ parameters.failOnTestFailure }}
+      failTaskOnFailedTests: true
       testRunTitle: '$(testRunTitle)'
       buildPlatform: $(buildPlatform)
       buildConfiguration: $(buildConfiguration)

--- a/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-RunTests-Stage.yml
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 parameters:
   pipelineKind: ''
-  failOnTestFailure: true
 
 stages:
 - stage: RunTests
@@ -23,7 +22,6 @@ stages:
       dependsOn: CreateTestPayload
       testOS: 'Win11-25H2'
       testPayloadArtifactName: 'TestPayload'
-      failOnTestFailure: ${{ parameters.failOnTestFailure }}
 
   - ${{ if ne(parameters.pipelineKind, 'QuickPR') }}:
     - template: WinUI-RunTestPassOnPipeline-Job.yml
@@ -32,7 +30,6 @@ stages:
         dependsOn: CreateTestPayload
         testOS: 'Win11-23H2'
         testPayloadArtifactName: 'TestPayload'
-        failOnTestFailure: ${{ parameters.failOnTestFailure }}
 
     - template: WinUI-RunTestPassOnPipeline-Job.yml
       parameters:
@@ -40,4 +37,3 @@ stages:
         dependsOn: CreateTestPayload
         testOS: 'Win10-RS5'
         testPayloadArtifactName: 'TestPayload'
-        failOnTestFailure: ${{ parameters.failOnTestFailure }}

--- a/build/WinUI-GitHub-PR.yml
+++ b/build/WinUI-GitHub-PR.yml
@@ -168,8 +168,6 @@ extends:
       - template: AzurePipelinesTemplates\WinUI-RunTests-Stage.yml
         parameters:
           pipelineKind: PR
-          # Test results are published but do not gate the pipeline yet.
-          failOnTestFailure: false
 
     - ${{ if eq(parameters.runFullValidation, true) }}:
       - template: AzurePipelinesTemplates\WinUI-RunStaticTests-Stage.yml


### PR DESCRIPTION
## Description

Ensures GitHub-backed PR validation fails when published test results contain genuine failures. Removes the temporary non-gating parameter and makes test result publication always enforce failures.

## Validation

Not run (pipeline-only change).