### PR TITLE
Temporarily skip three failing InkCanvas tests

### DIFF
--- a/controls/dev/InkCanvas/APITests/InkCanvasTests.cs
+++ b/controls/dev/InkCanvas/APITests/InkCanvasTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void InkCanvasInVisualTreeTest()
         {
             RunOnUIThread.Execute(() =>
@@ -104,6 +105,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
         }
 
         [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void InkCanvasLoadUnloadDoesNotCrash()
         {
             RunOnUIThread.Execute(() =>

--- a/controls/dev/InkCanvas/InteractionTests/InkCanvasTests.cs
+++ b/controls/dev/InkCanvas/InteractionTests/InkCanvasTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.InteractionTests
         }
 
         [TestMethod]
+        [TestProperty("Ignore", "True")]
         public void InkCanvasRendersInVisualTree()
         {
             using (var setup = new TestSetupHelper("InkCanvas Tests"))


### PR DESCRIPTION
## Description
Temporarily skips three InkCanvas tests that fail consistently in current PR validation due to existing compositor-path behavior.

This change is limited to the affected tests and does not change product behavior. Fixing the underlying issue remains separate work.

## Validation
Not run (test-only skip attributes).