### PR TITLE
Consolidate mirror + integrate into a single two-stage pipeline

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-MirrorGitHubToInternal-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-MirrorGitHubToInternal-Stage.yml
@@ -9,10 +9,12 @@ parameters:
   default: github/internal/main
 
 stages:
-- stage: Source
+- stage: FastForwardPublicMirror
+  displayName: Fast-forward public mirror
   dependsOn: []
   jobs:
-  - job: MirrorGitHubToInternal
+  - job: UpdateInternalMirror
+    displayName: Update internal mirror from GitHub main
     pool:
       type: windows
     timeoutInMinutes: 60

--- a/build/AzurePipelinesTemplates/WinUI-PublicMirrorMerge-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-PublicMirrorMerge-Stage.yml
@@ -6,6 +6,9 @@ parameters:
 - name: dependsOnStage
   type: string
   default: ''
+- name: checkoutRepository
+  type: string
+  default: self
 
 stages:
 - stage: IntegratePublicMirror
@@ -31,7 +34,7 @@ stages:
     - name: repositoryRelativePath
       value: 's\repository'
     steps:
-    - checkout: targetRepository
+    - checkout: ${{ parameters.checkoutRepository }}
       submodules: false
       persistCredentials: true
       fetchDepth: 1

--- a/build/AzurePipelinesTemplates/WinUI-PublicMirrorMerge-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-PublicMirrorMerge-Stage.yml
@@ -21,7 +21,7 @@ stages:
   lockBehavior: runLatest
   jobs:
   - job: MergePublicMirror
-    displayName: Merge public mirror
+    displayName: Merge public mirror into target branch
     pool:
       type: windows
     timeoutInMinutes: 30
@@ -33,7 +33,16 @@ stages:
       value: true
     - name: repositoryRelativePath
       value: 's\repository'
+    - name: scriptsRelativePath
+      value: 's\scripts'
     steps:
+    - checkout: self
+      submodules: false
+      persistCredentials: false
+      fetchDepth: 1
+      fetchTags: false
+      path: '$(scriptsRelativePath)'
+      displayName: Checkout pipeline scripts from GitHub source
     - checkout: ${{ parameters.checkoutRepository }}
       submodules: false
       persistCredentials: true
@@ -43,10 +52,10 @@ stages:
       displayName: Checkout internal repository
 
     - task: PowerShell@2
-      displayName: Merge public mirror into internal branch
+      displayName: Merge public mirror into target branch
       inputs:
         workingDirectory: '$(Pipeline.Workspace)'
-        filePath: '$(Pipeline.Workspace)\$(repositoryRelativePath)\scripts\MergePublicMirrorIntoInternalBranch.ps1'
+        filePath: '$(Pipeline.Workspace)\$(scriptsRelativePath)\scripts\MergePublicMirrorIntoInternalBranch.ps1'
         arguments: >
           -RepositoryDirectory '$(repositoryRelativePath)'
           -SourceBranchName '${{ parameters.sourceBranchName }}'

--- a/build/AzurePipelinesTemplates/WinUI-PublicMirrorMerge-Stage.yml
+++ b/build/AzurePipelinesTemplates/WinUI-PublicMirrorMerge-Stage.yml
@@ -3,11 +3,19 @@ parameters:
   type: string
 - name: targetBranchName
   type: string
+- name: dependsOnStage
+  type: string
+  default: ''
 
 stages:
 - stage: IntegratePublicMirror
   displayName: Integrate public mirror
-  dependsOn: []
+  ${{ if parameters.dependsOnStage }}:
+    dependsOn:
+    - ${{ parameters.dependsOnStage }}
+  ${{ else }}:
+    dependsOn: []
+  lockBehavior: runLatest
   jobs:
   - job: MergePublicMirror
     displayName: Merge public mirror
@@ -15,11 +23,15 @@ stages:
       type: windows
     timeoutInMinutes: 30
     variables:
-      ob_outputDirectory: '$(Build.SourcesDirectory)\out'
-      ob_git_skip_checkout_none: true
-      repositoryRelativePath: 's\repository'
+    - group: WinUI-GitHub-Main-Integration-Lock
+    - name: ob_outputDirectory
+      value: '$(Build.SourcesDirectory)\out'
+    - name: ob_git_skip_checkout_none
+      value: true
+    - name: repositoryRelativePath
+      value: 's\repository'
     steps:
