### PR TITLE
Skip redir bitmap creation and add placeholder visual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bld/
 # Visual Studio Code cache/options directory
 .vscode/.BROWSE*
 
+# Local Git worktrees
+.worktrees/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/Samples/WindowPlaceholderVisual/App.xaml
+++ b/Samples/WindowPlaceholderVisual/App.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="WindowPlaceholderVisual.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/Samples/WindowPlaceholderVisual/App.xaml.cpp
+++ b/Samples/WindowPlaceholderVisual/App.xaml.cpp
@@ -1,0 +1,31 @@
+#include "pch.h"
+#include "App.xaml.h"
+#include "MainWindow.xaml.h"
+
+using namespace winrt;
+using namespace Microsoft::UI::Xaml;
+
+namespace winrt::WindowPlaceholderVisual::implementation
+{
+    App::App()
+    {
+#if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
+        UnhandledException([](IInspectable const&, UnhandledExceptionEventArgs const& e)
+        {
+            if (IsDebuggerPresent())
+            {
+                auto errorMessage = e.Message();
+                __debugbreak();
+            }
+        });
+#endif
+    }
+
+    void App::OnLaunched([[maybe_unused]] LaunchActivatedEventArgs const& e)
+    {
+        auto mainWindow = make<MainWindow>();
+        m_window = mainWindow;
+        m_window.Activate();
+        mainWindow.BeginDelayedContent();
+    }
+}

--- a/Samples/WindowPlaceholderVisual/App.xaml.h
+++ b/Samples/WindowPlaceholderVisual/App.xaml.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "App.xaml.g.h"
+
+namespace winrt::WindowPlaceholderVisual::implementation
+{
+    struct App : AppT<App>
+    {
+        App();
+
+        void OnLaunched(Microsoft::UI::Xaml::LaunchActivatedEventArgs const&);
+
+    private:
+        Microsoft::UI::Xaml::Window m_window{ nullptr };
+    };
+}

--- a/Samples/WindowPlaceholderVisual/MainWindow.idl
+++ b/Samples/WindowPlaceholderVisual/MainWindow.idl
@@ -1,0 +1,9 @@
+namespace WindowPlaceholderVisual
+{
+    [default_interface]
+    runtimeclass MainWindow : Microsoft.UI.Xaml.Window
+    {
+        MainWindow();
+        void BeginDelayedContent();
+    }
+}

--- a/Samples/WindowPlaceholderVisual/MainWindow.xaml
+++ b/Samples/WindowPlaceholderVisual/MainWindow.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="WindowPlaceholderVisual.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Window placeholder visual comparison" />

--- a/Samples/WindowPlaceholderVisual/MainWindow.xaml.cpp
+++ b/Samples/WindowPlaceholderVisual/MainWindow.xaml.cpp
@@ -1,0 +1,105 @@
+#include "pch.h"
+#include "MainWindow.xaml.h"
+#if __has_include("MainWindow.g.cpp")
+#include "MainWindow.g.cpp"
+#endif
+
+using namespace winrt;
+using namespace Microsoft::UI::Dispatching;
+using namespace Microsoft::UI::Xaml;
+using namespace Microsoft::UI::Xaml::Controls;
+using namespace Microsoft::UI::Xaml::Media;
+
+namespace winrt::WindowPlaceholderVisual::implementation
+{
+    void MainWindow::BeginDelayedContent()
+    {
+        m_contentTimer = DispatcherQueue().CreateTimer();
+        m_contentTimer.Interval(std::chrono::seconds(2));
+        m_contentTimer.IsRepeating(false);
+
+        auto weakThis = get_weak();
+        m_contentTimer.Tick([weakThis](DispatcherQueueTimer const&, IInspectable const&)
+        {
+            if (auto strongThis = weakThis.get())
+            {
+                strongThis->AttachFinalContent();
+            }
+        });
+        m_contentTimer.Start();
+    }
+
+    void MainWindow::AttachFinalContent()
+    {
+        m_contentTimer.Stop();
+        m_contentTimer = nullptr;
+
+        auto root = Grid();
+        root.Background(SolidColorBrush(Windows::UI::Color{ 0xff, 0x28, 0x0a, 0x50 }));
+
+        auto panel = StackPanel();
+        panel.HorizontalAlignment(HorizontalAlignment::Center);
+        panel.VerticalAlignment(VerticalAlignment::Center);
+        panel.Spacing(12);
+        panel.Margin(Thickness{ 40 });
+
+        auto heading = TextBlock();
+        heading.Text(L"Contrasting content attached after a 2-second delay");
+        heading.FontSize(26);
+        heading.FontWeight(Windows::UI::Text::FontWeights::SemiBold());
+        heading.TextWrapping(TextWrapping::Wrap);
+        heading.Foreground(SolidColorBrush(Windows::UI::Colors::White()));
+        panel.Children().Append(heading);
+
+        const bool noRedirectionEnabled = g_noRedirectionMode == FeatureMode::On;
+        const bool placeholderEnabled = g_placeholderMode == FeatureMode::On;
+        const auto noRedirectionMode = noRedirectionEnabled ? L"ON" : L"OFF";
+        const auto placeholderMode = placeholderEnabled ? L"ON" : L"OFF";
+        const auto requestedTheme =
+            Application::Current().RequestedTheme() == ApplicationTheme::Dark ? L"Dark" : L"Light";
+
+        auto noRedirectionText = TextBlock();
+        noRedirectionText.Text(hstring{
+            std::wstring{ L"No-redirection change: " } + noRedirectionMode });
+        noRedirectionText.FontSize(22);
+        noRedirectionText.Foreground(
+            SolidColorBrush(Windows::UI::Color{ 0xff, 0xff, 0xd7, 0x00 }));
+        panel.Children().Append(noRedirectionText);
+
+        auto placeholderText = TextBlock();
+        placeholderText.Text(hstring{
+            std::wstring{ L"Window placeholder change: " } + placeholderMode });
+        placeholderText.FontSize(22);
+        placeholderText.Foreground(
+            SolidColorBrush(Windows::UI::Color{ 0xff, 0xff, 0xd7, 0x00 }));
+        panel.Children().Append(placeholderText);
+
+        const wchar_t* combination =
+            noRedirectionEnabled
+                ? (placeholderEnabled ? L"Combined mitigation" : L"No redirection only")
+                : (placeholderEnabled ? L"Placeholder only" : L"Baseline");
+
+        auto combinationText = TextBlock();
+        combinationText.Text(hstring{ std::wstring{ L"Combination: " } + combination });
+        combinationText.FontSize(20);
+        combinationText.Foreground(SolidColorBrush(Windows::UI::Colors::White()));
+        panel.Children().Append(combinationText);
+
+        auto themeText = TextBlock();
+        themeText.Text(L"Application requested theme: " + hstring{ requestedTheme });
+        themeText.FontSize(18);
+        themeText.Foreground(SolidColorBrush(Windows::UI::Colors::White()));
+        panel.Children().Append(themeText);
+
+        auto instructions = TextBlock();
+        instructions.Text(hstring{
+            L"Launch with --no-redirection=on|off --placeholder=on|off to compare all four combinations." });
+        instructions.FontSize(18);
+        instructions.TextWrapping(TextWrapping::Wrap);
+        instructions.Foreground(SolidColorBrush(Windows::UI::Colors::White()));
+        panel.Children().Append(instructions);
+
+        root.Children().Append(panel);
+        Content(root);
+    }
+}

--- a/Samples/WindowPlaceholderVisual/MainWindow.xaml.h
+++ b/Samples/WindowPlaceholderVisual/MainWindow.xaml.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "MainWindow.g.h"
+
+namespace winrt::WindowPlaceholderVisual::implementation
+{
+    struct MainWindow : MainWindowT<MainWindow>
+    {
+        MainWindow() = default;
+
+        void BeginDelayedContent();
+
+    private:
+        void AttachFinalContent();
+
+        Microsoft::UI::Dispatching::DispatcherQueueTimer m_contentTimer{ nullptr };
+    };
+}
+
+namespace winrt::WindowPlaceholderVisual::factory_implementation
+{
+    struct MainWindow : MainWindowT<MainWindow, implementation::MainWindow>
+    {
+    };
+}

