### PR TITLE
CD3D11Device::~CD3D11Device: release the wrapper's D2D device context and brush

### DIFF
--- a/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.cpp
+++ b/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.cpp
@@ -625,6 +625,15 @@ _Check_return_ HRESULT CD3D11DeviceInstance::EnsureDeviceSpecificD2DResources(_I
     return S_OK;
 }
 
+// Counterpart to EnsureDeviceSpecificD2DResources: these belong to one CD3D11Device, so they go when it does.
+void CD3D11DeviceInstance::ReleaseDeviceSpecificD2DResources(_In_ const CD3D11Device* deviceWrapper)
+{
+    wil::cs_leave_scope_exit guard = m_lock.lock();
+
+    m_d2dDeviceContexts.erase(deviceWrapper);
+    m_d2dSolidColorBrushes.erase(deviceWrapper);
+}
+
 //------------------------------------------------------------------------------
 //
 //  Synopsis:

--- a/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.h
+++ b/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.h
@@ -107,6 +107,7 @@ public:
     _Check_return_ HRESULT EnsureResources();
     _Check_return_ HRESULT EnsureD2DResources();
     _Check_return_ HRESULT EnsureDeviceSpecificD2DResources(_In_ const CD3D11Device* deviceWrapper);
+    void ReleaseDeviceSpecificD2DResources(_In_ const CD3D11Device* deviceWrapper);
     _Check_return_ HRESULT EnsureD2DFactory();
 
     // Transfers ownership of the device-removed event and its registration cookie to the caller.

--- a/dxaml/xcp/plat/win/desktop/d3d11device.cpp
+++ b/dxaml/xcp/plat/win/desktop/d3d11device.cpp
@@ -82,6 +82,12 @@ CD3D11Device::CD3D11Device()
 //-------------------------------------------------------------------------
 CD3D11Device::~CD3D11Device()
 {
+    // m_deviceInstance is empty if CD3D11DeviceInstance::GetInstance failed inside Create.
+    if (m_deviceInstance != nullptr)
+    {
+        m_deviceInstance->ReleaseDeviceSpecificD2DResources(this);
+    }
+
     // Release intermediate upload texture
     ReleaseInterface(m_UploadIntermediate.pTexture);
 }


### PR DESCRIPTION
Description:  
A WinUI 3 UI thread that shuts down leaks an ID2D1DeviceContext and an ID2D1SolidColorBrush, plus whatever surface that context still has as its render target.

Single-UI-thread processes are unaffected, because the last wrapper takes the shared instance down with it. 

Processes that keep one UI thread alive while others come and go accumulate two D2D objects per closed thread for the life of the process.

Root cause:  
CD3D11DeviceInstance is shared per process but stores the per-thread D2D objects in m_d2dDeviceContexts and m_d2dSolidColorBrushes, keyed by that thread's CD3D11Device 

The stale key is also a dangling pointer, so a later CD3D11Device allocated at the same address matches the dead thread's entry and picks up its device context.

Fix:  
Add CD3D11DeviceInstance::ReleaseDeviceSpecificD2DResources, the counterpart to EnsureDeviceSpecificD2DResources, and call it from ~CD3D11Device under the same m_lock.

The lock is required as the destructor runs on a different thread than the one that created the wrapper, concurrently with other threads inserting.

The m_deviceInstance null check covers CD3D11Device::Create failing inside GetInstance, where the destructor runs on a half-built object.

Behavior:  
Single-UI-thread processes are unchanged. 

Live UI threads keep their own device context and brush, closing one thread does not disturb another, and device-lost cleanup still clears both maps.

A closed UI thread now releases its two D2D objects instead of leaving them for the process lifetime.

Testing:  
8 open/close cycles of XAML islands on dedicated UI threads.

Without the fix the entry count climbs 2, 4, 6 ... 20 and every ~CD3D11Device frees nothing (before == after). 

With the fix it oscillates 2 to 4, each destructor drops exactly 2, and final teardown reaches 0.

A standalone D3D11/D2D harness over the same ownership graph reports 16 leftover entries with the atlas refcount unchanged across close before the fix, versus 0 entries and the refcount dropping by one after.
 It also reproduces a new wrapper at a recycled address inheriting the dead thread's device context and render target, and shows a fresh context with the fix.

Green cases hold on both legs: concurrent UI threads each render, a thread reopened after teardown renders, closing one thread leaves another's context and brush intact, and device-lost cleanup still empties the maps.