-    - checkout: self
+    - checkout: targetRepository
       submodules: false
       persistCredentials: true
       fetchDepth: 1

--- a/build/WinUI-MirrorGitHubToInternal-Official.yml
+++ b/build/WinUI-MirrorGitHubToInternal-Official.yml
@@ -65,5 +65,5 @@ extends:
       parameters:
         sourceBranchName: github/internal/main
         targetBranchName: user/gpaskaleva/mirror-integration-target
-        dependsOnStage: Source
+        dependsOnStage: FastForwardPublicMirror
         checkoutRepository: targetRepository

--- a/build/WinUI-MirrorGitHubToInternal-Official.yml
+++ b/build/WinUI-MirrorGitHubToInternal-Official.yml
@@ -5,6 +5,11 @@
 # preserve target-only content. This pipeline publishes when run. It must be
 # defined from the public GitHub repository so CI runs directly when main
 # advances.
+#
+# A second stage then integrates github/internal/main into the internal
+# integration branch (main) via a --no-ff merge, so a single run performs both
+# legs (fast-forward mirror, then integrate). The integrate stage takes an
+# exclusive lock (lockBehavior: runLatest) so concurrent runs cannot race.
 
 trigger:
   batch: true
@@ -55,3 +60,9 @@ extends:
       parameters:
         sourceBranchName: main
         targetBranchName: github/internal/main
+    # TODO: switch targetBranchName to main once the mirror pipeline identity has push/bypass permission on main.
+    - template: AzurePipelinesTemplates\WinUI-PublicMirrorMerge-Stage.yml@self
+      parameters:
+        sourceBranchName: github/internal/main
+        targetBranchName: user/gpaskaleva/mirror-integration-target
+        dependsOnStage: Source

--- a/build/WinUI-MirrorGitHubToInternal-Official.yml
+++ b/build/WinUI-MirrorGitHubToInternal-Official.yml
@@ -60,10 +60,9 @@ extends:
       parameters:
         sourceBranchName: main
         targetBranchName: github/internal/main
-    # TODO: switch targetBranchName to main once the mirror pipeline identity has push/bypass permission on main.
     - template: AzurePipelinesTemplates\WinUI-PublicMirrorMerge-Stage.yml@self
       parameters:
         sourceBranchName: github/internal/main
-        targetBranchName: user/gpaskaleva/mirror-integration-target
+        targetBranchName: main
         dependsOnStage: FastForwardPublicMirror
         checkoutRepository: targetRepository

--- a/build/WinUI-MirrorGitHubToInternal-Official.yml
+++ b/build/WinUI-MirrorGitHubToInternal-Official.yml
@@ -66,3 +66,4 @@ extends:
         sourceBranchName: github/internal/main
         targetBranchName: user/gpaskaleva/mirror-integration-target
         dependsOnStage: Source
+        checkoutRepository: targetRepository