--- a/Samples/WindowPlaceholderVisual/WindowPlaceholderVisual.sln
+++ b/Samples/WindowPlaceholderVisual/WindowPlaceholderVisual.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.37314.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WindowPlaceholderVisual", "WindowPlaceholderVisual.vcxproj", "{2789FCB1-DAB5-4F41-9306-49185B4C18C9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2789FCB1-DAB5-4F41-9306-49185B4C18C9}.Debug|x64.ActiveCfg = Debug|x64
+		{2789FCB1-DAB5-4F41-9306-49185B4C18C9}.Debug|x64.Build.0 = Debug|x64
+		{2789FCB1-DAB5-4F41-9306-49185B4C18C9}.Release|x64.ActiveCfg = Release|x64
+		{2789FCB1-DAB5-4F41-9306-49185B4C18C9}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Samples/WindowPlaceholderVisual/WindowPlaceholderVisual.vcxproj
+++ b/Samples/WindowPlaceholderVisual/WindowPlaceholderVisual.vcxproj
@@ -1,0 +1,221 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug_test|ARM64">
+      <Configuration>Debug_test</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug_test|ARM64EC">
+      <Configuration>Debug_test</Configuration>
+      <Platform>ARM64EC</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug_test|Win32">
+      <Configuration>Debug_test</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug_test|x64">
+      <Configuration>Debug_test</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64EC">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64EC</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64EC">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64EC</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <XamlLightup>true</XamlLightup>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{2789fcb1-dab5-4f41-9306-49185b4c18c9}</ProjectGuid>
+    <ProjectName>WindowPlaceholderVisual</ProjectName>
+    <RootNamespace>WindowPlaceholderVisual</RootNamespace>
+    <!--
+      $(TargetName) should be same as $(RootNamespace) so that the produced binaries (.exe/.pri/etc.)
+      have a name that matches the .winmd
+    -->
+    <TargetName>$(RootNamespace)</TargetName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>false</AppContainerApplication>
+    <AppxPackage>false</AppxPackage>
+    <WindowsPackageType>None</WindowsPackageType>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <UseWinUI>true</UseWinUI>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.props')" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.props')" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.props')" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.props')" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.props')" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.props')" />
+  <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.props')" />
+  <PropertyGroup>
+    <OutDir>$(ArtifactsBinDir)Samples\WindowPlaceholderVisual\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <DesktopCompatible>true</DesktopCompatible>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug_test'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Manifest Include="app.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="App.xaml.h">
+      <DependentUpon>App.xaml</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="MainWindow.xaml.h">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml" />
+    <Page Include="MainWindow.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="App.xaml.cpp">
+      <DependentUpon>App.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="MainWindow.xaml.cpp">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="program.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="MainWindow.idl">
+      <SubType>Code</SubType>
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Midl>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.targets')" />
+    <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.targets')" />
+    <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.targets')" />
+    <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.targets')" />
+    <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.targets')" />
+    <Import Project="$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.targets" Condition="Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.props'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.MSIX.$(MicrosoftWindowsSDKBuildToolsMsixNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.MSIX.targets'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.props'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.WinUI.$(WinUIVersion)\build\native\Microsoft.WindowsAppSDK.WinUI.targets'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.props'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Windows.SDK.BuildTools.$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.props'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Base.$(BasePackageVersion)\build\native\Microsoft.WindowsAppSDK.Base.targets'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.props'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.InteractiveExperiences.$(IXPPackageVersion)\build\native\Microsoft.WindowsAppSDK.InteractiveExperiences.targets'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.props'))" />
+    <Error Condition="!Exists('$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.WindowsAppSDK.Foundation.$(FoundationPackageVersion)\build\native\Microsoft.WindowsAppSDK.Foundation.targets'))" />
+    <!-- Detect addition of a props file to the WebView2 package (best practice is to always include both props and targets, even if empty, for future-proofing) -->
+    <PropertyGroup>
+      <ErrorText>This project does not import the newly added WebView2 NuGet package props file {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="Exists('$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.props')" Text="$([System.String]::Format('$(ErrorText)', '$(NugetPackageDirectory)\Microsoft.Web.WebView2.$(WebView2PackageVersion)\build\native\Microsoft.Web.WebView2.props'))" />
+  </Target>
+  <!--
+    ARM64EC apps are packaged as x64 (an x64 MSIX containing ARM64EC binaries, for execution on
+    an ARM64 OS). The WinAppSDK/MSIX packaging targets' _GetPackageArchitecture calls the
+    WinAppSdkGetPackageArchitecture task, which rejects Platform=ARM64EC (error APPX0504). The
+    repo-wide override in eng\configuration.arm64ec.targets is imported (via Directory.Build.targets)
+    before those packaging targets, so it gets overridden back. Redefining the target here - after
+    the ExtensionTargets ImportGroup - makes this the last definition so it wins, mapping ARM64EC to
+    an x64 package while leaving all other platforms to the real task. Matches WinUICppNoPCHSampleApp.
+  -->
+  <Target Name="_GetPackageArchitecture">
+    <PropertyGroup Condition="'$(Platform)'=='arm64ec'">
+      <PackageArchitecture>x64</PackageArchitecture>
+    </PropertyGroup>
+    <WinAppSdkGetPackageArchitecture Platform="$(Platform)" ProjectArchitecture="@(ProjectArchitecture)" RecursiveProjectArchitecture="@(_RecursiveProjectArchitecture)" VsTelemetrySession="$(VsTelemetrySession)" Condition="'$(Platform)'!='arm64ec'">
+      <Output TaskParameter="PackageArchitecture" PropertyName="PackageArchitecture" />
+    </WinAppSdkGetPackageArchitecture>
+  </Target>
+</Project>

--- a/Samples/WindowPlaceholderVisual/WindowPlaceholderVisual.vcxproj.filters
+++ b/Samples/WindowPlaceholderVisual/WindowPlaceholderVisual.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="MainWindow.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="MainWindow.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="App.xaml.cpp" />
+    <ClCompile Include="MainWindow.xaml.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="program.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="App.xaml.h" />
+    <ClInclude Include="MainWindow.xaml.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="app.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/Samples/WindowPlaceholderVisual/app.manifest
+++ b/Samples/WindowPlaceholderVisual/app.manifest
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="WindowPlaceholderVisual.app"/>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Samples/WindowPlaceholderVisual/packages.config
+++ b/Samples/WindowPlaceholderVisual/packages.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.VCRTForwarders.140" version="1.0.6" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.3719.77" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.BuildTools.MSIX" version="1.7.20250508.1" />
+</packages>

--- a/Samples/WindowPlaceholderVisual/pch.cpp
+++ b/Samples/WindowPlaceholderVisual/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/Samples/WindowPlaceholderVisual/pch.h
+++ b/Samples/WindowPlaceholderVisual/pch.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <windows.h>
+#include <unknwn.h>
+#include <restrictederrorinfo.h>
+#include <hstring.h>
+
+#undef GetCurrentTime
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.UI.h>
+#include <winrt/Windows.UI.Text.h>
+#include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Microsoft.UI.Xaml.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Markup.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.Xaml.Settings.h>
+
+#include <chrono>
+#include <string>
+#include <string_view>
+
+#define DISABLE_XAML_GENERATED_MAIN
+
+enum class FeatureMode
+{
+    Off,
+    On,
+};
+
+extern FeatureMode g_noRedirectionMode;
+extern FeatureMode g_placeholderMode;

--- a/Samples/WindowPlaceholderVisual/program.cpp
+++ b/Samples/WindowPlaceholderVisual/program.cpp
@@ -1,0 +1,86 @@
+#include "pch.h"
+#include "App.xaml.h"
+
+using namespace winrt;
+using namespace Microsoft::UI::Xaml;
+using namespace Microsoft::UI::Xaml::Settings;
+
+FeatureMode g_noRedirectionMode = FeatureMode::Off;
+FeatureMode g_placeholderMode = FeatureMode::Off;
+
+namespace
+{
+    constexpr auto SkipWindowRedirectionSurfaceChange =
+        static_cast<XamlChangeId>(63530879);
+    constexpr auto WindowPlaceholderVisualChange =
+        static_cast<XamlChangeId>(63530880);
+
+    struct ParsedModes
+    {
+        FeatureMode noRedirectionMode;
+        FeatureMode placeholderMode;
+        bool conflictingSwitches;
+    };
+
+    ParsedModes ParseModes(std::wstring_view commandLine)
+    {
+        const bool noRedirectionOn =
+            commandLine.find(L"--no-redirection=on") != std::wstring_view::npos;
+        const bool noRedirectionOff =
+            commandLine.find(L"--no-redirection=off") != std::wstring_view::npos;
+        const bool placeholderOn =
+            commandLine.find(L"--placeholder=on") != std::wstring_view::npos;
+        const bool placeholderOff =
+            commandLine.find(L"--placeholder=off") != std::wstring_view::npos;
+
+        return
+        {
+            noRedirectionOn ? FeatureMode::On : FeatureMode::Off,
+            placeholderOn ? FeatureMode::On : FeatureMode::Off,
+            (noRedirectionOn && noRedirectionOff) || (placeholderOn && placeholderOff),
+        };
+    }
+
+    void SetChangeState(XamlChangeId changeId, FeatureMode mode)
+    {
+        if (mode == FeatureMode::On)
+        {
+            XamlOptionalChanges::EnableChange(changeId);
+        }
+        else
+        {
+            XamlOptionalChanges::DisableChange(changeId);
+        }
+    }
+}
+
+int __stdcall wWinMain(
+    _In_ HINSTANCE,
+    _In_opt_ HINSTANCE,
+    _In_ PWSTR commandLine,
+    _In_ int)
+{
+    const auto parsedModes = ParseModes(commandLine ? commandLine : L"");
+    if (parsedModes.conflictingSwitches)
+    {
+        MessageBoxW(
+            nullptr,
+            L"Specify only one value for each of --no-redirection=on|off and --placeholder=on|off.",
+            L"Window placeholder visual comparison",
+            MB_OK | MB_ICONERROR);
+        return 2;
+    }
+
+    g_noRedirectionMode = parsedModes.noRedirectionMode;
+    g_placeholderMode = parsedModes.placeholderMode;
+
+    winrt::init_apartment(winrt::apartment_type::single_threaded);
+    SetChangeState(SkipWindowRedirectionSurfaceChange, g_noRedirectionMode);
+    SetChangeState(WindowPlaceholderVisualChange, g_placeholderMode);
+
+    Application::Start([](auto&&)
+    {
+        make<WindowPlaceholderVisual::implementation::App>();
+    });
+    return 0;
+}

--- a/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
+++ b/controls/test/MUXControlsTestApp/Utilities/APITestBase.cs
@@ -170,6 +170,10 @@ namespace MUXControlsTestApp.Utilities
                         {
                             changeId = XamlChangeId.DeferContextFlyoutInit;
                         }
+                        else if (string.Equals(name, "SkipWindowRedirectionSurface", StringComparison.OrdinalIgnoreCase))
+                        {
+                            changeId = XamlChangeId.SkipWindowRedirectionSurface;
+                        }
 
                         Verify.AreNotEqual(changeId, XamlChangeId._Reserved, "Unknown XamlChangeId: " + name);
 

--- a/dxaml/test/infra/client/idl/Private.Infrastructure.idl
+++ b/dxaml/test/infra/client/idl/Private.Infrastructure.idl
@@ -929,6 +929,11 @@ namespace Private.Infrastructure
         HRESULT GetAllocationCount([out, retval] UINT64* count);
         HRESULT GetAllocationSize([out, retval] UINT64* size);
         HRESULT GetDeallocationCount([out, retval] UINT64* count);
+
+        // Returns whether the window's top-level island currently holds the window placeholder
+        // visual installed before the first rendered frame. Fails if the window or its island
+        // render data cannot be resolved, so missing state is never reported as FALSE.
+        HRESULT HasWindowPlaceholder([in] Microsoft.UI.Xaml.Window* window, [out, retval] BOOLEAN* hasPlaceholder);
     }
 
     [version(NTDDI_WIN10_RS3)]

