### PR TITLE
Fix use-after-free of cached ICustomProperty descriptors in runtime {Binding}

### DIFF
--- a/dxaml/xcp/dxaml/lib/PropertyProviderPropertyAccess.cpp
+++ b/dxaml/xcp/dxaml/lib/PropertyProviderPropertyAccess.cpp
@@ -19,7 +19,7 @@ PropertyProviderPropertyAccess::Initialize(
     m_pOwnerNoRef = pOwner;
 
     SetPtrValue(m_tpSource, pSource);
-    SetPtrValue(m_tpProperty, pProperty);
+    m_spProperty = pProperty;
 
     m_pPropertyType = pPropertyType;
 
@@ -112,7 +112,7 @@ PropertyProviderPropertyAccess::GetValue(_COM_Outptr_result_maybenull_ IInspecta
 {
     if (IsConnected())
     {
-        IFC_RETURN(m_tpProperty->GetValue(m_tpSource.Get(), ppValue));
+        IFC_RETURN(m_spProperty->GetValue(m_tpSource.Get(), ppValue));
     }
     else
     {
@@ -126,7 +126,7 @@ HRESULT
 PropertyProviderPropertyAccess::SetValue(_In_ IInspectable *pValue)
 {
     IFCEXPECT_RETURN(IsConnected());
-    IFC_RETURN(m_tpProperty->SetValue(m_tpSource.Get(), pValue));
+    IFC_RETURN(m_spProperty->SetValue(m_tpSource.Get(), pValue));
     return S_OK;
 }
 
@@ -184,16 +184,8 @@ PropertyProviderPropertyAccess::TryReconnect(_In_ IInspectable* pSource, _In_ BO
             IFC_RETURN(WindowsCompareStringOrdinal(m_sourceType.Get().Name, newSourceType.Get().Name, &nResult));
             if (nResult == 0)
             {
-                // The cached property may have been collected while this accessor was disconnected.
-                ctl::ComPtr<xaml_data::ICustomProperty> spProperty;
-                IFC_RETURN(spCPP->GetCustomProperty(wrl_wrappers::HStringReference(GetPropertyName()).Get(), spProperty.ReleaseAndGetAddressOf()));
-                SetPtrValue(m_tpProperty, spProperty.Get());
-
-                if (spProperty)
-                {
-                    IFC_RETURN(SetSource(pSource, fListenToChanges));
-                    bConnected = TRUE;
-                }
+                IFC_RETURN(SetSource(pSource, fListenToChanges));
+                bConnected = TRUE;
             }
         }
     }

--- a/dxaml/xcp/dxaml/lib/PropertyProviderPropertyAccess.cpp
+++ b/dxaml/xcp/dxaml/lib/PropertyProviderPropertyAccess.cpp
@@ -184,8 +184,16 @@ PropertyProviderPropertyAccess::TryReconnect(_In_ IInspectable* pSource, _In_ BO
             IFC_RETURN(WindowsCompareStringOrdinal(m_sourceType.Get().Name, newSourceType.Get().Name, &nResult));
             if (nResult == 0)
             {
-                IFC_RETURN(SetSource(pSource, fListenToChanges));
-                bConnected = TRUE;
+                // The cached property may have been collected while this accessor was disconnected.
+                ctl::ComPtr<xaml_data::ICustomProperty> spProperty;
+                IFC_RETURN(spCPP->GetCustomProperty(wrl_wrappers::HStringReference(GetPropertyName()).Get(), spProperty.ReleaseAndGetAddressOf()));
+                SetPtrValue(m_tpProperty, spProperty.Get());
+
+                if (spProperty)
+                {
+                    IFC_RETURN(SetSource(pSource, fListenToChanges));
+                    bConnected = TRUE;
+                }
             }
         }
     }

--- a/dxaml/xcp/dxaml/lib/PropertyProviderPropertyAccess.h
+++ b/dxaml/xcp/dxaml/lib/PropertyProviderPropertyAccess.h
@@ -26,7 +26,7 @@ public:
     _Check_return_ HRESULT GetType(_Outptr_ const CClassInfo **ppType) override
     { *ppType = m_pPropertyType; return S_OK; }
     bool IsConnected() override
-    { return m_tpProperty && m_tpSource; }
+    { return m_spProperty && m_tpSource; }
     _Check_return_ HRESULT SetSource(_In_opt_ IInspectable *pSource, _In_ BOOLEAN fListenToChanges) override;
     _Check_return_ HRESULT GetSource(_COM_Outptr_result_maybenull_ IInspectable **ppSource) override;
     _Check_return_ HRESULT GetSourceType(_Outptr_ const CClassInfo **ppType) override;
@@ -62,7 +62,14 @@ private:
 
     IPropertyAccessHost *m_pOwnerNoRef = nullptr;
     TypeNamePtr m_sourceType;
-    TrackerPtr<xaml_data::ICustomProperty> m_tpProperty;
+
+    // The property descriptor is owned by this accessor, so it is held with a strong reference
+    // instead of a TrackerPtr. A tracker reference only keeps a CCW alive while this object is
+    // reachable during the reference tracker walk, but a source that is still alive keeps raising
+    // change notifications into accessors whose binding target has already become unreachable
+    // (for example a discarded item container waiting for its deferred final release). Reusing a
+    // descriptor that the GC collected in the meantime is a use-after-free.
+    ctl::ComPtr<xaml_data::ICustomProperty> m_spProperty;
     TrackerPtr<xaml_data::ICustomPropertyProvider> m_tpSource;
     const CClassInfo *m_pPropertyType = nullptr;
 };


### PR DESCRIPTION
## Fixes

Related to microsoft/CsWinRT#1834

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Runtime `{Binding}` expressions resolve properties on managed sources through `ICustomPropertyProvider`. `PropertyProviderPropertyAccess` caches the `ICustomProperty` descriptor returned by the provider and reuses it for every subsequent `GetValue`/`SetValue`, and for same-type reconnections.

### Root cause

The descriptor was stored in a `TrackerPtr`. For a CCW that is a reference-tracker reference (`AddRefFromReferenceTracker` + `Peg`, no COM reference): the CLR keeps the managed object alive only while XAML reports it reachable during the reference-tracker walk, i.e. while it is pegged from a live root or found from a live RCW. The accessor itself has a different lifetime: it is owned by the binding's property path, and it stays subscribed to the source's `INotifyPropertyChanged.PropertyChanged` until the binding is torn down. That opens the following window:

1. A binding target leaves the live tree, e.g. an item container is discarded when a list's items source is replaced. Nothing pegs the binding chain any more and the container's managed wrapper dies in the next full GC.
2. In that GC the managed descriptor behind `m_tpProperty` is collected. The accessor, its path step and the binding expression are native objects and stay alive; the tear-down of the discarded target is deferred to a later UI tick (`UIAffinityReleaseQueue`) — or does not happen at all while XAML still considers the target reachable (see the repro below).
3. The binding source, which the app still holds, raises `PropertyChanged`. The accessor is still subscribed, `IsConnected()` only checks the two tracker pointers for non-null, and `m_tpProperty->GetValue(...)` invokes a CCW whose managed target no longer exists. This happens through `PropertyPathListener::PropertyPathStepChanged` → `PropertyAccessPathStep::GetValue` when the leaf source is updated in place, and through `ConnectPathStep` right after the same-type `TryReconnect` reuse when an intermediate source is replaced.

CsWinRT resolves the `ICustomProperty` instance behind the dead CCW to `null`. Depending on what the freed handle slot holds at that moment, the call either fails with a `NullReferenceException` (`0x80004003`) that surfaces from the `PropertyChanged` invocation, or faults with `0xC0000005` inside the virtual dispatch stub (`CLRStub[VSD_DispatchStub]` ← `ABI.Microsoft.UI.Xaml.Data.ICustomProperty.Do_Abi_GetValue_2` ← `PropertyProviderPropertyAccess::GetValue`), which is the crash reported in the linked issue. Because the timing depends on garbage collection, the failure is intermittent.

### Repro

https://github.com/hez2010/winui-binding-lifetime-repro — a page whose rows are generated from a `DataTemplate` and carry the 4-step runtime binding `{Binding ColumnsViewModel.PrimaryColumn.Length.Value, ElementName=PageRoot}`; the view model types implement `IBindableCustomPropertyImplementation` the way the CsWinRT generator does (a new descriptor per `GetProperty` call), and every descriptor is tracked with a `WeakReference`. The deterministic mode:

1. realizes a row and waits for the binding to connect (descriptor created, getter called);
2. runs a full GC with the row in the tree — the descriptor survives;
3. discards the row the way a virtualizing panel discards a container (the native element leaves the tree while its managed wrapper is alive; the wrapper then dies);
4. runs a full GC — with the current binary the descriptor is collected although the native binding still holds it and is still subscribed;
5. raises the change notification on the column;
6. lets XAML run its deferred cleanup and checks that the descriptor is collectible afterwards and that the torn-down binding no longer listens.

To keep the discarded row in the state XAML sees as "reachable" (weak references intact, no deferred cleanup) while nothing protects its descriptors, the container is given a unique-instance managed wrapper before step 2: the runtime never reports the collection of unique-instance wrappers to the reference tracker (`DisconnectFromTrackerSource` is only called for cached wrappers), so XAML keeps treating the container as referenced by a live RCW. CsWinRT creates such wrappers itself for tear-off scenarios (an object whose runtime class is not projected, marshaled under two different static types); the fix does not depend on how an application reaches that state.

| binary | descriptor after the container is discarded (binding still subscribed) | change notification | after XAML tears the binding down | result |
| --- | --- | --- | --- | --- |
| WinUI 3.2.0.2509 (Windows App SDK 2.0.0-experimental3) | collected | `GetValue` on the dead CCW: CsWinRT resolves it to `null` → `NullReferenceException` (`0x80004003`) | – | FAIL |
| this PR (`Build.cmd product`, x64fre) | alive | source re-read through the live descriptor | released, handler detached (no leak) | PASS |

The repro's stress mode (a recycling `ListView` with four such bindings per row, 80 items-source replacements, containers touched from `ContainerContentChanging`, mixed GC flavors, 320 change notifications) reaches collected descriptors several times per run with the current binary (4–8 failing notifications) and passes with the patched binary; after tearing the list down, every one of the ~12k descriptors handed out during the run is collected within ~250 ms — the strong reference does not extend the descriptor's lifetime beyond its accessor. The logs are in the repo (`result-*.log`); the README describes how to build the binary sets.

### Fix

The descriptor is an artifact owned by the accessor, not shared application state like the source, so it is held with a strong `ctl::ComPtr` instead of a `TrackerPtr`. It cannot be collected while an accessor holds it, and it is released together with the accessor when the binding is detached, so nothing leaks. Every consumer (`GetValue`, `SetValue`, `TryReconnect`, target refresh) is covered without re-querying the provider. Native `ICustomProperty` implementations are unaffected: a `TrackerPtr` already held those with a COM reference. The same-type reconnection optimization in `TryReconnect` is unchanged.

## Customer Impact

Managed WinUI applications using runtime `{Binding}` against `ICustomPropertyProvider` sources (which includes every .NET view model bound with `{Binding}`) can terminate with an access violation when a binding source raises a change notification after garbage collection, once one of its binding targets has been discarded. The failure is intermittent and typically shows up during navigation or list refreshes, and applications cannot work around it.

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

The only behavioral difference is that the descriptor object is kept alive for the lifetime of the accessor. CsWinRT's descriptors (`ManagedCustomProperty`, `BindableCustomProperty`) capture only property metadata and static getters, so this cannot form a cycle; an app-implemented `ICustomProperty` that captured a UI element would now be kept alive until its binding is detached.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally
- [x] Built `Microsoft.UI.Xaml.dll` (x64fre) from this branch and ran the linked repro against the released 3.2.0.2509 binary (fails: the collected descriptor is invoked, in both the deterministic and the stress mode) and the patched binary (deterministic and stress modes pass, including the leak/detach checks)

## Screenshots (if appropriate)
