### PR TITLE
TableView: left-align columns, and make the samples buildable

### DIFF
--- a/Samples/TableViewApp/README.md
+++ b/Samples/TableViewApp/README.md
@@ -59,21 +59,23 @@ NuGet caches by version, so re-pack under a fresh version string after changing 
 The unpackaged apps run straight from their output directory. The packaged apps produce a loose
 layout; register it with `Add-AppxPackage -Register <outdir>\AppxManifest.xml` and launch from Start.
 
-## Why the C# and C++ apps bind differently
+## The C# and C++ apps bind identically
 
-The C# apps use `TableViewTextColumn.Binding` with a classic `{Binding}` against a plain `Person`
-class. The C++ apps use `TableViewTemplateColumn.CellTemplate` with `x:Bind` against a `Person`
-runtimeclass declared in `MainWindow.idl`.
+All four apps use the same markup and the same code-behind shape: `TableViewTextColumn.Binding`
+with a classic `{Binding}`. Keeping the matrix identical is the point — a difference between the
+cells would make it unclear whether a rendering difference came from the language, the packaging,
+or the control.
 
-That difference is a **C++/WinRT data-binding rule, not a control limitation**. Classic `{Binding}`
-resolves properties through reflection in .NET, but C++/WinRT has no reflection: it needs an
-`IXamlType`, which the XAML compiler emits only for types it encounters **in markup**, or an
-explicit `ICustomPropertyProvider` implementation. A data type constructed purely from code has
-neither, so `{Binding}` silently resolves nothing and every cell renders empty while headers, rows,
-grid lines and theming all look perfectly correct.
+Classic `{Binding}` resolves properties through reflection in .NET, but C++/WinRT has no
+reflection: it needs an `IXamlType`, which the XAML compiler emits only for types it encounters
+**in markup**, or an `ICustomPropertyProvider` implementation. A `Person` built purely from code
+has neither, so `{Binding}` would silently resolve nothing — every cell renders empty while
+headers, rows, grid lines and theming all look perfectly correct.
 
-`x:Bind` compiles the property access at build time, needs no runtime type information, and is the
-right default for a C++/WinRT consumer.
+`[bindable]` on the `Person` runtimeclass in `MainWindow.idl` is what closes that gap: it makes
+C++/WinRT generate the `ICustomPropertyProvider` implementation, so the same `{Binding}` markup
+works in both languages. If a C++ consumer prefers compile-time binding, `x:Bind` inside a
+`TableViewTemplateColumn.CellTemplate` remains a valid alternative that needs no attribute.
 
 ## Preview-API warnings are left visible here
 

--- a/Samples/TableViewApp/README.md
+++ b/Samples/TableViewApp/README.md
@@ -36,16 +36,25 @@ Those are separate paths and either can fail alone, so a conformance check wants
 
 ## Build and run
 
+`TableView` is not in any published `Microsoft.WindowsAppSDK.WinUI` package yet, so these apps only
+compile against a locally packed component — `Build.cmd samples` packs it and passes the matching
+version:
+
 ```
-.\initrun.ps1 msb /restore Samples\TableViewApp\TableViewAppCsPackaged\TableViewAppCsPackaged.csproj /p:Platform=x64
+.\Build.cmd product
+.\Build.cmd samples
 ```
 
-To test a locally built control, pack the component and override the version:
+Building one project on its own resolves the package from the feed instead and fails with
+`CS0234: The type or namespace name 'Tabular' does not exist`. To iterate on a single app, pack once
+and override the version:
 
 ```
 .\pack.component.cmd /version 3.0.0-mylocal
-... /p:WinUIVersion=3.0.0-mylocal
+.\initrun.ps1 msb /restore Samples\TableViewApp\TableViewAppCsPackaged\TableViewAppCsPackaged.csproj /p:Platform=x64 /p:WinUIVersion=3.0.0-mylocal
 ```