--- a/dxaml/test/infra/client/lib/WindowHelper.cpp
+++ b/dxaml/test/infra/client/lib/WindowHelper.cpp
@@ -2108,6 +2108,10 @@ std::vector<std::pair<xaml_settings::XamlChangeId, bool>> GetXamlOptionalChanges
             {
                 changeId = xaml_settings::XamlChangeId_DeferContextFlyoutInit;
             }
+            else if (_wcsicmp(name.c_str(), L"SkipWindowRedirectionSurface") == 0)
+            {
+                changeId = xaml_settings::XamlChangeId_SkipWindowRedirectionSurface;
+            }
 
             if (changeId == xaml_settings::XamlChangeId__Reserved)
             {
@@ -3645,6 +3649,22 @@ HRESULT WindowHelper::GetWindows(_Outptr_ wfc::IVectorView<xaml::Window*>** wind
 
             LogThrow_IfFailed(applicationPrivate->get_Windows(windows));
         });
+    }
+    COM_END
+}
+
+HRESULT WindowHelper::HasWindowPlaceholder(_In_ xaml::IWindow* window, _Out_ BOOLEAN* hasPlaceholder)
+{
+    COM_START_GROUP(L"WindowHelper::HasWindowPlaceholder")
+    {
+        *hasPlaceholder = FALSE;
+
+        BOOLEAN result = FALSE;
+        RunOnUIThread([&]() {
+            LogThrow_IfFailed(GetTestHooks()->HasWindowPlaceholder(window, &result));
+        });
+
+        *hasPlaceholder = result;
     }
     COM_END
 }

--- a/dxaml/test/infra/client/lib/WindowHelper.h
+++ b/dxaml/test/infra/client/lib/WindowHelper.h
@@ -240,6 +240,11 @@ namespace Private { namespace Infrastructure {
             _Outptr_ wfc::IVectorView<xaml::Window*>** windows
             ) override;
 
+        IFACEMETHOD(HasWindowPlaceholder)(
+            _In_ xaml::IWindow* window,
+            _Out_ BOOLEAN* hasPlaceholder
+            ) override;
+
         IFACEMETHOD(DetachMemoryManagerEvents)() override;
 
         IFACEMETHOD(GetElementRenderedVisuals)(_In_ xaml::IUIElement* element, wfc::IVector<IInspectable*>* visuals);

--- a/dxaml/test/native/external/controls/window/WindowIntegrationTests.cpp
+++ b/dxaml/test/native/external/controls/window/WindowIntegrationTests.cpp
@@ -11,6 +11,7 @@
 #include <SafeEventRegistration.h>
 #include <TestCleanupWrapper.h>
 #include <ControlHelper.h>
+#include <DisableRenderingScopeGuard.h>
 #include <WindowAutoCloser.h>
 #include <microsoft.ui.xaml.window.h> // for IWindowNative
 
@@ -62,6 +63,41 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             windowHeight,
             outerWidthInDips - windowWidth,
             outerHeightInDips - windowHeight);