--- a/scripts/MergePublicMirrorIntoInternalBranch.ps1
+++ b/scripts/MergePublicMirrorIntoInternalBranch.ps1
@@ -177,6 +177,10 @@ Invoke-GitCommand -Repository $repositoryFullPath -Arguments @("config", "user.n
 Invoke-GitCommand -Repository $repositoryFullPath -Arguments @("config", "user.email", "winui-github-integration@microsoft.com")
 
 $maximumPublishAttempts = 3
+# Safety net for the rare case where the target moves between our fetch and
+# our push (e.g. a manual/admin push or another writer). A non-fast-forward
+# rejection triggers a re-fetch and rebuild on the new tip. Our own runs are
+# already serialized by the stage's runLatest lock, so this seldom fires.
 for ($publishAttempt = 1; $publishAttempt -le $maximumPublishAttempts; $publishAttempt++) {
     Write-Host "##[group]Fetching integration branches (attempt $publishAttempt of $maximumPublishAttempts)"
     $fetchArguments = @(

--- a/scripts/MergePublicMirrorIntoInternalBranch.ps1
+++ b/scripts/MergePublicMirrorIntoInternalBranch.ps1
@@ -6,11 +6,8 @@ Merges the exact public mirror branch into the internal integration branch.
 The script creates and publishes a no-fast-forward merge commit directly to
 the configured target branch. It never rewrites history or force-pushes.
 
-The first integration establishes the relationship between unrelated histories
-with an "ours" merge, preserving the target tree while recording the current
-public mirror commit as integrated. Subsequent integrations use ordinary
-no-fast-forward merges. Conflicts and concurrent target updates fail the run
-without modifying the target branch.
+The source and target must already share history. Conflicts and concurrent
+target updates fail the run without modifying the target branch.
 #>
 
 [CmdletBinding()]
@@ -61,8 +58,14 @@ function Get-GitCommandResult {
     )
 
     Write-Host -ForegroundColor Blue "##[command]git -C '$Repository' $($Arguments -join ' ')"
-    $output = & git -C $Repository @Arguments
-    $exitCode = $global:LASTEXITCODE
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $output = & git -C $Repository @Arguments 2>&1
+        $exitCode = $global:LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
 
     return @{
         ExitCode = $exitCode
@@ -170,128 +173,160 @@ $sourceRefName = "refs/heads/$SourceBranchName"
 $targetRefName = "refs/heads/$TargetBranchName"
 $sourceTrackingRef = "refs/remotes/$RemoteName/$SourceBranchName"
 $targetTrackingRef = "refs/remotes/$RemoteName/$TargetBranchName"
-
-Write-Host "##[group]Fetching integration branches"
-$fetchArguments = @(
-    "fetch",
-    "--prune",
-    "--no-tags"
-)
-$repositoryIsShallow = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
-    "rev-parse",
-    "--is-shallow-repository"
-)
-if ($repositoryIsShallow -eq "true") {
-    $fetchArguments += "--unshallow"
-}
-$fetchArguments += @(
-    $RemoteName,
-    "+$sourceRefName`:$sourceTrackingRef",
-    "+$targetRefName`:$targetTrackingRef"
-)
-Invoke-GitCommand -Repository $repositoryFullPath -Arguments $fetchArguments
-$sourceCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "--verify", "$sourceTrackingRef^{commit}")
-$targetCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "--verify", "$targetTrackingRef^{commit}")
-Write-Host "Source '$SourceBranchName': $sourceCommit"
-Write-Host "Target '$TargetBranchName': $targetCommit"
-Write-Host "##[endgroup]"
-
-if (Test-GitAncestor -Repository $repositoryFullPath -PossibleAncestor $sourceCommit -Commit $targetCommit) {
-    Write-Host "Target '$TargetBranchName' already contains source commit '$sourceCommit'. No merge is needed."
-    Write-Host "##vso[task.setvariable variable=IntegratedSourceCommit;isOutput=true]$sourceCommit"
-    Write-Host "##vso[task.setvariable variable=PublishedTargetCommit;isOutput=true]$targetCommit"
-    exit 0
-}
-
-Write-Host "##[group]Creating integration merge"
-Invoke-GitCommand -Repository $repositoryFullPath -Arguments @("checkout", "--detach", $targetTrackingRef)
 Invoke-GitCommand -Repository $repositoryFullPath -Arguments @("config", "user.name", "WinUI GitHub integration")
 Invoke-GitCommand -Repository $repositoryFullPath -Arguments @("config", "user.email", "winui-github-integration@microsoft.com")
 
-$mergeBaseResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @(
-    "merge-base",
-    $targetTrackingRef,
-    $sourceTrackingRef
-)
-$isBootstrap = $false
-$mergeArguments = @("merge", "--no-ff", "--no-edit")
-if ($mergeBaseResult.ExitCode -eq 1) {
-    $isBootstrap = $true
-    Write-Host "No merge base exists. Creating the one-time ancestry bootstrap while preserving the target tree."
-    $mergeArguments += @(
-        "--allow-unrelated-histories",
-        "--strategy=ours"
+$maximumPublishAttempts = 3
+for ($publishAttempt = 1; $publishAttempt -le $maximumPublishAttempts; $publishAttempt++) {
+    Write-Host "##[group]Fetching integration branches (attempt $publishAttempt of $maximumPublishAttempts)"
+    $fetchArguments = @(
+        "fetch",
+        "--prune",
+        "--no-tags"
     )
-} elseif ($mergeBaseResult.ExitCode) {
-    throw "Unable to determine the merge base between '$TargetBranchName' and '$SourceBranchName'."
-}
-
-$mergeMessage = if ($isBootstrap) {
-    "Bootstrap GitHub main ancestry into $TargetBranchName"
-} else {
-    "Merge GitHub main into $TargetBranchName"
-}
-$mergeArguments += @(
-    "-m",
-    $mergeMessage,
-    $sourceTrackingRef
-)
-
-$mergeResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments $mergeArguments
-if ($mergeResult.ExitCode) {
-    $conflicts = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("status", "--short")
-    & git -C $repositoryFullPath merge --abort 2>$null
-    throw "Unable to integrate '$SourceBranchName' because the merge has conflicts.`n$conflicts"
-}
-
-$mergeCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "HEAD")
-$mergeParents = (Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
-    "rev-list",
-    "--parents",
-    "-n",
-    "1",
-    $mergeCommit
-)).Split(" ")
-if ($mergeParents.Count -ne 3 -or $mergeParents[1] -ne $targetCommit -or $mergeParents[2] -ne $sourceCommit) {
-    throw "Merge '$mergeCommit' must have exactly target '$targetCommit' as its first parent and source '$sourceCommit' as its second parent."
-}
-
-if ($isBootstrap) {
-    $targetTree = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "$targetCommit^{tree}")
-    $mergeTree = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "$mergeCommit^{tree}")
-    if ($mergeTree -ne $targetTree) {
-        throw "Bootstrap merge '$mergeCommit' changed the target tree. Expected '$targetTree', found '$mergeTree'."
+    $repositoryIsShallow = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
+        "rev-parse",
+        "--is-shallow-repository"
+    )
+    if ($repositoryIsShallow -eq "true") {
+        $fetchArguments += "--unshallow"
     }
