### PR TITLE
Preserve divergent paths during inbound integrate via restore-path list

### DIFF
--- a/scripts/MergePublicMirrorIntoInternalBranch.ps1
+++ b/scripts/MergePublicMirrorIntoInternalBranch.ps1
@@ -142,6 +142,26 @@ function Test-GitAncestor {
     throw "Unable to determine whether '$PossibleAncestor' is an ancestor of '$Commit'."
 }
 
+function Reset-PathToTarget {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Repository,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TargetCommit,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Pathspec
+    )
+
+    $existsInTarget = Get-GitCommandResult -Repository $Repository -Arguments @("cat-file", "-e", "${TargetCommit}:$Pathspec")
+    if ($existsInTarget.ExitCode -eq 0) {
+        Invoke-GitCommand -Repository $Repository -Arguments @("checkout", $TargetCommit, "--", $Pathspec)
+    } else {
+        Invoke-GitCommand -Repository $Repository -Arguments @("rm", "-r", "--force", "--ignore-unmatch", "--", $Pathspec)
+    }
+}
+
 $repositoryFullPath = [IO.Path]::GetFullPath([IO.Path]::Combine($pwd, $RepositoryDirectory))
 if (-not (Test-Path -LiteralPath $repositoryFullPath -PathType Container)) {
     throw "RepositoryDirectory '$RepositoryDirectory' does not identify an existing directory."
@@ -234,6 +254,18 @@ for ($publishAttempt = 1; $publishAttempt -le $maximumPublishAttempts; $publishA
         exit 0
     }
 
+    $restorePathsListText = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(
+        "show",
+        "${sourceCommit}:build/PipelineScripts/WinUISourceMirroringRestorePaths.txt"
+    )
+    $restorePathspecs = @(
+        $restorePathsListText -split "`n" |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ -and (-not $_.StartsWith("#")) } |
+            ForEach-Object { $_ -replace "\\", "/" }
+    )
+    Write-Host "Preserving $($restorePathspecs.Count) divergent path(s) at the target's version during integration."
+
     Write-Host "##[group]Creating integration merge"
     Invoke-GitCommand -Repository $repositoryFullPath -Arguments @("checkout", "--detach", $targetTrackingRef)
 
@@ -251,16 +283,37 @@ for ($publishAttempt = 1; $publishAttempt -le $maximumPublishAttempts; $publishA
     $mergeResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @(
         "merge",
         "--no-ff",
-        "--no-edit",
-        "-m",
-        "Merge GitHub main into $TargetBranchName",
+        "--no-commit",
         $sourceTrackingRef
     )
-    if ($mergeResult.ExitCode) {
+    $mergeHeadResult = Get-GitCommandResult -Repository $repositoryFullPath -Arguments @("rev-parse", "-q", "--verify", "MERGE_HEAD")
+    if ($mergeHeadResult.ExitCode) {
+        & git -C $repositoryFullPath merge --abort 2>$null
+        throw "Unable to start the integration merge of '$SourceBranchName'.`n$($mergeResult.Output)"
+    }
+
+    # Keep divergent paths from crossing repositories. WinUISourceMirroringRestorePaths.txt lists
+    # paths where GitHub and the internal repo intentionally differ; the outbound mirror preserves
+    # GitHub's copies, and inbound we likewise preserve the target's. Reset each listed path to the
+    # target's version. This runs even on a clean merge, so source-only paths that merged without a
+    # conflict (e.g. specs) are dropped, not just modify/delete conflicts.
+    foreach ($restorePathspec in $restorePathspecs) {
+        Reset-PathToTarget -Repository $repositoryFullPath -TargetCommit $targetCommit -Pathspec $restorePathspec
+    }
+
+    $unmergedPaths = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("diff", "--name-only", "--diff-filter=U")
+    if (-not [string]::IsNullOrWhiteSpace($unmergedPaths)) {
         $conflicts = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("status", "--short")
         & git -C $repositoryFullPath merge --abort 2>$null
-        throw "Unable to integrate '$SourceBranchName' because the merge has conflicts.`n$conflicts"
+        throw "Unable to integrate '$SourceBranchName' because the merge has conflicts outside the restore-path list.`n$conflicts"
     }
+
+    Invoke-GitCommand -Repository $repositoryFullPath -Arguments @(
+        "commit",
+        "--no-edit",
+        "-m",
+        "Merge GitHub main into $TargetBranchName"
+    )
 
     $mergeCommit = Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @("rev-parse", "HEAD")
     $mergeParents = (Get-GitCommandOutput -Repository $repositoryFullPath -Arguments @(


### PR DESCRIPTION
## Summary

Makes the inbound integrate (public GitHub `main` → internal `main`) honor the shared
divergent-paths list so paths that intentionally differ between the two repositories are
never carried across during the merge.

## Problem

The integrate step performs a `git merge --no-ff` of the public source branch into the
internal target branch. It had no path awareness, which caused two issues whenever the
source touched a path that the two repos intentionally keep different:

- **Hard failure (modify/delete):** when the source modified a file that does not exist on
  the internal side (e.g. the GitHub-only PR-validation wrapper), the merge produced a
  modify/delete conflict and the step failed.
- **Silent pollution (adds):** source-only paths that merge cleanly (e.g. `specs/`) were
  being added into the internal repo, since clean adds never conflict.

## Fix

Reuse the existing `build/PipelineScripts/WinUISourceMirroringRestorePaths.txt` list — the
same list the outbound mirror already uses — but with mirrored semantics: for every listed
path, keep the **local (internal target)** version.

Changes in `scripts/MergePublicMirrorIntoInternalBranch.ps1`:

- Merge now runs with `--no-ff --no-commit`, and `MERGE_HEAD` is verified before proceeding.
- Each listed path is reconciled to the target's state via a new `Reset-PathToTarget` helper
  (checks out the target's version, or removes the path when the target doesn't have it).
  This runs even on a clean merge, so source-only additions are dropped rather than landing.
- After reconciliation, the step fails only on residual conflicts **outside** the list, then
  commits explicitly.
- Reconciliation lives inside the existing publish/retry loop, so it re-applies per attempt.

The list is read from the source commit (`git show <sourceCommit>:...RestorePaths.txt`), so
it's layout-independent and always reflects the source's own declared divergent paths.

## Behavior

- Listed divergent paths keep the internal repo's version (including staying absent).
- Any real conflict outside the list still fails the run, as before.
- A merge whose only changes were excluded paths still records a proper two-parent merge
  commit, preserving ancestry for future integrations.

## Validation

Verified end-to-end on a throwaway mirror + integrate pipeline against refreshed real
content: the integrate stage passed, and the previously-offending divergent paths did **not**
land on the internal target branch.

## Notes

Split out on its own branch so the exclusion behavior can be reviewed independently of the
production cutover change.