+    }
+
+    // Returns the top-level HWND backing a Window. The HWND exists as soon as the Window is
+    // created, so this is safe to call before Activate().
+    HWND GetWindowHandleForWindow(xaml::Window^ window)
+    {
+        IWindowNative* windowNative = nullptr;
+        VERIFY_SUCCEEDED(reinterpret_cast<IUnknown*>(window)->QueryInterface(__uuidof(IWindowNative), (void**)&windowNative));
+
+        HWND windowHandle = nullptr;
+        const HRESULT hr = windowNative->get_WindowHandle(&windowHandle);
+
+        windowNative->Release();
+        windowNative = nullptr;
+
+        VERIFY_SUCCEEDED(hr);
+        return windowHandle;
+    }
+
+    bool HasNoRedirectionBitmapExtendedStyle(HWND windowHandle)
+    {
+        return (::GetWindowLongPtr(windowHandle, GWL_EXSTYLE) & WS_EX_NOREDIRECTIONBITMAP) != 0;
+    }
+
+    bool HasWindowPlaceholder(xaml::Window^ window)
+    {
+        return !!TestServices::WindowHelper->HasWindowPlaceholder(window);
+    }
+
+    xaml::Window^ LoadWindowWithContent()
+    {
+        return safe_cast<xaml::Window^>(xaml_markup::XamlReader::Load(
+            L"<Window xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+            L"  <Grid x:Name='rootPanel' Background='Red'/>"
+            L"</Window>"));
     }
 
     bool WindowIntegrationTests::ClassSetup()
@@ -2516,5 +2552,221 @@ void WindowIntegrationTests::ContentSetInMarkupIsReleasedWhenCleared()
 #endif
     }
 
+    void WindowIntegrationTests::WindowPlaceholderIsUsedUntilFirstFrame()
+    {
+        TestCleanupWrapper cleanup;
+
+        WindowAutoCloser window1;
+
+        {
+            // Rendering is disabled for the whole window lifetime up to the assertion below:
+            // a frame that ran between creation and activation would connect the island content
+            // permanently, and activation would then (correctly) skip the placeholder.
+            DisableRenderingScopeGuard disableRendering;
+
+            HWND windowHandle = nullptr;
+            RunOnUIThread([&]()
+            {
+                window1.Attach(LoadWindowWithContent());
+                windowHandle = GetWindowHandleForWindow(window1.get());
+            });
+
+            VERIFY_IS_NOT_NULL(windowHandle);
+
+            LOG_OUTPUT(L"----- The HWND is created without a redirection surface, before it is ever activated -----");
+            VERIFY_IS_TRUE(HasNoRedirectionBitmapExtendedStyle(windowHandle));
+
+            LOG_OUTPUT(L"----- No placeholder exists before the window is activated -----");
+            VERIFY_IS_FALSE(HasWindowPlaceholder(window1.get()));
+
+            RunOnUIThread([&]()
+            {
+                window1->Activate();
+            });
+
+            LOG_OUTPUT(L"----- Activation installs the placeholder before the first frame -----");
+            VERIFY_IS_TRUE(HasWindowPlaceholder(window1.get()));
+        }
+
+        LOG_OUTPUT(L"----- The first rendered frame replaces the placeholder with the real content -----");
+        TestServices::WindowHelper->WaitForIdle();
+
+        VERIFY_IS_FALSE(HasWindowPlaceholder(window1.get()));
+
+        RunOnUIThread([&]()
+        {
+            VERIFY_IS_TRUE(!!window1->Visible);
+
+            auto rootPanel = safe_cast<xaml_controls::Grid^>(window1->Content);
+            VERIFY_IS_NOT_NULL(rootPanel);
+            VERIFY_IS_GREATER_THAN(rootPanel->ActualWidth, 0.0);
+            VERIFY_IS_GREATER_THAN(rootPanel->ActualHeight, 0.0);
+        });
+
+        LOG_OUTPUT(L"----- Activating again after the first frame does not reinstall the placeholder -----");
+        {
+            // Rendering stays disabled across this second Activate(): if activation reinstalled a
+            // placeholder, nothing could clear it before the assertion below. A FALSE result
+            // therefore proves the placeholder path is confined to the initial activation.
+            DisableRenderingScopeGuard disableRendering;
+
+            RunOnUIThread([&]()
+            {
+                window1->Activate();
+            });
+
+            VERIFY_IS_FALSE(HasWindowPlaceholder(window1.get()));
+        }
+
+        TestServices::WindowHelper->WaitForIdle();
+
+        VERIFY_IS_FALSE(HasWindowPlaceholder(window1.get()));
+    }
+
+    void WindowIntegrationTests::WindowPlaceholderIsNotUsedWhenDisabled()
+    {
+        TestCleanupWrapper cleanup;
+
+        WindowAutoCloser window1;
+
+        {
+            DisableRenderingScopeGuard disableRendering;
+
+            HWND windowHandle = nullptr;
+            RunOnUIThread([&]()
+            {
+                window1.Attach(LoadWindowWithContent());
+                windowHandle = GetWindowHandleForWindow(window1.get());
+            });
+
+            VERIFY_IS_NOT_NULL(windowHandle);
+
+            LOG_OUTPUT(L"----- The HWND keeps its redirection surface when the change is disabled -----");
+            VERIFY_IS_FALSE(HasNoRedirectionBitmapExtendedStyle(windowHandle));
+
+            RunOnUIThread([&]()
+            {
+                window1->Activate();
+            });
+
+            // A FALSE result here is meaningful rather than vacuous: the query fails (and throws)
+            // unless the window resolves to a desktop window whose island has a render data entry,
+            // which is the same state in which WindowPlaceholderIsUsedUntilFirstFrame observes a
+            // placeholder. So FALSE means "an entry exists and holds no placeholder visual", not
+            // "placeholder state could not be determined".
+            LOG_OUTPUT(L"----- No placeholder is installed, even before the first frame -----");
+            VERIFY_IS_FALSE(HasWindowPlaceholder(window1.get()));
+        }
+
+        TestServices::WindowHelper->WaitForIdle();
+
+        LOG_OUTPUT(L"----- ...and still none after the window has rendered -----");
+        VERIFY_IS_FALSE(HasWindowPlaceholder(window1.get()));
+
+        RunOnUIThread([&]()
+        {
+            VERIFY_IS_TRUE(!!window1->Visible);
+
+            auto rootPanel = safe_cast<xaml_controls::Grid^>(window1->Content);
+            VERIFY_IS_NOT_NULL(rootPanel);
+            VERIFY_IS_GREATER_THAN(rootPanel->ActualWidth, 0.0);
+            VERIFY_IS_GREATER_THAN(rootPanel->ActualHeight, 0.0);
+        });
+    }
+
+    void WindowIntegrationTests::WindowPlaceholderSurvivesCloseBeforeFirstFrame()
+    {
+        TestCleanupWrapper cleanup;
+
+        {
+            WindowAutoCloser window1;
+            DisableRenderingScopeGuard disableRendering;
+
+            RunOnUIThread([&]()
+            {
+                window1.Attach(LoadWindowWithContent());
+                window1->Activate();
+            });
+
+            LOG_OUTPUT(L"----- The window is closed while its placeholder is still installed -----");
+            VERIFY_IS_TRUE(HasWindowPlaceholder(window1.get()));
+
+            window1.Close();
+        }
+
+        // Resume rendering and let the framework tick: tearing down an island that still owned a
+        // placeholder must not fault or leave stale render data behind.
+        TestServices::WindowHelper->WaitForIdle();
+
+        LOG_OUTPUT(L"----- A subsequent window still goes through the full placeholder lifetime -----");
+        WindowAutoCloser window2;
+
+        {
+            DisableRenderingScopeGuard disableRendering;
+
+            RunOnUIThread([&]()
+            {
+                window2.Attach(LoadWindowWithContent());
+                window2->Activate();
+            });
+
+            VERIFY_IS_TRUE(HasWindowPlaceholder(window2.get()));
+        }
+
+        TestServices::WindowHelper->WaitForIdle();
+
+        VERIFY_IS_FALSE(HasWindowPlaceholder(window2.get()));
+
+        RunOnUIThread([&]()
+        {
+            VERIFY_IS_TRUE(!!window2->Visible);
+        });
+    }
+
+    void WindowIntegrationTests::WindowPlaceholderIsTrackedPerWindow()
+    {
+        TestCleanupWrapper cleanup;
+
+        WindowAutoCloser window1;
+        WindowAutoCloser window2;
+
+        {
+            DisableRenderingScopeGuard disableRendering;
+
+            RunOnUIThread([&]()
+            {
+                window1.Attach(LoadWindowWithContent());
+                window2.Attach(LoadWindowWithContent());
+            });
+
+            LOG_OUTPUT(L"----- Activating one window does not install a placeholder in the other -----");
+            RunOnUIThread([&]()
+            {
+                window1->Activate();
+            });
+
+            VERIFY_IS_TRUE(HasWindowPlaceholder(window1.get()));
+            VERIFY_IS_FALSE(HasWindowPlaceholder(window2.get()));
+
+            LOG_OUTPUT(L"----- Each opted-in window gets its own placeholder -----");
+            RunOnUIThread([&]()
+            {
+                window2->Activate();
+            });
+
+            VERIFY_IS_TRUE(HasWindowPlaceholder(window1.get()));
+            VERIFY_IS_TRUE(HasWindowPlaceholder(window2.get()));
+
+            LOG_OUTPUT(L"----- Closing one window leaves the other window's placeholder alone -----");
+            window2.Close();
+
+            VERIFY_IS_TRUE(HasWindowPlaceholder(window1.get()));
+        }
+
+        LOG_OUTPUT(L"----- The remaining window's placeholder is replaced once rendering resumes -----");
+        TestServices::WindowHelper->WaitForIdle();
+
+        VERIFY_IS_FALSE(HasWindowPlaceholder(window1.get()));
+    }
 
 } } } } } } // Microsoft::UI::Xaml::Tests::Controls::Window

