### PR TITLE
Temporarily skip six MediaPlayerElement caption tests

### DIFF
--- a/dxaml/test/native/external/foundation/graphics/MediaPlayerElement/ClosedCaptionTestsMPE.h
+++ b/dxaml/test/native/external/foundation/graphics/MediaPlayerElement/ClosedCaptionTestsMPE.h
@@ -24,21 +24,21 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithCustomStyle)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with custom style.")
-                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
+                TEST_METHOD_PROPERTY(L"TestPass:MaxOSVer", WINDOWS_OS_VERSION_24H2)
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithCustomRegion)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with custom region.")
-                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
+                TEST_METHOD_PROPERTY(L"TestPass:MaxOSVer", WINDOWS_OS_VERSION_24H2)
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithLines)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with cues and multiple lines")
-                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
+                TEST_METHOD_PROPERTY(L"TestPass:MaxOSVer", WINDOWS_OS_VERSION_24H2)
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()
@@ -50,7 +50,7 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithSubformatting)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with subformatting")
-                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
+                TEST_METHOD_PROPERTY(L"TestPass:MaxOSVer", WINDOWS_OS_VERSION_24H2)
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
                 TEST_METHOD_PROPERTY(L"TestPass:MinOSVer", WINDOWS_OS_VERSION_19H1) // TODO: [MediaPlayerElement] Some CC tests fail on RS5
@@ -58,7 +58,7 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithMultipleColors)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with multi-color line")
-                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
+                TEST_METHOD_PROPERTY(L"TestPass:MaxOSVer", WINDOWS_OS_VERSION_24H2)
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
                 TEST_METHOD_PROPERTY(L"TestPass:MinOSVer", WINDOWS_OS_VERSION_19H1) // TODO: [MediaPlayerElement] Some CC tests fail on RS5
@@ -66,7 +66,7 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithOutline)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with text outline")
-                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
+                TEST_METHOD_PROPERTY(L"TestPass:MaxOSVer", WINDOWS_OS_VERSION_24H2)
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()

--- a/dxaml/test/native/external/foundation/graphics/MediaPlayerElement/ClosedCaptionTestsMPE.h
+++ b/dxaml/test/native/external/foundation/graphics/MediaPlayerElement/ClosedCaptionTestsMPE.h
@@ -24,18 +24,21 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithCustomStyle)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with custom style.")
+                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithCustomRegion)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with custom region.")
+                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithLines)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with cues and multiple lines")
+                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()
@@ -47,6 +50,7 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithSubformatting)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with subformatting")
+                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
                 TEST_METHOD_PROPERTY(L"TestPass:MinOSVer", WINDOWS_OS_VERSION_19H1) // TODO: [MediaPlayerElement] Some CC tests fail on RS5
@@ -54,6 +58,7 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithMultipleColors)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with multi-color line")
+                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
                 TEST_METHOD_PROPERTY(L"TestPass:MinOSVer", WINDOWS_OS_VERSION_19H1) // TODO: [MediaPlayerElement] Some CC tests fail on RS5
@@ -61,6 +66,7 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
 
             BEGIN_TEST_METHOD(MediaPlayerElementWithOutline)
                 TEST_METHOD_PROPERTY(L"Description", L"Closed Captions with text outline")
+                TEST_METHOD_PROPERTY(L"Ignore", L"TRUE")
                 TEST_METHOD_PROPERTY(L"VelocityTestPass:OneCoreStrict", L"Desktop")
                 TEST_METHOD_PROPERTY(L"HasAssociatedMasterFile", L"True")
             END_TEST_METHOD()


### PR DESCRIPTION
## Description
Temporarily skips six MediaPlayerElement closed-caption tests whose rendered caption output does not match the expected test baselines in the current validation environment.

This change is limited to the affected tests and does not change product behavior. Resolving the underlying caption-output difference remains separate work.

## Validation
Not run (test-only metadata change).