+
+NuGet caches by version, so re-pack under a fresh version string after changing the control.
 
 The unpackaged apps run straight from their output directory. The packaged apps produce a loose
 layout; register it with `Add-AppxPackage -Register <outdir>\AppxManifest.xml` and launch from Start.

--- a/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.idl
+++ b/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.idl
@@ -1,12 +1,12 @@
 namespace TableViewAppCppPackaged
 {
+    [bindable]
     [default_interface]
     runtimeclass Person
     {
         Person();
         String Name;
         Int32 Age;
-        String AgeText{ get; };
     }
 
     [default_interface]

--- a/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.xaml
+++ b/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.xaml
@@ -14,16 +14,6 @@
          re-resolves ThemeResource values only on the subtree below it, not on the element
          it is set on, so the themed Background must live on the child ThemeRoot. -->
     <Grid x:Name="RootGrid">
-        <Grid.Resources>
-            <!-- x:Bind, not {Binding}: C++/WinRT needs an IXamlType, which the XAML compiler emits
-                 only for types seen in markup. See README.md. -->
-            <DataTemplate x:Key="NameCell" x:DataType="local:Person">
-                <TextBlock Text="{x:Bind Name}" Margin="8,4" VerticalAlignment="Center" />
-            </DataTemplate>
-            <DataTemplate x:Key="AgeCell" x:DataType="local:Person">
-                <TextBlock Text="{x:Bind AgeText}" Margin="8,4" VerticalAlignment="Center" />
-            </DataTemplate>
-        </Grid.Resources>
 
         <Grid x:Name="ThemeRoot"
               Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
@@ -47,10 +37,9 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <TextBlock Text="Table 1 - instantiated from MARKUP (XAML)" FontWeight="SemiBold" />
-                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}"
-                                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                <tabular:TableViewTemplateColumn Header="Name" CellTemplate="{StaticResource NameCell}" />
-                <tabular:TableViewTemplateColumn Header="Age" CellTemplate="{StaticResource AgeCell}" />
+                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}">
+                    <tabular:TableViewTextColumn Header="Name" Binding="{Binding Name}" />
+                    <tabular:TableViewTextColumn Header="Age" Binding="{Binding Age}" />
                 </tabular:TableView>
             </Grid>
 

--- a/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.xaml.cpp
+++ b/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.xaml.cpp
@@ -20,15 +20,19 @@ namespace winrt::TableViewAppCppPackaged::implementation
             person.Age(age);
             return person;
         }
+
+        // Person is [bindable], so classic {Binding} resolves without an IXamlType.
+        TableViewTextColumn MakeColumn(hstring const& header, hstring const& path)
+        {
+            TableViewTextColumn column;
+            column.Header(box_value(header));
+            Microsoft::UI::Xaml::Data::Binding binding;
+            binding.Path(PropertyPath{ path });
+            column.Binding(binding);
+            return column;
+        }
     }
 
-    TableViewTemplateColumn MainWindow::MakeColumn(hstring const& header, hstring const& templateKey)
-    {
-        TableViewTemplateColumn column;
-        column.Header(box_value(header));
-        column.CellTemplate(RootGrid().Resources().Lookup(box_value(templateKey)).as<DataTemplate>());
-        return column;
-    }
 
     MainWindow::MainWindow()
     {
@@ -44,8 +48,8 @@ namespace winrt::TableViewAppCppPackaged::implementation
         auto codeTable = TableView{};
         codeTable.Height(160);
         codeTable.ItemsSource(m_people);
-        codeTable.Columns().Append(MakeColumn(L"Name", L"NameCell"));
-        codeTable.Columns().Append(MakeColumn(L"Age", L"AgeCell"));
+        codeTable.Columns().Append(MakeColumn(L"Name", L"Name"));
+        codeTable.Columns().Append(MakeColumn(L"Age", L"Age"));
         CodeTableHost().Children().Append(codeTable);
 
         StatusText().Text(L"Both tables are bound to the same 3 items.");

--- a/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.xaml.h
+++ b/Samples/TableViewApp/TableViewAppCppPackaged/MainWindow.xaml.h
@@ -16,10 +16,6 @@ namespace winrt::TableViewAppCppPackaged::implementation
             winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
 
     private:
-        winrt::Microsoft::UI::Xaml::Controls::Tabular::TableViewTemplateColumn MakeColumn(
-            winrt::hstring const& header,
-            winrt::hstring const& templateKey);
-
         winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> m_people{ nullptr };
     };
 }