--- a/dxaml/test/native/external/controls/window/WindowIntegrationTests.h
+++ b/dxaml/test/native/external/controls/window/WindowIntegrationTests.h
@@ -195,6 +195,34 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests { namespac
             TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
         END_TEST_METHOD()
 
+        //
+        // Top-level window placeholder (SkipWindowRedirectionSurface)
+        //
+
+        BEGIN_TEST_METHOD(WindowPlaceholderIsUsedUntilFirstFrame)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates that an opted-in window is created without a redirection surface, shows a placeholder visual from activation until its first rendered frame, and then shows its real content.")
+            TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
+            TEST_METHOD_PROPERTY(L"Data:XamlOptionalChanges", L"{SkipWindowRedirectionSurface:true}")
+        END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(WindowPlaceholderIsNotUsedWhenDisabled)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates that with the optional change disabled the window keeps its redirection surface and no placeholder is ever installed.")
+            TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
+            TEST_METHOD_PROPERTY(L"Data:XamlOptionalChanges", L"{SkipWindowRedirectionSurface:false}")
+        END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(WindowPlaceholderSurvivesCloseBeforeFirstFrame)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates that closing an opted-in window while its placeholder is still installed (before the first frame) is safe and does not break later windows.")
+            TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
+            TEST_METHOD_PROPERTY(L"Data:XamlOptionalChanges", L"{SkipWindowRedirectionSurface:true}")
+        END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(WindowPlaceholderIsTrackedPerWindow)
+            TEST_METHOD_PROPERTY(L"Description", L"Validates that each opted-in window tracks its own placeholder state independently before rendering resumes.")
+            TEST_METHOD_PROPERTY(L"Hosting:Mode", L"WPF")
+            TEST_METHOD_PROPERTY(L"Data:XamlOptionalChanges", L"{SkipWindowRedirectionSurface:true}")
+        END_TEST_METHOD()
+
     };
 
 } } } } } }

--- a/dxaml/test/native/external/framework/settings/XamlOptionalChangesTests.cpp
+++ b/dxaml/test/native/external/framework/settings/XamlOptionalChangesTests.cpp
@@ -49,6 +49,8 @@ static ComPtr<xaml_settings_abi::IXamlOptionalChangesStatics> GetStatics()
 }
 
 static const auto c_iconNoGrid = xaml_settings_abi::XamlChangeId_IconNoGridOptimization;
+static const auto c_skipWindowRedirectionSurface = static_cast<xaml_settings_abi::XamlChangeId>(
+    xaml_settings::XamlChangeId::SkipWindowRedirectionSurface);
 
 // ---------------------------------------------------------------------------
 // Setup / Cleanup
@@ -168,6 +170,19 @@ void XamlOptionalChangesTests::IsChangeEnabledWorksAfterLock()
     // Query still works after lock
     VERIFY_SUCCEEDED(statics->IsChangeEnabled(c_iconNoGrid, &val));
     VERIFY_IS_TRUE(!!val);
+}
+
+void XamlOptionalChangesTests::SkipWindowRedirectionSurfaceValueIsRecognized()
+{
+    auto statics = GetStatics();
+    BOOLEAN mutated = FALSE;
+    BOOLEAN enabled = FALSE;
+
+    VERIFY_SUCCEEDED(statics->EnableChange(c_skipWindowRedirectionSurface, &mutated));
+    VERIFY_IS_TRUE(!!mutated);
+
+    VERIFY_SUCCEEDED(statics->IsChangeEnabled(c_skipWindowRedirectionSurface, &enabled));
+    VERIFY_IS_TRUE(!!enabled);
 }
 
 void XamlOptionalChangesTests::UnrecognizedValueContract()

