### PR TITLE
Add internal issue field to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,10 @@
 ## Fixes
 
-<!-- Link the issue this PR addresses. Use "Fixes #xxx" or "Closes #xxx" so GitHub auto-closes it on merge. -->
+<!-- Link either the public GitHub issue or the internal issue this PR addresses. Remove the unused line. -->
 <!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->
 
 Fixes #
+Internal Issue: https://task.ms/<ado-bug-id>
 
 ## PR Type
 


### PR DESCRIPTION
## Description

Allows contributors to reference either a public GitHub issue or an internal issue from the pull request template. The existing GitHub `Fixes #` field remains available, and an `Internal Issue` field using the `task.ms` format is added alongside it.

## Validation

Reviewed the rendered Markdown structure and verified the template diff contains no whitespace errors.