-    Write-Host "Verified that the ancestry bootstrap preserves the target tree '$targetTree'."
+    $fetchArguments += @(
+        $RemoteName,
+        "+$sourceRefName`:$sourceTrackingRef",
+        "+$targetRefName`:$targetTrackingRef"
+    )
+    Invoke-GitCommand -Repository $repositoryFullPath -Arguments $fetchArguments
+    $sourceCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "--verify", "$sourceTrackingRef^{commit}")
+    $targetCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "--verify", "$targetTrackingRef^{commit}")
+    $repositoryIsShallow = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
+        "rev-parse",
+        "--is-shallow-repository"
+    )
+    if ($repositoryIsShallow -eq "true") {
+        $shallowFile = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
+            "rev-parse",
+            "--git-path",
+            "shallow"
+        )
+        if (-not [System.IO.Path]::IsPathRooted($shallowFile)) {
+            $shallowFile = Join-Path $repositoryFullPath $shallowFile
+        }
+        foreach ($shallowBoundary in @(Get-Content -LiteralPath $shallowFile)) {
+            if ((Test-GitAncestor -Repository $repositoryFullPath -PossibleAncestor $shallowBoundary -Commit $sourceCommit) -or
+                (Test-GitAncestor -Repository $repositoryFullPath -PossibleAncestor $shallowBoundary -Commit $targetCommit)) {
+                throw "Integration history remains shallow at '$shallowBoundary' after fetching '$SourceBranchName' and '$TargetBranchName'."
+            }
+        }
+    }
+    Write-Host "Source '$SourceBranchName': $sourceCommit"
+    Write-Host "Target '$TargetBranchName': $targetCommit"
+    Write-Host "##[endgroup]"
+
+    if (Test-GitAncestor -Repository $repositoryFullPath -PossibleAncestor $sourceCommit -Commit $targetCommit) {
+        Write-Host "Target '$TargetBranchName' already contains source commit '$sourceCommit'. No merge is needed."
+        Write-Host "##vso[task.setvariable variable=IntegratedSourceCommit;isOutput=true]$sourceCommit"
+        Write-Host "##vso[task.setvariable variable=PublishedTargetCommit;isOutput=true]$targetCommit"
+        exit 0
+    }
+
+    Write-Host "##[group]Creating integration merge"
+    Invoke-GitCommand -Repository $repositoryFullPath -Arguments @("checkout", "--detach", $targetTrackingRef)
+
+    $mergeBaseResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @(
+        "merge-base",
+        $targetTrackingRef,
+        $sourceTrackingRef
+    )
+    if ($mergeBaseResult.ExitCode -eq 1) {
+        throw "Source '$SourceBranchName' and target '$TargetBranchName' have unrelated histories. Complete the one-time ancestry setup outside this recurring integration pipeline."
+    } elseif ($mergeBaseResult.ExitCode) {
+        throw "Unable to determine the merge base between '$TargetBranchName' and '$SourceBranchName'."
+    }
+
+    $mergeResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @(
+        "merge",
+        "--no-ff",
+        "--no-edit",
+        "-m",
+        "Merge GitHub main into $TargetBranchName",
+        $sourceTrackingRef
+    )
+    if ($mergeResult.ExitCode) {
+        $conflicts = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("status", "--short")
+        & git -C $repositoryFullPath merge --abort 2>$null
+        throw "Unable to integrate '$SourceBranchName' because the merge has conflicts.`n$conflicts"
+    }
+
+    $mergeCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "HEAD")
+    $mergeParents = (Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
+        "rev-list",
+        "--parents",
+        "-n",
+        "1",
+        $mergeCommit
+    )).Split(" ")
+    if ($mergeParents.Count -ne 3 -or $mergeParents[1] -ne $targetCommit -or $mergeParents[2] -ne $sourceCommit) {
+        throw "Merge '$mergeCommit' must have exactly target '$targetCommit' as its first parent and source '$sourceCommit' as its second parent."
+    }
+
+    Write-Host "Created integration merge '$mergeCommit'."
+    Write-Host "##[endgroup]"
+
+    Write-Host "##[group]Publishing integration merge"
+    $pushResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @(
+        "push",
+        "--porcelain",
+        $RemoteName,
+        "$mergeCommit`:$targetRefName"
+    )
+    if ($pushResult.ExitCode) {
+        $isConcurrentUpdate = $pushResult.Output -match "(?m)^!\s+.*\[(remote )?rejected\]\s+.*\(.*(fetch first|non-fast-forward|stale info|incorrect old value provided|TF401028|has already been updated by another client).*\)\s*$"
+        if (-not $isConcurrentUpdate) {
+            throw "Unable to publish merge '$mergeCommit'.`n$($pushResult.Output)"
+        }
+
+        $currentTargetResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @(
+            "ls-remote",
+            "--exit-code",
+            $RemoteName,
+            $targetRefName
+        )
+        if ($currentTargetResult.ExitCode) {
+            throw "Unable to publish merge '$mergeCommit' and unable to query target branch '$TargetBranchName'.`n$($pushResult.Output)"
+        }
+
+        $currentTargetCommit = ($currentTargetResult.Output -split "\s+")[0]
+        if ($currentTargetCommit -eq $targetCommit) {
+            throw "Unable to publish merge '$mergeCommit' while target branch '$TargetBranchName' remained at '$targetCommit'.`n$($pushResult.Output)"
+        }
+        if ($publishAttempt -eq $maximumPublishAttempts) {
+            throw "Target branch '$TargetBranchName' advanced from '$targetCommit' to '$currentTargetCommit' while publishing, and all $maximumPublishAttempts attempts were exhausted.`n$($pushResult.Output)"
+        }
+
+        Write-Warning "Target branch '$TargetBranchName' advanced from '$targetCommit' to '$currentTargetCommit' while publishing. Rebuilding the merge from current branch tips."
+        Write-Host "##[endgroup]"
+        continue
+    }
+
+    Invoke-GitCommand -Repository $repositoryFullPath -Arguments @(
+        "fetch",
+        "--no-tags",
+        $RemoteName,
+        "+$targetRefName`:$targetTrackingRef"
+    )
+    $publishedTargetCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
+        "rev-parse",
+        "--verify",
+        "$targetTrackingRef^{commit}"
+    )
+    if (-not (Test-GitAncestor -Repository $repositoryFullPath -PossibleAncestor $mergeCommit -Commit $publishedTargetCommit)) {
+        throw "Target branch '$TargetBranchName' at '$publishedTargetCommit' does not contain published merge '$mergeCommit'."
+    }
+
+    Write-Host "Published target branch '$TargetBranchName' at '$publishedTargetCommit'."
+    Write-Host "##vso[task.setvariable variable=IntegratedSourceCommit;isOutput=true]$sourceCommit"
+    Write-Host "##vso[task.setvariable variable=PublishedTargetCommit;isOutput=true]$publishedTargetCommit"
+    Write-Host "##[endgroup]"
+    exit 0
 }