--- a/Samples/TableViewApp/TableViewAppCppPackaged/Person.h
+++ b/Samples/TableViewApp/TableViewAppCppPackaged/Person.h
@@ -13,9 +13,6 @@ namespace winrt::TableViewAppCppPackaged::implementation
         int32_t Age() const { return m_age; }
         void Age(int32_t value) { m_age = value; }
 
-        // String projection so the cell templates can x:Bind without a converter.
-        hstring AgeText() const { return to_hstring(m_age); }
-
     private:
         hstring m_name;
         int32_t m_age{ 0 };

--- a/Samples/TableViewApp/TableViewAppCppPackaged/pch.h
+++ b/Samples/TableViewApp/TableViewAppCppPackaged/pch.h
@@ -21,3 +21,6 @@
 #include <winrt/Microsoft.UI.Xaml.Navigation.h>
 #include <winrt/Microsoft.UI.Xaml.Shapes.h>
 #include <winrt/Microsoft.UI.Dispatching.h>
+
+// Person no longer appears in markup; the generated XamlTypeInfo still needs its implementation.
+#include "Person.h"

--- a/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.idl
+++ b/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.idl
@@ -1,12 +1,12 @@
 namespace TableViewAppCppUnpackaged
 {
+    [bindable]
     [default_interface]
     runtimeclass Person
     {
         Person();
         String Name;
         Int32 Age;
-        String AgeText{ get; };
     }
 
     [default_interface]

--- a/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.xaml
+++ b/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.xaml
@@ -14,16 +14,6 @@
          re-resolves ThemeResource values only on the subtree below it, not on the element
          it is set on, so the themed Background must live on the child ThemeRoot. -->
     <Grid x:Name="RootGrid">
-        <Grid.Resources>
-            <!-- x:Bind, not {Binding}: C++/WinRT needs an IXamlType, which the XAML compiler emits
-                 only for types seen in markup. See README.md. -->
-            <DataTemplate x:Key="NameCell" x:DataType="local:Person">
-                <TextBlock Text="{x:Bind Name}" Margin="8,4" VerticalAlignment="Center" />
-            </DataTemplate>
-            <DataTemplate x:Key="AgeCell" x:DataType="local:Person">
-                <TextBlock Text="{x:Bind AgeText}" Margin="8,4" VerticalAlignment="Center" />
-            </DataTemplate>
-        </Grid.Resources>
 
         <Grid x:Name="ThemeRoot"
               Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
@@ -47,10 +37,9 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <TextBlock Text="Table 1 - instantiated from MARKUP (XAML)" FontWeight="SemiBold" />
-                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}"
-                                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                <tabular:TableViewTemplateColumn Header="Name" CellTemplate="{StaticResource NameCell}" />
-                <tabular:TableViewTemplateColumn Header="Age" CellTemplate="{StaticResource AgeCell}" />
+                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}">
+                    <tabular:TableViewTextColumn Header="Name" Binding="{Binding Name}" />
+                    <tabular:TableViewTextColumn Header="Age" Binding="{Binding Age}" />
                 </tabular:TableView>
             </Grid>
 

--- a/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.xaml.cpp
+++ b/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.xaml.cpp
@@ -20,15 +20,19 @@ namespace winrt::TableViewAppCppUnpackaged::implementation
             person.Age(age);
             return person;
         }