--- a/dxaml/test/native/external/framework/settings/XamlOptionalChangesTests.h
+++ b/dxaml/test/native/external/framework/settings/XamlOptionalChangesTests.h
@@ -48,6 +48,11 @@ namespace Microsoft { namespace UI { namespace Xaml { namespace Tests {
                 L"Verifies IsChangeEnabled still returns correct value after Lock")
         END_TEST_METHOD()
 
+        BEGIN_TEST_METHOD(SkipWindowRedirectionSurfaceValueIsRecognized)
+            TEST_METHOD_PROPERTY(L"Description",
+                L"Verifies the SkipWindowRedirectionSurface value can be enabled and queried")
+        END_TEST_METHOD()
+
         BEGIN_TEST_METHOD(UnrecognizedValueContract)
             TEST_METHOD_PROPERTY(L"Description",
                 L"Verifies unrecognized values: pre-lock Enable/Disable returns FALSE, post-lock both throw E_ILLEGAL_STATE_CHANGE")

--- a/dxaml/xcp/components/comptree/DCompTreeHost.cpp
+++ b/dxaml/xcp/components/comptree/DCompTreeHost.cpp
@@ -1009,6 +1009,10 @@ _Check_return_ HRESULT DCompTreeHost::ConnectXamlIslandTargetRoots()
                 IFCFAILFAST(content->QueryInterface(IID_PPV_ARGS(&contentIslandExperimental)));
                 IFC_RETURN(contentIslandExperimental->put_Root(wucVisual));
 
+                const bool replacedWindowPlaceholder =
+                    renderData.windowPlaceholderVisual != nullptr;
+                renderData.windowPlaceholderVisual.Reset();
+
                 xamlIslandRoot->SetRootVisual(wucVisual);
 
                 renderData.contentConnected = true;
@@ -1031,6 +1035,10 @@ _Check_return_ HRESULT DCompTreeHost::ConnectXamlIslandTargetRoots()
                 if (m_needsFrameRateVisual)
                 {
                     ShowUIThreadCounters();
+                }
+
+                if (m_needsFrameRateVisual || replacedWindowPlaceholder)
+                {
                     IFC_RETURN(CommitMainDevice());
                 }
 
@@ -2483,6 +2491,68 @@ void DCompTreeHost::AddXamlIslandTarget(_In_ CXamlIslandRoot* xamlIslandRoot)
     }
 }
 
+_Check_return_ HRESULT DCompTreeHost::PrepareXamlIslandForWindowShow(
+    _In_ CXamlIslandRoot* xamlIslandRoot,
+    _In_ UINT32 backgroundColor)
+{
+    auto islandData = m_islandRenderData.find(xamlIslandRoot);
+    IFCEXPECT_RETURN(islandData != m_islandRenderData.end());
+
+    auto& renderData = islandData->second;
+    if (renderData.contentConnected || renderData.windowPlaceholderVisual)
+    {
+        return S_OK;
+    }
+
+    wrl::ComPtr<WUComp::ICompositionColorBrush> colorBrush;
+    IFC_RETURN(GetCompositor()->CreateColorBrush(colorBrush.ReleaseAndGetAddressOf()));
+    IFC_RETURN(colorBrush->put_Color(ColorUtils::GetWUColor(backgroundColor)));
+
+    wrl::ComPtr<WUComp::ICompositionBrush> brush;
+    IFC_RETURN(colorBrush.As(&brush));
+
+    wrl::ComPtr<WUComp::ISpriteVisual> spriteVisual;
+    IFC_RETURN(GetCompositor()->CreateSpriteVisual(spriteVisual.ReleaseAndGetAddressOf()));
+    IFC_RETURN(spriteVisual->put_Brush(brush.Get()));
+
+    wrl::ComPtr<WUComp::IVisual> windowPlaceholderVisual;
+    IFC_RETURN(spriteVisual.As(&windowPlaceholderVisual));
+
+    const auto xamlIslandRootSize = xamlIslandRoot->GetSize();
+    wfn::Vector2 placeholderSize;
+    placeholderSize.X = xamlIslandRootSize.Width;
+    placeholderSize.Y = xamlIslandRootSize.Height;
+    IFC_RETURN(windowPlaceholderVisual->put_Size(placeholderSize));
+
+    auto contentIsland = xamlIslandRoot->GetContentIsland();
+    IFCEXPECT_RETURN(contentIsland);
+
+    wrl::ComPtr<ixp::IContentIslandExperimental> contentIslandExperimental;
+    IFC_RETURN(contentIsland->QueryInterface(
+        IID_PPV_ARGS(contentIslandExperimental.ReleaseAndGetAddressOf())));
+    IFC_RETURN(contentIslandExperimental->put_Root(windowPlaceholderVisual.Get()));
+
+    renderData.windowPlaceholderVisual = std::move(windowPlaceholderVisual);
+
+    return CommitMainDevice();
+}
+
+_Check_return_ HRESULT DCompTreeHost::HasXamlIslandWindowPlaceholder(
+    _In_ CXamlIslandRoot* xamlIslandRoot,
+    _Out_ bool* hasPlaceholder) const
+{
+    *hasPlaceholder = false;
+
+    // An island with no render data has no placeholder state to report at all. Fail instead of
+    // answering false, so a caller cannot mistake missing state for "no placeholder installed".
+    auto islandData = m_islandRenderData.find(xamlIslandRoot);
+    IFCEXPECT_RETURN(islandData != m_islandRenderData.end());
+
+    *hasPlaceholder = islandData->second.windowPlaceholderVisual != nullptr;
+
+    return S_OK;
+}
+
 void DCompTreeHost::UpdateXamlIslandTargetSize(_In_ CXamlIslandRoot* xamlIslandRoot)
 {
     if(xamlIslandRoot)
@@ -2490,14 +2560,28 @@ void DCompTreeHost::UpdateXamlIslandTargetSize(_In_ CXamlIslandRoot* xamlIslandR
         auto islandData = m_islandRenderData.find(xamlIslandRoot);
         if (islandData != m_islandRenderData.end())
         {
+            auto& renderData = islandData->second;
+            if (!renderData.windowsPresentTarget && !renderData.windowPlaceholderVisual)
+            {
+                return;
+            }
+
+            const auto xamlIslandRootSize = xamlIslandRoot->GetSize();
             // If XamlIslandRoot size is set before WindowsPresentTarget has been
             // created, the target size will be set in EnsureXamlIslandTargetRoots
             // on WindowsPresentTarget's creation.
-            if(islandData->second.windowsPresentTarget)
+            if(renderData.windowsPresentTarget)
             {
-                auto xamlIslandRootSize = xamlIslandRoot->GetSize();
-                IFCFAILFAST(islandData->second.windowsPresentTarget->SetWidth(static_cast<XUINT32>(xamlIslandRootSize.Width)));
-                IFCFAILFAST(islandData->second.windowsPresentTarget->SetHeight(static_cast<XUINT32>(xamlIslandRootSize.Height)));
+                IFCFAILFAST(renderData.windowsPresentTarget->SetWidth(static_cast<XUINT32>(xamlIslandRootSize.Width)));
+                IFCFAILFAST(renderData.windowsPresentTarget->SetHeight(static_cast<XUINT32>(xamlIslandRootSize.Height)));
+            }
+
+            if (renderData.windowPlaceholderVisual)
+            {
+                wfn::Vector2 placeholderSize;
+                placeholderSize.X = xamlIslandRootSize.Width;
+                placeholderSize.Y = xamlIslandRootSize.Height;
+                IFCFAILFAST(renderData.windowPlaceholderVisual->put_Size(placeholderSize));
             }
         }
 
@@ -2523,6 +2607,25 @@ void DCompTreeHost::RemoveXamlIslandTarget(_In_ CXamlIslandRoot* xamlIslandRoot)
     if (refreshFrameRateVisual)
     {
         HideUIThreadCounters();
+    }
+
+    if (islandData->second.windowPlaceholderVisual)
+    {
+        if (auto contentIsland = xamlIslandRoot->GetContentIsland())
+        {
+            wrl::ComPtr<ixp::IContentIslandExperimental> contentIslandExperimental;
+            HRESULT hr = contentIsland->QueryInterface(
+                IID_PPV_ARGS(contentIslandExperimental.ReleaseAndGetAddressOf()));
+            if (SUCCEEDED(hr))
+            {
+                hr = contentIslandExperimental->put_Root(nullptr);
+            }
+
+            if (FAILED(hr) && hr != RO_E_CLOSED)
+            {
+                IFCFAILFAST(hr);
+            }
+        }
     }
 
     m_islandRenderData.erase(islandData);

--- a/dxaml/xcp/components/comptree/inc/DCompTreeHost.h
+++ b/dxaml/xcp/components/comptree/inc/DCompTreeHost.h
@@ -298,6 +298,7 @@ public:
     {
         xref_ptr<WindowsPresentTarget> windowsPresentTarget;
         bool contentConnected = false;
+        wrl::ComPtr<WUComp::IVisual> windowPlaceholderVisual;
         // For testing - normally we can get the visual out of the Composition island, but for tests this returns a
         // real visual when we want the mock. So track the root visual separately.
         wrl::ComPtr<ixp::IVisual> m_islandRootVisual;
@@ -322,6 +323,13 @@ public:
     XamlLightTargetMap& GetXamlLightTargetMap();
 
     void AddXamlIslandTarget(_In_ CXamlIslandRoot* xamlIslandRoot);
+    _Check_return_ HRESULT PrepareXamlIslandForWindowShow(
+        _In_ CXamlIslandRoot* xamlIslandRoot,
+        _In_ UINT32 backgroundColor);
+    // Fails if the island has no render data entry, so missing state is never reported as false.
+    _Check_return_ HRESULT HasXamlIslandWindowPlaceholder(
+        _In_ CXamlIslandRoot* xamlIslandRoot,
+        _Out_ bool* hasPlaceholder) const;
     void UpdateXamlIslandTargetSize(_In_ CXamlIslandRoot* xamlIslandRoot);
     void RemoveXamlIslandTarget(_In_ CXamlIslandRoot* xamlIslandRoot);
     _Check_return_ HRESULT ConnectXamlIslandTargetRoots();

--- a/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
+++ b/dxaml/xcp/components/metadata/inc/EnumDefs.g.h
@@ -2212,6 +2212,8 @@ namespace DirectUI
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
+        WindowPlaceholderVisual = 63530880,
     };
     DEFINE_ENUM_FLAG_OPERATORS(XamlChangeId);
 

--- a/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/inc/OptionalChangeState.h
@@ -28,6 +28,8 @@ namespace OptionalChangeState
     constexpr int BitIndex_OptimizeApplyStyles = 1;
     constexpr int BitIndex_DefaultStyleOptimizations = 2;
     constexpr int BitIndex_DeferContextFlyoutInit = 3;
+    constexpr int BitIndex_SkipWindowRedirectionSurface = 4;
+    constexpr int BitIndex_WindowPlaceholderVisual = 5;
 
     inline bool IsOptionalChangeEnabled(int bitIndex)
     {
@@ -53,5 +55,15 @@ namespace OptionalChangeState
     inline bool IsDeferContextFlyoutInitEnabled()
     {
         return IsOptionalChangeEnabled(BitIndex_DeferContextFlyoutInit) || IsPerfOptInEnabled();
+    }
+
+    inline bool IsSkipWindowRedirectionSurfaceEnabled()
+    {
+        return IsOptionalChangeEnabled(BitIndex_SkipWindowRedirectionSurface);
+    }
+
+    inline bool IsWindowPlaceholderVisualEnabled()
+    {
+        return IsOptionalChangeEnabled(BitIndex_WindowPlaceholderVisual);
     }
 }

--- a/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
+++ b/dxaml/xcp/dxaml/idl/winrt/core/microsoft.ui.xaml.coretypes2.idl
@@ -520,6 +520,8 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
+        WindowPlaceholderVisual = 63530880,
     };
 }
 
@@ -2364,4 +2366,3 @@ namespace Microsoft.UI.Xaml.Settings
     };
 
 }