-Write-Host "Created integration merge '$mergeCommit'."
-Write-Host "##[endgroup]"
-
-Write-Host "##[group]Publishing integration merge"
-Invoke-GitCommand -Repository $repositoryFullPath -Arguments @(
-    "push",
-    $RemoteName,
-    "$mergeCommit`:$targetRefName"
-)
-
-$publishedTarget = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @(
-    "ls-remote",
-    "--exit-code",
-    $RemoteName,
-    $targetRefName
-)
-if ($publishedTarget.ExitCode) {
-    throw "Unable to verify target branch '$TargetBranchName' after publication."
-}
-
-$publishedTargetCommit = ($publishedTarget.Output -split "\s+")[0]
-if ($publishedTargetCommit -ne $mergeCommit) {
-    throw "Target branch '$TargetBranchName' is at '$publishedTargetCommit', expected merge '$mergeCommit'."
-}
-
-Write-Host "Published target branch '$TargetBranchName' at '$publishedTargetCommit'."
-Write-Host "##vso[task.setvariable variable=IntegratedSourceCommit;isOutput=true]$sourceCommit"
-Write-Host "##vso[task.setvariable variable=PublishedTargetCommit;isOutput=true]$publishedTargetCommit"
-Write-Host "##[endgroup]"
-
-exit 0

