### PR TITLE
Preserve input services during test shutdown

### DIFF
--- a/dxaml/test/native/external/framework/lifetime/tests/CoreShutdownTests.cpp
+++ b/dxaml/test/native/external/framework/lifetime/tests/CoreShutdownTests.cpp
@@ -136,6 +136,8 @@ void CoreShutdownTests::FocusedTextBoxAtCoreShutdown()
     {
         textBox = ref new xaml_controls::TextBox();
         textBox->Text = L"focused text input at shutdown";
+        textBox->ContextFlyout = nullptr;
+        textBox->SelectionFlyout = nullptr;
         TestServices::WindowHelper->WindowContent = textBox;
     });
     TestServices::WindowHelper->WaitForIdle();

--- a/dxaml/xcp/core/dll/xcpcore.cpp
+++ b/dxaml/xcp/core/dll/xcpcore.cpp
@@ -10254,10 +10254,14 @@ HRESULT CCoreServices::ShutdownToIdle()
     m_spXamlSchemaContext.reset();
     m_spXamlNodeStreamCacheManager.reset();
 
+    auto inputServices = m_inputServices;
     IFC_RETURN(ResetState());
 
+    // Text core teardown can re-enter input services.
+    m_inputServices = std::move(inputServices);
     delete m_pTextCore;
     m_pTextCore = NULL;
+    m_inputServices = nullptr;
 
     // Proactively release our D3D device lost listener to guarantee we synchronize with any pending callback that might be in-flight.
     ReleaseDeviceLostListener();

--- a/dxaml/xcp/core/dll/xcpcore.cpp
+++ b/dxaml/xcp/core/dll/xcpcore.cpp
@@ -1573,7 +1573,7 @@ _Check_return_ HRESULT CCoreServices::ClearDefaultLanguageString()
 //
 //------------------------------------------------------------------------
 
-_Check_return_ HRESULT CCoreServices::ResetState()
+_Check_return_ HRESULT CCoreServices::ResetState(bool resetInputServices)
 {
     HRESULT recordHr = S_OK;
 
@@ -1596,7 +1596,10 @@ _Check_return_ HRESULT CCoreServices::ResetState()
     }
 
     m_pMainVisualTree = nullptr;
-    m_inputServices = nullptr;
+    if (resetInputServices)
+    {
+        m_inputServices = nullptr;
+    }
 
     // Release some stuff
 
@@ -10254,11 +10257,9 @@ HRESULT CCoreServices::ShutdownToIdle()
     m_spXamlSchemaContext.reset();
     m_spXamlNodeStreamCacheManager.reset();
 
-    auto inputServices = m_inputServices;
-    IFC_RETURN(ResetState());
+    IFC_RETURN(ResetState(false /* resetInputServices */));
 
-    // Text core teardown can re-enter input services.
-    m_inputServices = std::move(inputServices);
+    ASSERT(m_inputServices != nullptr);
     delete m_pTextCore;
     m_pTextCore = NULL;
     m_inputServices = nullptr;

--- a/dxaml/xcp/core/inc/corep.h
+++ b/dxaml/xcp/core/inc/corep.h
@@ -1556,7 +1556,7 @@ public:
 private:
     _Ret_maybenull_ CSwapChainBackgroundPanel* FindSCBP() const;
 
-    _Check_return_ HRESULT ResetState();
+    _Check_return_ HRESULT ResetState(bool resetInputServices = true);
     _Check_return_ HRESULT Initialize();
 
     _Check_return_ HRESULT GetDirectManipulationChanges(


### PR DESCRIPTION
Keeps the test-only shutdown path aligned with production core teardown by retaining input services until text-core destruction completes. This prevents focused `TextBox` cleanup from re-entering an already released service and allows the regression coverage added in #11680 to exercise the intended ordering.

The change is limited to `CCoreServices::ShutdownToIdle`; normal `ResetState` callers remain unchanged.

**Validation:** To be done in the pipeline itself