-

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.cpp
@@ -18,6 +18,7 @@
 #include "FrameworkTheming.h"
 #include "WindowHelpers.h"
 #include "XamlIslandRoot_Partial.h"
+#include "DCompTreeHost.h"
 #include "XamlTelemetry.h"
 #include <Theme.h>
 #include <dwmapi.h>
@@ -25,6 +26,7 @@
 #include "Microsoft.UI.Windowing.h"
 #include <FrameworkUdk/Theming.h>
 #include <Microsoft.UI.Interop.h>
+#include <OptionalChangeState.h>
 
 #pragma warning(disable:4267) //'var' : conversion from 'size_t' to 'type', possible loss of data
 
@@ -436,6 +438,19 @@ _Check_return_ HRESULT DesktopWindowImpl::ActivateImpl()
         if (AreNewWindowingApisEnabled())
         {
             IFC_RETURN(ApplyPendingClientSizeIfNeeded());
+        }
+
+        if (OptionalChangeState::IsWindowPlaceholderVisualEnabled())
+        {
+            ctl::ComPtr<DirectUI::XamlIslandRoot> xamlIslandRoot;
+            ctl::ComPtr<xaml_hosting::IXamlIslandRoot> island =
+                m_desktopWindowXamlSource->GetXamlIslandRootNoRef();
+            IFC_RETURN(island.As(&xamlIslandRoot));
+
+            auto coreIsland = static_cast<CXamlIslandRoot*>(xamlIslandRoot->GetHandle());
+            IFC_RETURN(coreIsland->GetDCompTreeHost()->PrepareXamlIslandForWindowShow(
+                coreIsland,
+                GetEffectiveWindowBackgroundColor()));
         }
     }
 
@@ -1203,6 +1218,50 @@ LRESULT LResultFromHResult(HRESULT hr)
     return 0;
 }
 