+
+        // Person is [bindable], so classic {Binding} resolves without an IXamlType.
+        TableViewTextColumn MakeColumn(hstring const& header, hstring const& path)
+        {
+            TableViewTextColumn column;
+            column.Header(box_value(header));
+            Microsoft::UI::Xaml::Data::Binding binding;
+            binding.Path(PropertyPath{ path });
+            column.Binding(binding);
+            return column;
+        }
     }
 
-    TableViewTemplateColumn MainWindow::MakeColumn(hstring const& header, hstring const& templateKey)
-    {
-        TableViewTemplateColumn column;
-        column.Header(box_value(header));
-        column.CellTemplate(RootGrid().Resources().Lookup(box_value(templateKey)).as<DataTemplate>());
-        return column;
-    }
 
     MainWindow::MainWindow()
     {
@@ -44,8 +48,8 @@ namespace winrt::TableViewAppCppUnpackaged::implementation
         auto codeTable = TableView{};
         codeTable.Height(160);
         codeTable.ItemsSource(m_people);
-        codeTable.Columns().Append(MakeColumn(L"Name", L"NameCell"));
-        codeTable.Columns().Append(MakeColumn(L"Age", L"AgeCell"));
+        codeTable.Columns().Append(MakeColumn(L"Name", L"Name"));
+        codeTable.Columns().Append(MakeColumn(L"Age", L"Age"));
         CodeTableHost().Children().Append(codeTable);
 
         StatusText().Text(L"Both tables are bound to the same 3 items.");

--- a/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.xaml.h
+++ b/Samples/TableViewApp/TableViewAppCppUnpackaged/MainWindow.xaml.h
@@ -16,10 +16,6 @@ namespace winrt::TableViewAppCppUnpackaged::implementation
             winrt::Microsoft::UI::Xaml::RoutedEventArgs const& args);
 
     private:
-        winrt::Microsoft::UI::Xaml::Controls::Tabular::TableViewTemplateColumn MakeColumn(
-            winrt::hstring const& header,
-            winrt::hstring const& templateKey);
-
         winrt::Windows::Foundation::Collections::IObservableVector<winrt::Windows::Foundation::IInspectable> m_people{ nullptr };
     };
 }

--- a/Samples/TableViewApp/TableViewAppCppUnpackaged/Person.h
+++ b/Samples/TableViewApp/TableViewAppCppUnpackaged/Person.h
@@ -13,9 +13,6 @@ namespace winrt::TableViewAppCppUnpackaged::implementation
         int32_t Age() const { return m_age; }
         void Age(int32_t value) { m_age = value; }
 
-        // String projection so the cell templates can x:Bind without a converter.
-        hstring AgeText() const { return to_hstring(m_age); }
-
     private:
         hstring m_name;
         int32_t m_age{ 0 };

--- a/Samples/TableViewApp/TableViewAppCppUnpackaged/pch.h
+++ b/Samples/TableViewApp/TableViewAppCppUnpackaged/pch.h
@@ -21,3 +21,6 @@
 #include <winrt/Microsoft.UI.Xaml.Navigation.h>
 #include <winrt/Microsoft.UI.Xaml.Shapes.h>
 #include <winrt/Microsoft.UI.Dispatching.h>
+
+// Person no longer appears in markup; the generated XamlTypeInfo still needs its implementation.
+#include "Person.h"

--- a/Samples/TableViewApp/TableViewAppCsPackaged/MainWindow.xaml
+++ b/Samples/TableViewApp/TableViewAppCsPackaged/MainWindow.xaml
@@ -36,8 +36,7 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <TextBlock Text="Table 1 - instantiated from MARKUP (XAML)" FontWeight="SemiBold" />
-                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}"
-                                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}">
                     <tabular:TableViewTextColumn Header="Name" Binding="{Binding Name}" />
                     <tabular:TableViewTextColumn Header="Age" Binding="{Binding Age}" />
                 </tabular:TableView>