--- a/scripts/MirrorGitRepositoryWithHistory.ps1
+++ b/scripts/MirrorGitRepositoryWithHistory.ps1
@@ -303,6 +303,12 @@ if ($targetBranchExists) {
     $targetCommit = Get-GitCommandOutput $TargetRepositoryDirectoryFullPath @("rev-parse", "--verify", "$targetTrackingRef^{commit}")
     Write-Host "##[debug]Target $TargetRemoteName/$TargetBranchName commit: $targetCommit"
 
+    if ($targetCommit -eq $sourceCommitInTargetRepository) {
+        Write-Host "Target branch '$TargetBranchName' ($targetCommit) is already at source '$SourceBranchName' ($sourceCommitInTargetRepository). Nothing to mirror."
+        Write-Host "##[endgroup]"
+        exit 0
+    }
+
     Write-Host -ForegroundColor Blue "##[command]git -C '$TargetRepositoryDirectoryFullPath' merge-base --is-ancestor $targetCommit $sourceCommitInTargetRepository"
     & git -C $TargetRepositoryDirectoryFullPath merge-base --is-ancestor $targetCommit $sourceCommitInTargetRepository
     $exitCode = $global:LASTEXITCODE


### PR DESCRIPTION
### Summary
Folds the Leg-2 integrate step into the Leg-1 mirror pipeline so a single
GitHub-triggered run performs both legs: fast-forward mirror
(main -> github/internal/main), then a --no-ff integrate
(github/internal/main -> target). Raised here because the mirror pipeline is
defined from this repo and these files are GitHub-sourced.

#### Changes
- Integrate/mirror scripts: retry-on-non-fast-forward + stale-ref/TF401028
  handling; mirror no-op guard tightened to exact-match so a target-ahead
  divergence is refused instead of silently accepted.
- WinUI-PublicMirrorMerge-Stage.yml: exclusive lock (variable group +
  lockBehavior: runLatest); new dependsOnStage param (default '', so the
  stage still works standalone); checkout switched from self to the declared
  targetRepository resource.
- WinUI-MirrorGitHubToInternal-Official.yml: add the integrate stage as a
  second stage (dependsOnStage: Source); header updated to note both legs.

#### Interim:
- The integrate stage currently targets a scratch branch
  (user/gpaskaleva/mirror-integration-target) instead of main, so the
  two-stage flow can be validated without direct pushes to main. Flipping to
  main is a one-line parameter change once the mirror pipeline's build
  identity is granted push/bypass on main (see the TODO in the Official yaml).

#### Notes:
- The stage-graph wiring (expansion, ordering, targetRepository checkout,
  lock) is only fully verifiable via a pipeline run.
- Retiring the standalone integrate pipeline (and deleting
  WinUI-PublicMirrorMerge-Official.yml) is intentionally NOT part of this PR;
  it will be handled separately once the consolidated flow is validated.