+UINT32 DesktopWindowImpl::GetEffectiveWindowBackgroundColor()
+{
+    Theming::Theme appTheme = Theming::Theme::None;
+    ctl::ComPtr<xaml::IUIElement> content;
+    if (!m_bIsClosed && SUCCEEDED(get_ContentImpl(&content)) && content)
+    {
+        ctl::ComPtr<DirectUI::FrameworkElement> contentAsFE;
+        VERIFYHR(content.As<DirectUI::FrameworkElement>(&contentAsFE));
+        ASSERT(contentAsFE != nullptr);
+
+        xaml::ElementTheme actualTheme;
+        VERIFYHR(contentAsFE->get_ActualTheme(&actualTheme));
+        if (actualTheme != xaml::ElementTheme_Default)
+        {
+            appTheme = actualTheme == xaml::ElementTheme_Light ? Theming::Theme::Light : Theming::Theme::Dark;
+        }
+    }
+
+    return m_dxamlCoreNoRef->GetHandle()->GetFrameworkTheming()->GetHwndBackground(appTheme);
+}
+
+_Check_return_ HRESULT DesktopWindowImpl::HasActiveWindowPlaceholder(_Out_ bool* hasPlaceholder)
+{
+    *hasPlaceholder = false;
+
+    IFCEXPECT_RETURN(m_desktopWindowXamlSource);
+
+    ctl::ComPtr<xaml_hosting::IXamlIslandRoot> island = m_desktopWindowXamlSource->GetXamlIslandRootNoRef();
+    IFCEXPECT_RETURN(island);
+
+    ctl::ComPtr<DirectUI::XamlIslandRoot> xamlIslandRoot;
+    IFC_RETURN(island.As(&xamlIslandRoot));
+
+    auto coreIsland = static_cast<CXamlIslandRoot*>(xamlIslandRoot->GetHandle());
+    IFCEXPECT_RETURN(coreIsland);
+
+    DCompTreeHost* dcompTreeHost = coreIsland->GetDCompTreeHost();
+    IFCEXPECT_RETURN(dcompTreeHost);
+
+    IFC_RETURN(dcompTreeHost->HasXamlIslandWindowPlaceholder(coreIsland, hasPlaceholder));
+
+    return S_OK;
+}
+
 LRESULT DesktopWindowImpl::OnMessage(
     UINT uMsg,
     WPARAM wParam,
@@ -1252,24 +1311,13 @@ LRESULT DesktopWindowImpl::OnMessage(
             return LResultFromHResult(OnNonClientRegionButtonUp(wParam, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)));
         case WM_ERASEBKGND:
         {
-            Theming::Theme appTheme = Theming::Theme::None;
-            ctl::ComPtr<xaml::IUIElement> content;
-            if(!m_bIsClosed && SUCCEEDED(get_ContentImpl(&content)) && content)
+            if (OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled())
             {
-                ctl::ComPtr<DirectUI::FrameworkElement> contentAsFE;
-                VERIFYHR(content.As<DirectUI::FrameworkElement>(&contentAsFE));
-                ASSERT(contentAsFE != nullptr);
-
-                xaml::ElementTheme actualTheme;
-                VERIFYHR(contentAsFE->get_ActualTheme(&actualTheme));
-                if (actualTheme != xaml::ElementTheme_Default)
-                {
-                    appTheme = actualTheme == xaml::ElementTheme_Light ? Theming::Theme::Light : Theming::Theme::Dark;
-                }
+                return 1;
             }
 
             auto hdc = (HDC)wParam;
-            auto color = ColorUtils::GetWUColor(dxamlCore->GetHandle()->GetFrameworkTheming()->GetHwndBackground(appTheme));
+            auto color = ColorUtils::GetWUColor(GetEffectiveWindowBackgroundColor());
             RECT rc = WindowHelpers::GetClientWindowCoordinates(m_hwnd.get());
             auto oldColor  = ::SetBkColor(hdc, RGB(color.R, color.G, color.B));
             ASSERT(oldColor != CLR_INVALID);
@@ -1667,8 +1715,13 @@ void DesktopWindowImpl::RegisterDesktopWindowClass()
 
 void DesktopWindowImpl::CreateDesktopWindow()
 {
+    const DWORD extendedStyle =
+        OptionalChangeState::IsSkipWindowRedirectionSurfaceEnabled()
+            ? WS_EX_NOREDIRECTIONBITMAP
+            : 0;
+
     _CreateWindow(
-        0,                                 // Extended Style
+        extendedStyle,                     // Extended Style
         s_windowClassName,                 // name of window class
         s_defaultWindowTitle,              // title-bar string
         WS_OVERLAPPEDWINDOW | WS_VISIBLE,  // top-level window

--- a/dxaml/xcp/dxaml/lib/DesktopWindowImpl.h
+++ b/dxaml/xcp/dxaml/lib/DesktopWindowImpl.h
@@ -123,6 +123,12 @@ namespace DirectUI
         void SetHasSizeOverrides(bool hasSizeOverrides) override;
         void SetShrinkApplicationViewVisibleBounds(bool enabled) override;
 
+        // Reports whether this window's top-level island currently holds the window
+        // placeholder visual installed before the first rendered frame. Fails if the
+        // island or its render data cannot be resolved, so callers cannot mistake
+        // missing state for "no placeholder".
+        _Check_return_ HRESULT HasActiveWindowPlaceholder(_Out_ bool* hasPlaceholder);
+
     public:
         LRESULT OnMessage(
             UINT const message,
@@ -194,6 +200,7 @@ namespace DirectUI
         void Shutdown();
         static _Check_return_ Window* GetMUXWindowFromHwnd(_In_ DXamlCore *dxamlCore, _In_ const HWND& hwnd);
         _Check_return_ HRESULT CheckIsWindowClosed();
+        UINT32 GetEffectiveWindowBackgroundColor();
         _Check_return_ HRESULT OnDesktopWindowXamlSourceTakeFocusRequested(_In_ xaml::Hosting::IDesktopWindowXamlSource* desktopWindowXamlSource, _In_ xaml::Hosting::IDesktopWindowXamlSourceTakeFocusRequestedEventArgs* args);
         _Check_return_ HRESULT RestoreFocus(_Outptr_ xaml_hosting::IXamlSourceFocusNavigationResult** ppEventSource);
         void SetFocusToContentIsland();

--- a/dxaml/xcp/dxaml/lib/DxamlCoreTestHooks_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/DxamlCoreTestHooks_Partial.cpp
@@ -65,6 +65,8 @@
 #include "IXamlTestHooks-errors.h"
 #include "DesktopWindowXamlSource_Partial.h"
 #include "XamlIslandRoot_Partial.h"
+#include "Window_Partial.h"
+#include "DesktopWindowImpl.h"
 #include "HWWalk.h"
 #include "LoadLibraryAbs.h"
 #include "xcpwindow.h"
@@ -2032,6 +2034,29 @@ IFACEMETHODIMP DxamlCoreTestHooks::GetAllContentIslands(_In_ xaml_hosting::IDesk
             }
         }
     }
+
+    return S_OK;
+}
+
+IFACEMETHODIMP DxamlCoreTestHooks::HasWindowPlaceholder(_In_opt_ xaml::IWindow* window, _Out_ BOOLEAN* hasPlaceholder)
+{
+    IFCPTR_RETURN(hasPlaceholder);
+    *hasPlaceholder = FALSE;
+
+    // Follows the established hook pattern: a null window resolves to the app's first window.
+    ctl::ComPtr<DirectUI::Window> windowPeer = GetTargetWindow(window);
+    IFCEXPECT_RETURN(windowPeer);
+
+    // Only top-level desktop windows can hold a placeholder. Fail rather than report FALSE for
+    // anything we can't resolve, so a caller can't confuse "not applicable" with "no placeholder".
+    DirectUI::WindowImpl* windowImplNoRef = windowPeer->GetWindowImpl();
+    IFCEXPECT_RETURN(windowImplNoRef);
+    IFCEXPECT_RETURN(windowImplNoRef->GetWindowType() == WindowType::DesktopWindow);
+
+    bool hasActivePlaceholder = false;
+    IFC_RETURN(static_cast<DesktopWindowImpl*>(windowImplNoRef)->HasActiveWindowPlaceholder(&hasActivePlaceholder));
+
+    *hasPlaceholder = hasActivePlaceholder ? TRUE : FALSE;
 
     return S_OK;
 }

--- a/dxaml/xcp/dxaml/lib/DxamlCoreTestHooks_Partial.h
+++ b/dxaml/xcp/dxaml/lib/DxamlCoreTestHooks_Partial.h
@@ -308,6 +308,8 @@ namespace DirectUI
         IFACEMETHOD_(size_t, GetAllocationSize)() override;
         IFACEMETHOD_(size_t, GetDeallocationCount)() override;
 
+        IFACEMETHOD(HasWindowPlaceholder)(_In_opt_ xaml::IWindow* window, _Out_ BOOLEAN* hasPlaceholder) override;
+
     protected:
         _Check_return_ HRESULT QueryInterfaceImpl(_In_ REFIID riid, _Outptr_ void **ppvObject) override;
 

--- a/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/XamlOptionalChanges_Partial.cpp
@@ -44,6 +44,10 @@ static int GetBitIndex(xaml_settings::XamlChangeId id)
         return OptionalChangeState::BitIndex_DefaultStyleOptimizations;
     case xaml_settings::XamlChangeId_DeferContextFlyoutInit:
         return OptionalChangeState::BitIndex_DeferContextFlyoutInit;
+    case xaml_settings::XamlChangeId_SkipWindowRedirectionSurface:
+        return OptionalChangeState::BitIndex_SkipWindowRedirectionSurface;
+    case xaml_settings::XamlChangeId_WindowPlaceholderVisual:
+        return OptionalChangeState::BitIndex_WindowPlaceholderVisual;
     default:
         return -1;
     }

--- a/dxaml/xcp/inc/IXamlTestHooks-win.h
+++ b/dxaml/xcp/inc/IXamlTestHooks-win.h
@@ -364,4 +364,10 @@ DECLARE_INTERFACE_IID_(IXamlTestHooks, IXamlLoggerTestHooks, "43d4bcbd-4f02-4651
     IFACEMETHOD_(size_t, GetAllocationCount)() = 0;
     IFACEMETHOD_(size_t, GetAllocationSize)() = 0;
     IFACEMETHOD_(size_t, GetDeallocationCount)() = 0;
+
+    // Reports whether the given Window's top-level island currently holds the window placeholder
+    // visual that is installed before the first rendered frame. A null window resolves to the
+    // app's first window. Fails if the window or its island render data cannot be resolved, so
+    // missing state is never reported as FALSE.
+    IFACEMETHOD(HasWindowPlaceholder)(_In_opt_ xaml::IWindow* window, _Out_ BOOLEAN* hasPlaceholder) = 0;
 };

--- a/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
+++ b/dxaml/xcp/tools/XCPTypesAutoGen/XamlOM/Model/Microsoft.UI.Xaml.Settings.cs
@@ -20,6 +20,8 @@ namespace Microsoft.UI.Xaml.Settings
         OptimizeApplyStyles = 61697456,
         DefaultStyleOptimizations = 60995620,
         DeferContextFlyoutInit = 61098986,
+        SkipWindowRedirectionSurface = 63530879,
+        WindowPlaceholderVisual = 63530880,
     }
 
     // Provides static methods to opt in to or out of individual breaking or


### PR DESCRIPTION
Create no-redirection top-level windows, show a theme-aware placeholder until the first XAML frame

It is build up on @Sergio0694 PR https://github.com/microsoft/microsoft-ui-xaml/pull/11587

## Fixes

<!-- Link the issue this PR addresses. Use "Fixes #xxx" or "Closes #xxx" so GitHub auto-closes it on merge. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->

Fixes #

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

<!-- Describe your changes in detail. -->

### Current Behavior
<!-- How does this work today? -->

### New Behavior
<!-- How will it work after this PR? -->

## Customer Impact

<!-- How does this change affect end users? Is it user-facing or infra changes? -->

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [ ] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

## Screenshots (if appropriate)

<!-- If you are making visual changes, include before/after screenshots. -->