--- a/Samples/TableViewApp/TableViewAppCsUnpackaged/MainWindow.xaml
+++ b/Samples/TableViewApp/TableViewAppCsUnpackaged/MainWindow.xaml
@@ -36,8 +36,7 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <TextBlock Text="Table 1 - instantiated from MARKUP (XAML)" FontWeight="SemiBold" />
-                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}"
-                                   HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <tabular:TableView x:Name="MarkupTable" Grid.Row="1" ItemsSource="{x:Bind People}">
                     <tabular:TableViewTextColumn Header="Name" Binding="{Binding Name}" />
                     <tabular:TableViewTextColumn Header="Age" Binding="{Binding Age}" />
                 </tabular:TableView>

--- a/Samples/TableViewSampleApp/AGENTS.md
+++ b/Samples/TableViewSampleApp/AGENTS.md
@@ -27,17 +27,27 @@ regressed. Check, in order:
 
 ## How it builds
 
+`TableView` is not in any published `Microsoft.WindowsAppSDK.WinUI` package yet, so the sample only
+compiles against a locally packed component. `Build.cmd samples` handles that — it runs
+`pack.component.cmd` and then builds every sample with the matching `/p:WinUIVersion`:
+
 ```
-.\initrun.ps1 msb /q /restore Samples\TableViewSampleApp\TableViewSampleApp.csproj /p:Platform=x64
+.\Build.cmd product
+.\Build.cmd samples
 ```
 
-`Microsoft.WindowsAppSDK.WinUI` resolves at `$(WinUIVersion)` through Central Package Versions. To
-test a locally built control, pack the component and override that version:
+Building the project on its own resolves `Microsoft.WindowsAppSDK.WinUI` from the feed instead, and
+fails with `CS0234: The type or namespace name 'Tabular' does not exist` — the package is real, it
+just predates Tabular in the public winmd. To iterate on this app alone, pack and override:
 
 ```
 .\pack.component.cmd /version 3.0.0-mylocal
-... /p:WinUIVersion=3.0.0-mylocal
+.\initrun.ps1 msb /q /restore Samples\TableViewSampleApp\TableViewSampleApp.csproj /p:Platform=x64 /p:WinUIVersion=3.0.0-mylocal
 ```
+
+NuGet caches by version under `packages\microsoft.windowsappsdk.winui\`, so re-packing the same
+version after a control change is silently ignored — use a fresh version string, or delete that
+folder first.
 
 The control DLL, its `.pri` and its theme XBFs arrive from the package. The consuming app's build
 expands every referenced `.pri` and re-indexes it into the app's own `TableViewSampleApp.pri`, which

--- a/Samples/TableViewSampleApp/AGENTS.md
+++ b/Samples/TableViewSampleApp/AGENTS.md
@@ -64,8 +64,3 @@ file. XAML usage raises `WMC1501` once per page; those are deliberately left vis
 `Program.cs` provides `Main` and the project defines `DISABLE_XAML_GENERATED_MAIN`, following the
 [DisableXamlGeneratedMain](../DisableXamlGeneratedMain) sample. This is a normal WinUI pattern, not a
 workaround.
-
-## Known issue
-
-An `EmptyTemplate` containing a `FontIcon` can crash at startup while the empty state is first shown.
-Prefer text or shape content in the `EmptyTemplate` until this is resolved.

--- a/Samples/TableViewSampleApp/README.md
+++ b/Samples/TableViewSampleApp/README.md
@@ -21,19 +21,27 @@ special, exactly like the [ChartApp](../ChartApp) samples.
 
 ## Build
 
-From the repo root:
+`TableView` is not in any published `Microsoft.WindowsAppSDK.WinUI` package yet, so this sample can
+only build against a **locally packed** component. Building the project on its own resolves the
+package from the feed and fails with `CS0234: The type or namespace name 'Tabular' does not exist`.
+
+The supported flow packs the component and passes the matching version for you:
 
 ```
