### PR TITLE
Fix CommandBarFlyout OuterOverflowContentRoot RequestedTheme bug

### DIFF
--- a/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources.xaml
@@ -1060,7 +1060,7 @@
                   <!-- The Translation and Render transform are mutually exclusive properties. We need
                                          The translation property on contract 14+ for the drop shadow to work.  We need
                                          The TranslationTransform is needed before-->
-                  <Grid x:Name="OuterOverflowContentRootV2" RequestedTheme="{TemplateBinding ActualTheme}" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" Translation="0,0,32">
+                  <Grid x:Name="OuterOverflowContentRootV2" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" Translation="0,0,32">
                     <Grid x:Name="OverflowPopupSystemBackdropRoot" />
                     <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
                       <Grid.RowDefinitions>

--- a/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources_perf2026.xaml
+++ b/controls/dev/CommandBarFlyout/CommandBarFlyout_themeresources_perf2026.xaml
@@ -1059,7 +1059,7 @@
                   <!-- The Translation and Render transform are mutually exclusive properties. We need
                                          The translation property on contract 14+ for the drop shadow to work.  We need
                                          The TranslationTransform is needed before-->
-                  <Grid x:Name="OuterOverflowContentRootV2" RequestedTheme="{TemplateBinding ActualTheme}" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" Translation="0,0,32">
+                  <Grid x:Name="OuterOverflowContentRootV2" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" Translation="0,0,32">
                     <Grid x:Name="OverflowPopupSystemBackdropRoot" />
                     <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
                       <Grid.RowDefinitions>

--- a/controls/test/MUXControlsTestApp/Themes/DisableAnimationsStyles.xaml
+++ b/controls/test/MUXControlsTestApp/Themes/DisableAnimationsStyles.xaml
@@ -258,7 +258,7 @@
                                     <!-- The Translation and Render transform are mutually exclusive properties. We need
                                          The translation property on contract 14+ for the drop shadow to work.  We need
                                          The TranslationTransform is needed before-->
-                                    <Grid x:Name="OuterOverflowContentRootV2" RequestedTheme="{TemplateBinding ActualTheme}" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" Translation="0,0,32">
+                                    <Grid x:Name="OuterOverflowContentRootV2" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=FlyoutTemplateSettings.ExpandedWidth}" Translation="0,0,32">
                                         <Grid x:Name="OverflowPopupSystemBackdropRoot" />
                                         <Grid x:Name="OverflowContentRoot" HorizontalAlignment="Stretch" Background="{TemplateBinding Background}">
                                             <Grid.RowDefinitions>


### PR DESCRIPTION
Fix CommandBarFlyout OuterOverflowContentRoot RequestedTheme bug

## Fixes

<!-- Link the issue this PR addresses. Use "Fixes #xxx" or "Closes #xxx" so GitHub auto-closes it on merge. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->

Fixes #

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [✅] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

<!-- Describe your changes in detail. -->
修复 CommandBar SecondaryCommands 主题色 bug：
目前应用全局主题色在应用运行期间发生更改时，CommandBarFlyout 的 SecondaryCommands 区域并不会发生变化，这一问题同时影响到 TextCommandBarFlyout。经过调查发现是与 OuterOverflowContentRootV2 强行设置了 RequestedTheme 有关。所以希望能通过这个 PR 来修复这一相关问题

------------------------------

Fix the CommandBar SecondaryCommands theme color bug: Currently, when the app's global theme color changes during runtime, the SecondaryCommands area of the CommandBarFlyout doesn't update, and this also affects the TextCommandBarFlyout. After investigation, it was found to be related to OuterOverflowContentRootV2 forcibly setting the RequestedTheme. So, this PR hopes to fix that issue.

### Current Behavior
<!-- How does this work today? -->
目前应用全局主题色在应用运行期间发生更改时，CommandBarFlyout 的 SecondaryCommands 区域并不会发生变化，这一问题同时影响到 TextCommandBarFlyout。

------------------------------

Currently, when the app's global theme color changes during runtime, the SecondaryCommands area of the CommandBarFlyout doesn't update, and this also affects the TextCommandBarFlyout. 

### New Behavior
<!-- How will it work after this PR? -->
经过调查发现是与 OuterOverflowContentRootV2 强行设置了 RequestedTheme 有关。所以希望能通过这个 PR 来修复这一相关问题

------------------------------

After investigation, it was found to be related to OuterOverflowContentRootV2 forcibly setting the RequestedTheme. So, this PR hopes to fix that issue.

## Customer Impact

<!-- How does this change affect end users? Is it user-facing or infra changes? -->

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [ ✅] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [✅ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

## Screenshots (if appropriate)

<!-- If you are making visual changes, include before/after screenshots. -->
Current behavior
<img width="1676" height="1050" alt="image" src="https://github.com/user-attachments/assets/cdae0b5b-ca15-4817-b32d-8155a9691b07" />

<img width="1307" height="939" alt="image" src="https://github.com/user-attachments/assets/db0af7cb-af42-4f0f-a824-e6d158b93e24" />

------------------------------

移除后主题色正常，与 PrimaryCommands 主题色能保持一致

------------------------------

After removing it, the theme color is normal and can stay consistent with the PrimaryCommands theme color.

------------------------------

Releated issues（相关问题）
https://github.com/microsoft/microsoft-ui-xaml/issues/10708
https://github.com/microsoft/microsoft-ui-xaml/issues/11498
https://github.com/microsoft/microsoft-ui-xaml/issues/5320
https://github.com/microsoft/microsoft-ui-xaml/issues/10485