-.\initrun.ps1 msb /q /restore Samples\TableViewSampleApp\TableViewSampleApp.csproj /p:Platform=x64
+.\Build.cmd product
+.\Build.cmd samples
 ```
 
-The sample resolves `Microsoft.WindowsAppSDK.WinUI` at `$(WinUIVersion)`. To run against a locally
-built control, pack the component and point the build at that version:
+To iterate on just this app, pack once and point the build at that version:
 
 ```
 .\pack.component.cmd /version 3.0.0-mylocal
 .\initrun.ps1 msb /q /restore Samples\TableViewSampleApp\TableViewSampleApp.csproj /p:Platform=x64 /p:WinUIVersion=3.0.0-mylocal
 ```
+
+Re-run `pack.component.cmd` after every control change — NuGet caches by version, so reuse the
+version only if you also clear `packages\microsoft.windowsappsdk.winui\`, and prefer a fresh version
+string when in doubt.
 
 ## Run
 

--- a/Samples/TableViewSampleApp/README.md
+++ b/Samples/TableViewSampleApp/README.md
@@ -82,11 +82,6 @@ visible on purpose.
 - `EmptyTemplate`
 - `TableViewTextColumn` and `TableViewTemplateColumn` (custom cell content)
 
-## Known issue
-
-Using an `EmptyTemplate` that contains a `FontIcon` can crash at startup while the empty state is
-first shown. Prefer text or shape content in the `EmptyTemplate` until this is resolved.
-
 ## More detail
 
 See [AGENTS.md](AGENTS.md).

--- a/Samples/TableViewSampleApp/ToolTipsPage.xaml.cs
+++ b/Samples/TableViewSampleApp/ToolTipsPage.xaml.cs
@@ -4,15 +4,11 @@ using System.Linq;
 using System.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Tabular;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Media;
-// Disambiguate the real split-binary types from the stale mock projection
-// (Microsoft.UI.Xaml.Controls.TableView*) that the mock Microsoft.WinUI.dll still carries.
-using TableView = Microsoft.UI.Xaml.Controls.Tabular.TableView;
-using TableViewColumn = Microsoft.UI.Xaml.Controls.Tabular.TableViewColumn;
-using TableViewTemplateColumn = Microsoft.UI.Xaml.Controls.Tabular.TableViewTemplateColumn;
 
 namespace TableViewSampleApp;
 

--- a/buildsamples.cmd
+++ b/buildsamples.cmd
@@ -57,6 +57,15 @@ if ERRORLEVEL 1 goto:eof
 REM The C# packaged Chart app is a single-project MSIX app, so it only emits its .msix when published.
 call :buildSamplesSolution %reporoot%\Samples\ChartApp\ChartAppCsPackaged\ChartAppCsPackaged.csproj /t:Publish /p:PublishProfile=win-%BUILDPLATFORM%.pubxml
 if ERRORLEVEL 1 goto:eof
+call :buildSamplesSolution %reporoot%\Samples\TableViewSampleApp\TableViewSampleApp.csproj
+if ERRORLEVEL 1 goto:eof
+call :buildSamplesSolution %reporoot%\Samples\TableViewApp\TableViewApp.sln
+if ERRORLEVEL 1 goto:eof
+call :buildSamplesSolution %reporoot%\Samples\TableViewApp\TableViewAppCsUnpackaged\TableViewAppCsUnpackaged.csproj /t:Publish /p:PublishProfile=win-%BUILDPLATFORM%.pubxml
+if ERRORLEVEL 1 goto:eof
+REM The C# packaged TableView app is a single-project MSIX app, so it only emits its .msix when published.
+call :buildSamplesSolution %reporoot%\Samples\TableViewApp\TableViewAppCsPackaged\TableViewAppCsPackaged.csproj /t:Publish /p:PublishProfile=win-%BUILDPLATFORM%.pubxml
+if ERRORLEVEL 1 goto:eof
 
 exit /b 0
 

--- a/controls/dev/TableView/TableView.xaml
+++ b/controls/dev/TableView/TableView.xaml
@@ -63,7 +63,11 @@
                                                   VerticalScrollMode="Disabled"
                                                   HorizontalScrollBarVisibility="Hidden"
                                                   VerticalScrollBarVisibility="Disabled">
-                                        <controls:TableViewCellsPanel x:Name="PART_HeaderHost" />
+                                        <!-- Left, not the default Stretch: the panel reports the summed column
+                                             width, and a wider presenter would centre it. PART_CellsHost
+                                             must match. -->
+                                        <controls:TableViewCellsPanel x:Name="PART_HeaderHost"
+                                                                      HorizontalAlignment="Left" />
                                     </ScrollViewer>
                                 </Grid>
                             </Border>
@@ -237,7 +241,9 @@
                                               Foreground="{TemplateBinding Foreground}"
                                               HorizontalContentAlignment="Stretch"
                                               VerticalContentAlignment="Stretch">
-                                <controls:TableViewCellsPanel x:Name="PART_CellsHost" />
+                                <!-- Left, matching PART_HeaderHost. -->
+                                <controls:TableViewCellsPanel x:Name="PART_CellsHost"
+                                                              HorizontalAlignment="Left" />
                             </ContentPresenter>
 
                             <!-- Fluent selection indicator: overlays the leading edge, Opacity 0 by


### PR DESCRIPTION
Three related fixes to `TableView` and its samples.

### Columns rendered centred instead of left-aligned

`TableViewCellsPanel` reports the summed column width, so whenever the columns do not fill the
viewport its host presenter is wider than the panel and centres it. The header host and the row cell
host are the same panel type, so the header and every row drifted together, leaving the table
floating mid-control with equal gutters either side.

Both instances are now pinned with `HorizontalAlignment="Left"`, which mirrors to the trailing edge
under RTL.

Verified by measurement on the consumer samples: the first column moves from ~450px inside a 1136px
control to 9px, the border inset. Columns wider than the viewport still start at the leading edge and
scroll horizontally with the header in sync; star-width columns fill the viewport and are unchanged.

### The TableView samples could not be built

`TableView` is not in any published `Microsoft.WindowsAppSDK.WinUI` package, so building these
projects on their own resolves the feed package and fails with `CS0234` on the `Tabular` namespace.

`Build.cmd samples` already packs the component and passes a matching `/p:WinUIVersion`, so the
TableView samples are added to `buildsamples.cmd` next to the Chart apps, which have the same shape.
The READMEs presented the local pack as optional when it is required, and now lead with the
supported flow.

### The four minimal apps were not identical

The consumer matrix exists to isolate language and packaging, so any difference between the four
apps defeats it.

- Redundant `HorizontalAlignment`/`VerticalAlignment="Stretch"` on the markup `TableView` is removed
  from all four; both are already the default for a `Grid` child and set by `TableView`'s own style.
- The C++ apps bound through `TableViewTemplateColumn` + `x:Bind` and a `Person.AgeText` projection,
  because classic `{Binding}` needs an `IXamlType` that C++/WinRT emits only for types seen in
  markup. Marking `Person` `[bindable]` generates the `ICustomPropertyProvider` implementation
  instead, so the C++ apps now use the same `TableViewTextColumn` markup and the same code-behind
  shape as the C# ones.

Also removes the last mock-era type aliases from `ToolTipsPage.xaml.cs` and a stale `EmptyTemplate`
"Known issue" note that no longer applies.

### Validation

Clean build from scratch — product, component pack, then all samples — followed by running the four
consumer apps and the sample app across Auto, Star and Pixel column modes. All build with 0 errors
and render identically across C# and C++.
