### PR TITLE
InkCanvas: custom drying (app-rendered dry ink via InkPresenter.ActivateCustomDrying)

### DIFF
--- a/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml
+++ b/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml
@@ -24,7 +24,14 @@
             </Grid.RowDefinitions>
             <controls:InkToolbar x:Name="Toolbar" Grid.Row="0" Margin="0,0,0,6" />
             <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" Background="White">
-                <controls:InkCanvas x:Name="InkSurface" />
+                <Grid>
+                    <controls:InkCanvas x:Name="InkSurface" />
+                    <!-- App-owned dry-ink layer. While custom drying is active the app draws the dried
+                         strokes here (red polylines) via InkSynchronizer.BeginDry. A plain Canvas (not a
+                         second InkCanvas) avoids a second compositor splice. IsHitTestVisible=False lets pen
+                         input pass through to InkSurface below. -->
+                    <Canvas x:Name="DryOverlay" IsHitTestVisible="False" SizeChanged="OnDryOverlaySizeChanged" />
+                </Grid>
             </Border>
         </Grid>
 
@@ -88,6 +95,16 @@
                            Text="draw / erase to see events..." />
                 <TextBlock x:Name="EventLogText" TextWrapping="Wrap" IsTextSelectionEnabled="True"
                            FontFamily="Consolas" FontSize="11" />
+
+                <!-- Custom drying (WIP): the app takes over rendering of committed ink via InkSynchronizer.
+                     Activate, then draw: each StrokesCollected calls BeginDry() (the just-committed strokes)
+                     then EndDry(). If BeginDry returns 0 the OS capture-inside-notification did not land
+                     (the known gap this PR is for). -->
+                <TextBlock Text="Custom drying (WIP)" FontWeight="SemiBold" />
+                <ToggleSwitch x:Name="CustomDryToggle" Header="Activate custom drying"
+                              OnContent="Active" OffContent="Off" Toggled="OnCustomDryToggled" />
+                <TextBlock x:Name="CustomDryText" TextWrapping="Wrap" FontFamily="Consolas" FontSize="12"
+                           Text="off - activate, then draw a stroke" />
 
                 <TextBlock Text="Log" FontWeight="SemiBold" />
                 <TextBlock x:Name="LogText" TextWrapping="Wrap" IsTextSelectionEnabled="True"

--- a/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
+++ b/Samples/ScratchPadApp/ScratchPadApp/ScratchPadApp/MainWindow.xaml.cs
@@ -60,17 +60,38 @@ namespace ScratchPadApp
             // re-attaches it at runtime so we can compare without reinstalling.
             // (Toolbar.TargetInkCanvas is left null here; the toggle sets it.)
 
-            // Enable ALL input devices AFTER the toolbar wires up, and again once each is loaded, so a
-            // mouse/touch-only device (e.g. a VM with no pen) can ink.
+            // Enable ALL input devices once. The InkPresenter is a stable instance that caches this, so it
+            // does not need re-applying as the toolbar / canvas load.
             ApplyInputDeviceTypes();
+
+            // Deferred-start validation. The OS rejects _InitializeCustomDry with E_ILLEGAL_METHOD_CALL
+            // once input has been activated, and on desktop (DComp) input activates on the first
+            // non-zero SetSize. Calling here -- during construction, before the first layout pass --
+            // is the supported ordering. Set INK_CUSTOMDRY_AT_STARTUP=1 to exercise it.
+            if (Environment.GetEnvironmentVariable("INK_CUSTOMDRY_AT_STARTUP") == "1")
+            {
+                try
+                {
+                    _inkSynchronizer = InkSurface.InkPresenter.ActivateCustomDrying();
+                    _customDryActive = _inkSynchronizer != null;
+                    App.Log("STARTUP ActivateCustomDrying -> " + (_customDryActive ? "OK (non-null)" : "returned null"));
+                    CustomDryToggle.IsOn = _customDryActive;
+                    CustomDryText.Text = _customDryActive
+                        ? "activated at startup - draw a stroke; BeginDry/EndDry run on each collection"
+                        : "ActivateCustomDrying returned null";
+                }
+                catch (Exception ex)
+                {
+                    App.Log("STARTUP ActivateCustomDrying THREW: " + ex.GetType().Name + ": " + ex.Message);
+                }
+            }
+
             Toolbar.Loaded += (s, e) =>
             {
-                ApplyInputDeviceTypes();
                 App.Log("Toolbar.Loaded ActiveTool=" + (Toolbar.ActiveTool?.GetType().Name ?? "null"));
             };
             InkSurface.Loaded += (s, e) =>
             {
-                ApplyInputDeviceTypes();
                 App.Log($"InkSurface.Loaded size = {InkSurface.ActualWidth} x {InkSurface.ActualHeight}");
             };
             // Diagnostic: log raw pointer input reaching the canvas (handledEventsToo=true so we see it
@@ -120,6 +141,16 @@ namespace ScratchPadApp
         private void InkPresenter_StrokesCollected(Microsoft.UI.Xaml.Controls.InkPresenter sender, Microsoft.UI.Xaml.Controls.InkStrokesCollectedEventArgs args)
         {
             App.Log("StrokesCollected fired: " + (args?.Strokes?.Count ?? 0) + " strokes");
+
+            // Custom drying: bracket the app's own rendering of the just-committed strokes. BeginDry hands
+            // back the strokes the presenter committed (a real app renders them itself here); EndDry
+            // releases the wet-ink layer. A returned count of 0 means the OS BeginDry capture (only valid
+            // inside this notification) did not land - the known gap this PR is about.
+            if (_customDryActive && _inkSynchronizer != null)
+            {
+                CustomDryStep();
+            }
+
             if (args?.Strokes == null) return;
 
             StrokeSample last = null;
@@ -141,6 +172,15 @@ namespace ScratchPadApp
         private int _pointerPressedCount, _pointerMovedCount, _pointerReleasedCount, _pointerHoveredCount,
                     _pointerEnteredCount, _pointerExitedCount, _pointerLostCount;
         private readonly List<string> _eventLog = new List<string>();
+
+        // Custom drying (WIP): the synchronizer handed back by ActivateCustomDrying + running counters.
+        private Microsoft.UI.Xaml.Controls.InkSynchronizer _inkSynchronizer;
+        private bool _customDryActive;
+        private int _customDryCollections;
+        private int _customDryStrokesTotal;
+
+        // Constant tint the app paints dried strokes with; created once, not per collection.
+        private readonly SolidColorBrush _customDryTint = new SolidColorBrush(Windows.UI.Color.FromArgb(0xFF, 0xC0, 0x30, 0x30));
 
         // Subscribes to every event this PR adds. The high-frequency events (StrokeContinued,
         // PointerMoved, PointerHovered) are counted only; the rest are also written to a short log.
@@ -199,6 +239,91 @@ namespace ScratchPadApp
                     ? Microsoft.UI.Xaml.Controls.InkInputProcessingMode.None
                     : Microsoft.UI.Xaml.Controls.InkInputProcessingMode.Inking;
             App.Log("InputProcessingMode = " + InkSurface.InkPresenter.InputProcessingConfiguration.Mode);
+        }
+
+        // Activate custom drying: the app takes over rendering of committed ("dry") ink. Once active,
+        // each StrokesCollected brackets the app's rendering with InkSynchronizer.BeginDry()/EndDry().
+        private void OnCustomDryToggled(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                if (CustomDryToggle.IsOn)
+                {
+                    _inkSynchronizer = InkSurface.InkPresenter.ActivateCustomDrying();
+                    _customDryActive = _inkSynchronizer != null;
+                    _customDryCollections = 0;
+                    _customDryStrokesTotal = 0;
+                    CustomDryText.Text = _customDryActive
+                        ? "activated - draw a stroke; BeginDry/EndDry run on each collection"
+                        : "ActivateCustomDrying returned null";
+                    App.Log("Custom drying activated: " + _customDryActive);
+                }
+                else
+                {
+                    _customDryActive = false;
+                    _inkSynchronizer = null;
+                    CustomDryText.Text = "off";
+                    App.Log("Custom drying deactivated");
+                }
+            }
+            catch (Exception ex)
+            {
+                _customDryActive = false;
+                CustomDryText.Text = "ActivateCustomDrying failed: " + ex.Message;
+                App.Log("Custom drying activate failed: " + ex.Message);
+            }
+        }
+
+        // Clip the dry-ink overlay to its own bounds so app-rendered strokes that leave the canvas (a
+        // stroke keeps drawing once the pointer is captured) do not paint across the neighboring panel.
+        private void OnDryOverlaySizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            DryOverlay.Clip = new RectangleGeometry
+            {
+                Rect = new Windows.Foundation.Rect(0, 0, e.NewSize.Width, e.NewSize.Height)
+            };
+        }
+
+        // Runs from StrokesCollected while custom drying is active: BeginDry returns the strokes the
+        // presenter just committed (a real app renders them itself), then EndDry releases the wet layer.
+        private void CustomDryStep()
+        {
+            try
+            {
+                var dryStrokes = _inkSynchronizer.BeginDry();
+                int n = dryStrokes?.Count ?? 0;
+                _customDryCollections++;
+                _customDryStrokesTotal += n;
+
+                // The app renders the dried strokes itself - the whole point of custom drying. Draw each as
+                // a red polyline on our own overlay Canvas, so it is visibly the app (not InkCanvas) drawing
+                // the committed ink.
+                if (n > 0)
+                {
+                    foreach (var stroke in dryStrokes)
+                    {
+                        var pts = stroke.GetInkPoints();
+                        if (pts == null || pts.Count < 2) { continue; }
+                        var poly = new Microsoft.UI.Xaml.Shapes.Polyline { Stroke = _customDryTint, StrokeThickness = System.Math.Max(1.5, stroke.DrawingAttributes.Size.Width) };
+                        var pc = new PointCollection();
+                        foreach (var ip in pts) { pc.Add(ip.Position); }
+                        poly.Points = pc;
+                        DryOverlay.Children.Add(poly);
+                    }
+                }
+
+                _inkSynchronizer.EndDry();
+                CustomDryText.Text =
+                    $"collection #{_customDryCollections}: app rendered {n} stroke(s) (tinted)" +
+                    (n == 0 ? "  <- EMPTY" : "") +
+                    $"\ntotal dried = {_customDryStrokesTotal}";
+                App.Log($"CustomDry BeginDry={n}, app-rendered, EndDry ok");
+            }
+            catch (Exception ex)
+            {
+                CustomDryText.Text = "BeginDry/EndDry threw: " + ex.Message;
+                App.Log("CustomDry step failed: " + ex.Message);
+            }
         }
 
         private StrokeSample ProcessStroke(InkStroke stroke)

--- a/controls/dev/DllHost/XamlMember.cpp
+++ b/controls/dev/DllHost/XamlMember.cpp
@@ -5,17 +5,18 @@
 #include "common.h"
 
 #include "XamlMember.h"
+#include "XamlMetadataProvider.h"
 
 XamlMember::XamlMember(
     wstring_view const& memberName,
-    const winrt::IXamlType& type,
+    wstring_view const& typeName,
     std::function<winrt::IInspectable(const winrt::IInspectable&)> getter,
     std::function<void(const winrt::IInspectable&, const winrt::IInspectable&)> setter,
     bool isDependencyProperty,
     bool isAttachable)
 {
     m_memberName = memberName;
-    m_type = type;
+    m_typeName = typeName;
     m_getter = getter;
     m_setter = setter;
     m_isDependencyProperty = isDependencyProperty;
@@ -42,14 +43,23 @@ winrt::hstring XamlMember::Name()
     return m_memberName;
 }
 
+winrt::IXamlType XamlMember::ResolveType()
+{
+    if (!m_type)
+    {
+        m_type = XamlMetadataProvider::LookupXamlType(m_typeName);
+    }
+    return m_type;
+}
+
 winrt::IXamlType XamlMember::TargetType()
 {
-    return m_type;
+    return ResolveType();
 }
 
 winrt::IXamlType XamlMember::Type()
 {
-    return m_type;
+    return ResolveType();
 }
 
 winrt::IInspectable XamlMember::GetValue(winrt::IInspectable const& instance)

--- a/controls/dev/DllHost/XamlMember.h
+++ b/controls/dev/DllHost/XamlMember.h
@@ -9,7 +9,7 @@ class XamlMember :
 public:
     XamlMember(
         wstring_view const& memberName,
-        const winrt::IXamlType& type,
+        wstring_view const& typeName,
         std::function<winrt::IInspectable(const winrt::IInspectable&)> getter,
         std::function<void(const winrt::IInspectable&, const winrt::IInspectable&)> setter,
         bool isDependencyProperty,
@@ -28,7 +28,12 @@ public:
 
 private:
 
+    // Resolved on first use, not at construction: two types can reference each other (InkPresenter
+    // <-> InkStrokeInput), and resolving here would recurse before either is cached.
+    winrt::IXamlType ResolveType();
+
     hstring m_memberName{};
+    hstring m_typeName{};
     winrt::IXamlType m_type{};
     bool m_isDependencyProperty{};
     bool m_isAttachable{};

--- a/controls/dev/DllHost/XamlType.cpp
+++ b/controls/dev/DllHost/XamlType.cpp
@@ -165,15 +165,10 @@ void XamlTypeBase::AddMember(
     bool isAttachable
 )
 {
-    auto memberType = 
-        (memberTypeName == m_typeName)
-            ? *this
-            : XamlMetadataProvider::LookupXamlType(memberTypeName);
-
     auto member = 
         winrt::make<XamlMember>(
             name,
-            memberType,
+            memberTypeName,
             getter,
             setter, 
             isDependencyProperty,

--- a/controls/dev/InkCanvas/InkCanvas.cpp
+++ b/controls/dev/InkCanvas/InkCanvas.cpp
@@ -77,28 +77,9 @@ struct ThreadData
     wil::unique_hmodule m_hmodDComp;
 };
 
-//
-// IInkCommitRequestHandler implementation.
-// InkPresenter calls OnCommitRequested() when ink transitions from wet to dry
-// and needs the app to commit the DComposition device.
-//
-struct InkCommitRequestHandler : winrt::implements<InkCommitRequestHandler, IInkCommitRequestHandler>
-{
-    InkCommitRequestHandler(winrt::com_ptr<IDCompositionDevice> device)
-        : m_device(device) {}
-
-    IFACEMETHODIMP OnCommitRequested() override
-    {
-        if (m_device)
-        {
-            return m_device->Commit();
-        }
-        return S_OK;
-    }
-
-private:
-    winrt::com_ptr<IDCompositionDevice> m_device;
-};
+// InkCommitRequestHandler (the IInkCommitRequestHandler the presenter calls on every wet->dry
+// transition to commit the shared DComposition device) now lives in InkPresenter.h, so the InkPresenter
+// proxy can re-create it when it re-creates the OS presenter to activate custom drying at runtime.
 
 //
 //  InkCanvas
@@ -247,33 +228,21 @@ void InkCanvas::EnsureInkPresenter()
 
 void InkCanvas::UpdateInkPresenterSize()
 {
-    // XamlRoot() can be null while unloading / reparenting. This runs from the SizeChanged
-    // and XamlRoot().Changed handlers, so guard it the same way as PositionInkVisual /
-    // AttachToVisualLink to avoid dereferencing a null XamlRoot for RasterizationScale().
-    auto xamlRoot = XamlRoot();
-    if (!xamlRoot)
+    // Push the new size onto the OS presenter (on the ink thread) through the proxy.
+    // The proxy's queue no-ops if the OS presenter has not been created yet.
+    if (!m_inkPresenterProxy)
     {
         return;
     }
 
-    // Transform the width/height based on Xaml scaling
-    auto transformer = TransformToVisual(nullptr);
-    winrt::Rect rect{ 0, 0, static_cast<float>(ActualWidth()), static_cast<float>(ActualHeight())};
-    rect = transformer.TransformBounds(rect);
-
-    // Get the system scale
-    auto rootScale = xamlRoot.RasterizationScale();
-
-    // Push the new physical-pixel size onto the OS presenter (on the ink thread) through the proxy.
-    // The proxy's queue no-ops if the OS presenter has not been created yet.
-    if (m_inkPresenterProxy)
-    {
-        winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem(
-            [width = ActualWidth() * rootScale, height = ActualHeight() * rootScale](inking::InkPresenter const& presenter)
-            {
-                presenter.as<IInkPresenterDesktop>()->SetSize(static_cast<float>(width), static_cast<float>(height));
-            });
-    }
+    // Local DIPs, not root coordinates: the ink visual sits under the canvas's placement visual, so
+    // XAML already applies any RenderTransform. Transforming here would double-apply it, and for a
+    // rotation the axis-aligned bounds would hand the presenter swapped extents.
+    winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem(
+        [width = static_cast<float>(ActualWidth()), height = static_cast<float>(ActualHeight())](inking::InkPresenter const& presenter)
+        {
+            presenter.as<IInkPresenterDesktop>()->SetSize(width, height);
+        });
 }
 
 void InkCanvas::AttachToVisualLink()
@@ -359,15 +328,27 @@ void InkCanvas::AttachInkVisualToPresenter()
     // Clear the detach flag BEFORE queuing so the ink thread doesn't drop the SetRootVisual work.
     m_isDetached.store(false, std::memory_order_release);
 
-    // Bind the visual to the presenter on the ink thread. SetRootVisual drives both rendering and
-    // input routing. XAML positions/clips the ink visual for both compositor paths, so commit here.
-    // No commit-request handler (conflicts with InkSynchronizer).
-    winrt::get_self<::InkPresenter>(m_inkPresenterProxy)->QueueInkPresenterWorkItem([rootVisual = m_inkRootVisual, compositionDevice = m_threadData->m_compositionDevice](inking::InkPresenter const& presenter)
+    // Bind the visual to the presenter on the ink thread. SetRootVisual(rootVisual, device) roots the
+    // ink; SetCommitRequestHandler wires the DComp commit the presenter requests on every wet->dry
+    // transition (normal drying, and custom-dry EndDry) so the removal + new content land in one frame.
+    // The presenter holds a ref on the handler; it is replaced on re-attach and released at teardown.
+    auto* presenterSelf = winrt::get_self<::InkPresenter>(m_inkPresenterProxy);
+    presenterSelf->QueueInkPresenterWorkItem([rootVisual = m_inkRootVisual, compositionDevice = m_threadData->m_compositionDevice](inking::InkPresenter const& presenter)
         {
             auto desktopPresenter = presenter.as<IInkPresenterDesktop>();
-            winrt::check_hresult(desktopPresenter->SetRootVisual(rootVisual.get(), nullptr));
+            // Pass the composition device (not nullptr): custom drying needs it for the wet->dry
+            // handoff. The OS only uses the resulting commit provider in custom-dry mode.
+            winrt::check_hresult(desktopPresenter->SetRootVisual(rootVisual.get(), compositionDevice.get()));
+            auto commitHandler = winrt::make_self<InkCommitRequestHandler>(compositionDevice);
+            winrt::check_hresult(desktopPresenter->SetCommitRequestHandler(commitHandler.as<IInkCommitRequestHandler>().get()));
             winrt::check_hresult(compositionDevice->Commit());
         });
+}
+
+// Roots the ink visual under the given target. Shared by both compositor paths.
+void InkCanvas::SetInkRootVisual(IDCompositionTarget* target)
+{
+    winrt::check_hresult(target->SetRoot(m_inkRootVisual.get()));
 }
 
 // System compositor path: splices the ink visual directly under a lifted MUC visual via
@@ -404,7 +385,8 @@ void InkCanvas::AttachToSystemCompositor()
 #endif
         desktopDevice.get(),
         m_systemDCompTarget.put()));
-    winrt::check_hresult(m_systemDCompTarget->SetRoot(m_inkRootVisual.get()));
+    SetInkRootVisual(m_systemDCompTarget.get());
+    winrt::check_hresult(m_threadData->m_compositionDevice->Commit());
 
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, mucRootVisual);
 }
@@ -436,7 +418,7 @@ void InkCanvas::AttachToLiftedCompositor()
     m_systemVisualLink.IsAboveContent(true);
 
     winrt::com_ptr<IDCompositionTarget> target = m_systemVisualLink.DCompTarget();
-    winrt::check_hresult(target->SetRoot(m_inkRootVisual.get()));
+    SetInkRootVisual(target.get());
 
     winrt::check_hresult(m_threadData->m_compositionDevice->Commit());
     winrt::ElementCompositionPreview::SetElementChildVisual(*this, m_systemVisualLink.PlacementVisual());

--- a/controls/dev/InkCanvas/InkCanvas.h
+++ b/controls/dev/InkCanvas/InkCanvas.h
@@ -61,6 +61,9 @@ private:
     void AttachInkVisualToPresenter();
     // Sizes the lifted PlacementVisual to the control's physical-pixel bounds (lifted path only).
     void PositionInkVisual();
+    // Roots the ink visual under the given target and hands the composition device to the presenter.
+    // Shared by both compositor paths.
+    void SetInkRootVisual(IDCompositionTarget* target);
 
     std::shared_ptr<ThreadData> m_threadData;
  

--- a/controls/dev/InkCanvas/InkCanvas.idl
+++ b/controls/dev/InkCanvas/InkCanvas.idl
@@ -93,13 +93,8 @@
         event Windows.Foundation.TypedEventHandler<InkStrokeInput, Windows.UI.Core.PointerEventArgs> StrokeCanceled;
 
         // Back-pointer to the owning presenter (parity with UWP InkStrokeInput.InkPresenter). Returns
-        // our mirror InkPresenter, not the OS one, consistent with the wrapping model. Exposed as a
-        // method, NOT a property: a property here generates a XAML metadata thunk, and because
-        // InkPresenter.StrokeInput is itself a property thunk pointing back to InkStrokeInput, the two
-        // thunks form a cycle the metadata provider walks recursively (stack overflow at first use).
-        // A method carries no metadata thunk, breaking the cycle (same reasoning as
-        // InkPresenter.GetHighContrastAdjustment below). UWP's get_InkPresenter is a method at the ABI.
-        InkPresenter GetInkPresenter();
+        // our mirror InkPresenter, not the OS one, consistent with the wrapping model.
+        InkPresenter InkPresenter{ get; };
     }
 
     // Ink-thread-marshaled mirror of Windows.UI.Input.Inking.InkUnprocessedInput. Fires the raw
@@ -117,10 +112,20 @@
         event Windows.Foundation.TypedEventHandler<InkUnprocessedInput, Windows.UI.Core.PointerEventArgs> PointerLost;
 
         // Back-pointer to the owning presenter (parity with UWP InkUnprocessedInput.InkPresenter).
-        // Returns our mirror InkPresenter, not the OS one, consistent with the wrapping model. Exposed
-        // as a method, NOT a property, to avoid the recursive XAML metadata thunk cycle with
-        // InkPresenter.UnprocessedInput (see InkStrokeInput.GetInkPresenter above).
-        InkPresenter GetInkPresenter();
+        // Returns our mirror InkPresenter, not the OS one, consistent with the wrapping model.
+        InkPresenter InkPresenter{ get; };
+    }
+
+    // Ink-thread-marshaled mirror of Windows.UI.Input.Inking.InkSynchronizer. Returned by
+    // InkPresenter.ActivateCustomDrying; lets the app take over rendering of "dry" (committed) ink.
+    // BeginDry/EndDry bracket the app's own rendering of the strokes the presenter just committed, so
+    // the presenter does not also draw them. The OS synchronizer is thread-affine to the ink thread,
+    // so both calls marshal there through the owning InkPresenter.
+    [MUX_PREVIEW]
+    runtimeclass InkSynchronizer
+    {
+        Windows.Foundation.Collections.IVectorView<Windows.UI.Input.Inking.InkStroke> BeginDry();
+        void EndDry();
     }
 
     // Ink-thread-marshaled subset of Windows.UI.Input.Inking.InkPresenter.
@@ -133,18 +138,19 @@
         Windows.UI.Input.Inking.InkDrawingAttributes CopyDefaultDrawingAttributes();
         void SetPredefinedConfiguration(Windows.UI.Input.Inking.InkPresenterPredefinedConfiguration configuration);
 
-        // High-contrast rendering adjustment. Exposed as get/set methods rather than a property:
-        // our InkPresenter runtimeclass name-collides with Windows.UI.Input.Inking.InkPresenter, so
-        // the generated XAML metadata property thunk would bind to the OS presenter (whose enum type
-        // differs). Methods carry no XAML metadata thunk, so the mirror enum flows correctly.
-        InkHighContrastAdjustment GetHighContrastAdjustment();
-        void SetHighContrastAdjustment(InkHighContrastAdjustment value);
+        InkHighContrastAdjustment HighContrastAdjustment;
 
         InkStrokeContainer StrokeContainer{ get; };
         InkInputProcessingConfiguration InputProcessingConfiguration{ get; };
         InkInputConfiguration InputConfiguration{ get; };
         InkStrokeInput StrokeInput{ get; };
         InkUnprocessedInput UnprocessedInput{ get; };
+
+        // Switches the presenter into custom-drying mode and returns the InkSynchronizer used to
+        // bracket the app's own rendering of committed strokes (parity with UWP
+        // InkPresenter.ActivateCustomDrying). Must be called before the canvas begins receiving
+        // input, i.e. during page construction or Loaded, before the first layout pass sizes it.
+        InkSynchronizer ActivateCustomDrying();
 
         event Windows.Foundation.TypedEventHandler<InkPresenter, InkStrokesCollectedEventArgs> StrokesCollected;
         event Windows.Foundation.TypedEventHandler<InkPresenter, InkStrokesErasedEventArgs> StrokesErased;

--- a/controls/dev/InkCanvas/InkPresenter.cpp
+++ b/controls/dev/InkCanvas/InkPresenter.cpp
@@ -12,6 +12,19 @@
 // ---------------------------------------------------------------------------
 namespace
 {
+    // The OS dry-ink container is null while custom drying is active (the app owns dry ink), so every
+    // stroke-container operation has to check before dereferencing it.
+    inking::InkStrokeContainer RequireStrokeContainer(inking::InkPresenter const& presenter)
+    {
+        auto container = presenter.StrokeContainer();
+        if (!container)
+        {
+            throw winrt::hresult_illegal_method_call{
+                L"InkPresenter.StrokeContainer is not available while custom drying is active." };
+        }
+        return container;
+    }
+
     struct GenericInkCallback : winrt::implements<GenericInkCallback, IInkHostWorkItem>
     {
         GenericInkCallback(std::function<void()> func)
@@ -53,11 +66,11 @@ void RunOnInkHostThread(winrt::weak_ref<muxc::InkPresenter> const& presenter, st
     }
 }
 
-void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages)
+void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages)
 {
     if (auto strong = presenter.get())
     {
-        winrt::get_self<::InkPresenter>(strong)->RunInkPresenterWorkItemSync(std::move(workItem), propagateException, pumpMessages);
+        winrt::get_self<::InkPresenter>(strong)->RunInkPresenterWorkItemSync(std::move(workItem), pumpMessages);
     }
 }
 
@@ -76,7 +89,7 @@ void InkStrokeContainer::Clear()
     RunOnInkHostThread(m_owner,
         [](inking::InkPresenter const& presenter)
         {
-            presenter.StrokeContainer().Clear();
+            RequireStrokeContainer(presenter).Clear();
         });
 }
 
@@ -90,12 +103,12 @@ winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> InkStrok
     RunOnInkHostThreadSync(m_owner,
         [&snapshot](inking::InkPresenter const& presenter)
         {
-            for (auto const& stroke : presenter.StrokeContainer().GetStrokes())
+            for (auto const& stroke : RequireStrokeContainer(presenter).GetStrokes())
             {
                 snapshot.push_back(stroke);
             }
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 
     return winrt::single_threaded_vector<inking::InkStroke>(std::move(snapshot)).GetView();
 }
@@ -106,7 +119,7 @@ void InkStrokeContainer::AddStroke(inking::InkStroke const& stroke)
     RunOnInkHostThread(m_owner,
         [stroke](inking::InkPresenter const& presenter)
         {
-            presenter.StrokeContainer().AddStroke(stroke);
+            RequireStrokeContainer(presenter).AddStroke(stroke);
         });
 }
 
@@ -124,7 +137,7 @@ void InkStrokeContainer::AddStrokes(winrt::Windows::Foundation::Collections::IIt
     RunOnInkHostThread(m_owner,
         [agileStrokes](inking::InkPresenter const& presenter)
         {
-            presenter.StrokeContainer().AddStrokes(agileStrokes);
+            RequireStrokeContainer(presenter).AddStrokes(agileStrokes);
         });
 }
 
@@ -139,9 +152,9 @@ winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::SaveAsync(winrt::Wi
         [outputStream](inking::InkPresenter const& presenter)
         {
             // Run the OS async to completion on the ink thread that owns the container.
-            presenter.StrokeContainer().SaveAsync(outputStream).get();
+            RequireStrokeContainer(presenter).SaveAsync(outputStream).get();
         },
-        /* propagateException */ true, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 }
 
 winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::SaveAsync(winrt::Windows::Storage::Streams::IOutputStream outputStream, inking::InkPersistenceFormat inkPersistenceFormat)
@@ -155,9 +168,9 @@ winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::SaveAsync(winrt::Wi
         [outputStream, inkPersistenceFormat](inking::InkPresenter const& presenter)
         {
             // Run the OS async to completion on the ink thread that owns the container.
-            presenter.StrokeContainer().SaveAsync(outputStream, inkPersistenceFormat).get();
+            RequireStrokeContainer(presenter).SaveAsync(outputStream, inkPersistenceFormat).get();
         },
-        /* propagateException */ true, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 }
 
 winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::LoadAsync(winrt::Windows::Storage::Streams::IInputStream inputStream)
@@ -169,9 +182,9 @@ winrt::Windows::Foundation::IAsyncAction InkStrokeContainer::LoadAsync(winrt::Wi
     RunOnInkHostThreadSync(m_owner,
         [inputStream](inking::InkPresenter const& presenter)
         {
-            presenter.StrokeContainer().LoadAsync(inputStream).get();
+            RequireStrokeContainer(presenter).LoadAsync(inputStream).get();
         },
-        /* propagateException */ true, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 }
 
 // Selection / query members. Each marshals a single call to the OS container on the ink
@@ -185,9 +198,9 @@ inking::InkStroke InkStrokeContainer::GetStrokeById(uint32_t id)
     RunOnInkHostThreadSync(m_owner,
         [&result, id](inking::InkPresenter const& presenter)
         {
-            result = presenter.StrokeContainer().GetStrokeById(id);
+            result = RequireStrokeContainer(presenter).GetStrokeById(id);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -197,9 +210,9 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::DeleteSelected()
     RunOnInkHostThreadSync(m_owner,
         [&result](inking::InkPresenter const& presenter)
         {
-            result = presenter.StrokeContainer().DeleteSelected();
+            result = RequireStrokeContainer(presenter).DeleteSelected();
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -209,9 +222,9 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::MoveSelected(winrt::Windows
     RunOnInkHostThreadSync(m_owner,
         [&result, translation](inking::InkPresenter const& presenter)
         {
-            result = presenter.StrokeContainer().MoveSelected(translation);
+            result = RequireStrokeContainer(presenter).MoveSelected(translation);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -221,9 +234,9 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::SelectWithLine(winrt::Windo
     RunOnInkHostThreadSync(m_owner,
         [&result, from, to](inking::InkPresenter const& presenter)
         {
-            result = presenter.StrokeContainer().SelectWithLine(from, to);
+            result = RequireStrokeContainer(presenter).SelectWithLine(from, to);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -243,9 +256,9 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::SelectWithPolyLine(winrt::W
         {
             auto vec = winrt::single_threaded_vector<winrt::Windows::Foundation::Point>();
             for (auto const& p : snapshot) { vec.Append(p); }
-            result = presenter.StrokeContainer().SelectWithPolyLine(vec);
+            result = RequireStrokeContainer(presenter).SelectWithPolyLine(vec);
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
@@ -256,24 +269,24 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::BoundingRect()
     RunOnInkHostThreadSync(m_owner,
         [&result](inking::InkPresenter const& presenter)
         {
-            result = presenter.StrokeContainer().BoundingRect();
+            result = RequireStrokeContainer(presenter).BoundingRect();
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
     return result;
 }
 
 // Clipboard members. The OS container is thread-affine, so these run on the ink thread like
-// the other container operations. Copy/Paste propagate failures so the app sees the HRESULT
-// (e.g. an empty selection on copy, or an incompatible clipboard payload on paste) instead of
-// a silent no-op; the returned Rect from paste is the invalidated region.
+// the other container operations. Failures surface to the app as an HRESULT (e.g. an empty
+// selection on copy, or an incompatible clipboard payload on paste); the returned Rect from
+// paste is the invalidated region.
 void InkStrokeContainer::CopySelectedToClipboard()
 {
     RunOnInkHostThreadSync(m_owner,
         [](inking::InkPresenter const& presenter)
         {
-            presenter.StrokeContainer().CopySelectedToClipboard();
+            RequireStrokeContainer(presenter).CopySelectedToClipboard();
         },
-        /* propagateException */ true, /* pumpMessages */ true);
+        /* pumpMessages */ true);
 }
 
 winrt::Windows::Foundation::Rect InkStrokeContainer::PasteFromClipboard(winrt::Windows::Foundation::Point const& position)
@@ -282,22 +295,21 @@ winrt::Windows::Foundation::Rect InkStrokeContainer::PasteFromClipboard(winrt::W
     RunOnInkHostThreadSync(m_owner,
         [&result, position](inking::InkPresenter const& presenter)
         {
-            result = presenter.StrokeContainer().PasteFromClipboard(position);
+            result = RequireStrokeContainer(presenter).PasteFromClipboard(position);
         },
-        /* propagateException */ true, /* pumpMessages */ true);
+        /* pumpMessages */ true);
     return result;
 }
 
 bool InkStrokeContainer::CanPasteFromClipboard()
 {
-    // Query: best-effort, so a failure just reports "cannot paste" rather than throwing.
     bool result = false;
     RunOnInkHostThreadSync(m_owner,
         [&result](inking::InkPresenter const& presenter)
         {
-            result = presenter.StrokeContainer().CanPasteFromClipboard();
+            result = RequireStrokeContainer(presenter).CanPasteFromClipboard();
         },
-        /* propagateException */ false, /* pumpMessages */ true);
+        /* pumpMessages */ true);
     return result;
 }
 
@@ -428,7 +440,7 @@ void InkPresenter::QueueInkPresenterWorkItem(std::function<void(inking::InkPrese
 // deadlock. INVARIANT: a work item posted here must not synchronously call back to the UI thread
 // (the wait is non-pumping); anything needing UI/app objects uses the async path (SaveAsync /
 // LoadAsync resume_background() first, so the UI thread is never the one blocked).
-void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages)
+void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages)
 {
     if (!m_inkHost)
     {
@@ -437,19 +449,9 @@ void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPre
 
     if (::GetCurrentThreadId() == m_inkThreadId)
     {
-        try
+        if (m_osPresenter)
         {
-            if (m_osPresenter)
-            {
-                workItem(m_osPresenter);
-            }
-        }
-        catch (...)
-        {
-            if (propagateException)
-            {
-                throw;
-            }
+            workItem(m_osPresenter);
         }
         return;
     }
@@ -472,8 +474,8 @@ void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPre
             }
             catch (...)
             {
-                // Capture rather than swallow: SaveAsync/LoadAsync opt into re-propagation so a
-                // failed save/load is reported to the app. Best-effort getters ignore this.
+                // Captured here and rethrown on the calling thread below: the ink thread has no way
+                // to raise it at the caller.
                 workError = std::current_exception();
             }
             ::SetEvent(doneEvent.get());
@@ -499,7 +501,7 @@ void InkPresenter::RunInkPresenterWorkItemSync(std::function<void(inking::InkPre
         ::WaitForSingleObject(doneEvent.get(), INFINITE);
     }
 
-    if (propagateException && workError)
+    if (workError)
     {
         std::rethrow_exception(workError);
     }
@@ -595,7 +597,7 @@ winrt::InkDrawingAttributes InkPresenter::CopyDefaultDrawingAttributes()
         {
             result = presenter.CopyDefaultDrawingAttributes();
         },
-        /* propagateException */ false, /* pumpMessages */ false);
+        /* pumpMessages */ false);
 
     if (!result)
     {
@@ -614,12 +616,12 @@ void InkPresenter::SetPredefinedConfiguration(inking::InkPresenterPredefinedConf
         });
 }
 
-muxc::InkHighContrastAdjustment InkPresenter::GetHighContrastAdjustment() const noexcept
+muxc::InkHighContrastAdjustment InkPresenter::HighContrastAdjustment() const noexcept
 {
     return m_highContrastAdjustment;
 }
 
-void InkPresenter::SetHighContrastAdjustment(muxc::InkHighContrastAdjustment const& value)
+void InkPresenter::HighContrastAdjustment(muxc::InkHighContrastAdjustment const& value)
 {
     m_highContrastAdjustment = value;
 
@@ -672,6 +674,83 @@ muxc::InkUnprocessedInput InkPresenter::UnprocessedInput()
     return m_unprocessedInput;
 }
 
+muxc::InkSynchronizer InkPresenter::ActivateCustomDrying()
+{
+    // Idempotent (UWP parity): activate once; repeated calls return the same synchronizer.
+    if (m_customDrySynchronizer)
+    {
+        return m_customDrySynchronizer;
+    }
+
+    // Created on the UI (calling) thread, where the app invokes it - a proxy created on the ink thread
+    // crashes when called cross-apartment.
+    auto customDrySynchronizer = winrt::make<InkSynchronizer>(winrt::weak_ref<muxc::InkPresenter>{ *this });
+
+    // UWP parity: the OS rejects this with E_ILLEGAL_METHOD_CALL once ink input has activated (first
+    // non-zero SetSize), and the app owns that ordering - activate before the first layout pass.
+    bool activated = false;
+    RunInkPresenterWorkItemSync(
+        [&](inking::InkPresenter const& osPresenter)
+        {
+            winrt::get_self<::InkSynchronizer>(customDrySynchronizer)->Initialize(osPresenter.ActivateCustomDrying());
+            activated = true;
+        },
+        /* pumpMessages */ false);
+
+    // The work item never ran: no ink host, or the OS presenter has not been created yet. Report it
+    // rather than handing back a synchronizer whose BeginDry would silently do nothing.
+    if (!activated)
+    {
+        throw winrt::hresult_error(E_ILLEGAL_METHOD_CALL, L"InkPresenter is not ready for custom drying.");
+    }
+
+    m_customDrySynchronizer = customDrySynchronizer;
+    return m_customDrySynchronizer;
+}
+
+// -- InkSynchronizer mirror -----------------------------------------------------------------------
+// Owns the OS InkSynchronizer (adopted on the ink thread from the presenter's OS ActivateCustomDrying)
+// and marshals its BeginDry/EndDry onto the ink thread through the owning InkPresenter proxy's work
+// queue. UWP hands the app the OS object directly; this proxy exists only because that object is
+// ink-thread affine, so it forwards both calls and keeps no dry-transaction state of its own.
+// No-ops once the owner has been torn down.
+
+winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> InkSynchronizer::BeginDry()
+{
+    std::vector<inking::InkStroke> strokes;
+    RunOnInkHostThreadSync(m_owner,
+        [this, &strokes](inking::InkPresenter const&)
+        {
+            if (!m_osSynchronizer)
+            {
+                return;
+            }
+            auto dry = m_osSynchronizer.BeginDry();
+            if (dry && dry.Size())
+            {
+                strokes.resize(dry.Size(), nullptr);
+                dry.GetMany(0, strokes);
+            }
+        },
+        /* pumpMessages */ false);
+    // Build the returned collection on the calling (UI) thread so the app is never handed an
+    // ink-thread-affine object.
+    return winrt::single_threaded_vector<inking::InkStroke>(std::move(strokes)).GetView();
+}
+
+void InkSynchronizer::EndDry()
+{
+    RunOnInkHostThreadSync(m_owner,
+        [this](inking::InkPresenter const&)
+        {
+            if (m_osSynchronizer)
+            {
+                m_osSynchronizer.EndDry();
+            }
+        },
+        /* pumpMessages */ false);
+}
+
 winrt::event_token InkPresenter::StrokesCollected(winrt::Windows::Foundation::TypedEventHandler<muxc::InkPresenter, muxc::InkStrokesCollectedEventArgs> const& handler)
 {
     return m_strokesCollectedEvent.add(handler);
@@ -692,9 +771,11 @@ void InkPresenter::StrokesErased(winrt::event_token const& token)
     m_strokesErasedEvent.remove(token);
 }
 
-// Runs ONCE on the ink thread (from Start's work item) as soon as the OS presenter is created. The
-// proxy takes ownership of the OS presenter and owns everything about it from here on: initial
-// configuration and the stroke-event forwarding path.
+// Runs on the ink thread as soon as an OS presenter is created: once from Start's work item, and again
+// from ActivateCustomDrying when it swaps in a freshly-created presenter to activate custom drying. The
+// proxy adopts the given OS presenter and (re)establishes everything about it from here on: initial
+// configuration and the stroke-event forwarding path. Safe to run more than once - it always targets
+// the passed-in presenter, and the previously-adopted one is released when m_osPresenter is reassigned.
 void InkPresenter::InitializeOsPresenter(inking::InkPresenter const& osPresenter)
 {
     m_osPresenter = osPresenter;
@@ -733,7 +814,7 @@ void InkPresenter::InitializeOsPresenter(inking::InkPresenter const& osPresenter
     // snapshot the strokes here, marshal to the UI thread, and re-raise our own events there.
     // Handlers are attached eagerly and are harmless when the app never subscribes to our events.
     osPresenter.StrokesCollected(
-        [marshalToUi](inking::InkPresenter const&, inking::InkStrokesCollectedEventArgs const& args)
+        [marshalToUi, weakSelf](inking::InkPresenter const&, inking::InkStrokesCollectedEventArgs const& args)
         {
             auto strokes = args.Strokes();
             std::vector<inking::InkStroke> snapshot(strokes.Size(), nullptr);

--- a/controls/dev/InkCanvas/InkPresenter.h
+++ b/controls/dev/InkCanvas/InkPresenter.h
@@ -12,9 +12,11 @@
 #include "InkInputConfiguration.g.h"
 #include "InkStrokeInput.g.h"
 #include "InkUnprocessedInput.g.h"
+#include "InkSynchronizer.g.h"
 #include "InkPresenter.g.h"
 #include <windows.ui.input.inking.h>
 #include <inkpresenterdesktop.h>
+#include <dcomp.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.UI.Core.h>
@@ -29,18 +31,40 @@
 namespace inking = winrt::Windows::UI::Input::Inking;
 namespace muxc = winrt::Microsoft::UI::Xaml::Controls;
 
+// The IInkCommitRequestHandler the OS presenter calls (OnCommitRequested) on every wet->dry transition
+// - normal drying and custom-dry EndDry - so the host commits the shared DComposition device and the
+// change is presented. Defined here (rather than privately in InkCanvas.cpp) so the InkPresenter proxy
+// can re-create it when it re-creates the OS presenter to activate custom drying at runtime.
+struct InkCommitRequestHandler : winrt::implements<InkCommitRequestHandler, IInkCommitRequestHandler>
+{
+    InkCommitRequestHandler(winrt::com_ptr<IDCompositionDevice> device)
+        : m_device(device) {}
+
+    IFACEMETHODIMP OnCommitRequested() override
+    {
+        if (m_device)
+        {
+            return m_device->Commit();
+        }
+        return S_OK;
+    }
+
+private:
+    winrt::com_ptr<IDCompositionDevice> m_device;
+};
+
 // Marshals a work item onto the ink host thread through the owning InkPresenter proxy, passing the
 // OS presenter to the lambda. No-op if the proxy has already been destroyed. The child proxies
 // (InkStrokeContainer / InkInputProcessingConfiguration / InkInputConfiguration) call these instead
 // of reaching into the proxy's work queue directly; the queue lives on the InkPresenter proxy, which
 // is the sole owner of the thread-affine OS presenter and the ink host reference.
 void RunOnInkHostThread(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem);
-// Synchronous marshal onto the ink host thread. propagateException rethrows a work-item failure on the
-// caller (false for best-effort getters). pumpMessages uses a COM-pumping wait (COWAIT_DISPATCH_CALLS)
-// instead of a plain blocking wait - required for OLE-clipboard work that can call back into the
-// UI-thread clipboard owner while this wait is in progress; a non-pumping wait would deadlock. Pass
-// false for ordinary getters.
-void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages);
+// Synchronous marshal onto the ink host thread. A work-item failure is rethrown on the calling thread,
+// so ink-thread errors reach the app rather than being reported as a default-constructed result.
+// pumpMessages uses a COM-pumping wait (COWAIT_DISPATCH_CALLS) instead of a plain blocking wait -
+// required for OLE-clipboard work that can call back into the UI-thread clipboard owner while this wait
+// is in progress; a non-pumping wait would deadlock. Pass false for ordinary getters.
+void RunOnInkHostThreadSync(winrt::weak_ref<muxc::InkPresenter> const& presenter, std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages);
 
 // Snapshot of the InkStroke objects handed to InkPresenter.StrokesCollected. InkStroke is
 // agile, so the strokes are copied on the ink thread and this args object is re-raised on
@@ -170,8 +194,7 @@ public:
 
     // Back-pointer to the owning presenter mirror (UWP parity). Weak, so it never keeps the owner
     // alive; returns null once the owner is gone. Set by InkPresenter::Start (post-construction).
-    // Method (not property) to avoid a recursive XAML metadata thunk cycle - see the IDL comment.
-    muxc::InkPresenter GetInkPresenter() { return m_owner.get(); }
+    muxc::InkPresenter InkPresenter() { return m_owner.get(); }
     void SetOwner(winrt::weak_ref<muxc::InkPresenter> const& owner) { m_owner = owner; }
 
 private:
@@ -215,8 +238,7 @@ public:
 
     // Back-pointer to the owning presenter mirror (UWP parity). Weak, so it never keeps the owner
     // alive; returns null once the owner is gone. Set by InkPresenter::Start (post-construction).
-    // Method (not property) to avoid a recursive XAML metadata thunk cycle - see the IDL comment.
-    muxc::InkPresenter GetInkPresenter() { return m_owner.get(); }
+    muxc::InkPresenter InkPresenter() { return m_owner.get(); }
     void SetOwner(winrt::weak_ref<muxc::InkPresenter> const& owner) { m_owner = owner; }
 
 private:
@@ -228,6 +250,35 @@ private:
     winrt::event<Handler> m_pointerMoved;
     winrt::event<Handler> m_pointerReleased;
     winrt::event<Handler> m_pointerLost;
+};
+
+// Mirror of Windows.UI.Input.Inking.InkSynchronizer, returned by InkPresenter.ActivateCustomDrying.
+// Lets the app render committed ("dry") ink itself: BeginDry hands back the strokes the presenter just
+// committed and suppresses the presenter's own dry rendering; EndDry releases the wet-ink layer once
+// the app has drawn them. UWP returns the OS InkSynchronizer directly; this mirror exists only because
+// that object is thread-affine to the ink thread, so it forwards BeginDry/EndDry through the owning
+// InkPresenter proxy's work queue and holds no dry-transaction state of its own. The InkPresenter keeps
+// this projected mirror, never the raw OS inking::InkSynchronizer.
+class InkSynchronizer :
+    public winrt::implementation::InkSynchronizerT<InkSynchronizer>
+{
+public:
+    InkSynchronizer(winrt::weak_ref<muxc::InkPresenter> const& owner) : m_owner(owner) {}
+
+    winrt::Windows::Foundation::Collections::IVectorView<inking::InkStroke> BeginDry();
+    void EndDry();
+
+    // Internal (not on the winmd surface). Injects the OS InkSynchronizer (from the presenter's OS
+    // ActivateCustomDrying) into this UI-thread-created proxy. Called on the ink thread, where the OS
+    // synchronizer is valid.
+    void Initialize(inking::InkSynchronizer const& osSynchronizer) noexcept { m_osSynchronizer = osSynchronizer; }
+
+private:
+    winrt::weak_ref<muxc::InkPresenter> m_owner{ nullptr };
+
+    // The OS InkSynchronizer this mirror fronts (from OS ActivateCustomDrying). Thread-affine to the ink
+    // thread; only ever touched inside ink-thread work items. Null until custom drying is activated.
+    inking::InkSynchronizer m_osSynchronizer{ nullptr };
 };
 
 // Manipulable subset of Windows.UI.Input.Inking.InkPresenter. The OS presenter can only be created
@@ -253,14 +304,16 @@ public:
 
     void SetPredefinedConfiguration(inking::InkPresenterPredefinedConfiguration const& configuration);
 
-    muxc::InkHighContrastAdjustment GetHighContrastAdjustment() const noexcept;
-    void SetHighContrastAdjustment(muxc::InkHighContrastAdjustment const& value);
+    muxc::InkHighContrastAdjustment HighContrastAdjustment() const noexcept;
+    void HighContrastAdjustment(muxc::InkHighContrastAdjustment const& value);
 
     muxc::InkStrokeContainer StrokeContainer();
     muxc::InkInputProcessingConfiguration InputProcessingConfiguration();
     muxc::InkInputConfiguration InputConfiguration();
     muxc::InkStrokeInput StrokeInput();
     muxc::InkUnprocessedInput UnprocessedInput();
+
+    muxc::InkSynchronizer ActivateCustomDrying();
 
     winrt::event_token StrokesCollected(winrt::Windows::Foundation::TypedEventHandler<muxc::InkPresenter, muxc::InkStrokesCollectedEventArgs> const& handler);
     void StrokesCollected(winrt::event_token const& token);
@@ -279,7 +332,7 @@ public:
     // SetRootVisual / SetSize).
     void QueueInkPresenterWorkItem(std::function<void(inking::InkPresenter const&)> workItem);
     // pumpMessages uses a COM-pumping wait (see the free RunOnInkHostThreadSync); pass false for ordinary getters.
-    void RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool propagateException, bool pumpMessages);
+    void RunInkPresenterWorkItemSync(std::function<void(inking::InkPresenter const&)> workItem, bool pumpMessages);
 
     // Internal (not on the winmd surface). Shows/hides the ruler / protractor stencils on the OS
     // presenter. InkPresenterRuler / InkPresenterProtractor are thread-affine, so they are created
@@ -335,6 +388,11 @@ private:
     muxc::InkInputConfiguration m_inputConfiguration{ nullptr };
     muxc::InkStrokeInput m_strokeInput{ nullptr };
     muxc::InkUnprocessedInput m_unprocessedInput{ nullptr };
+
+    // Custom drying: the synchronizer handed back by ActivateCustomDrying (UI-thread cached; repeated
+    // calls return the same instance, UWP parity). It fronts the OS InkSynchronizer; this proxy keeps
+    // only this projected wrapper, never the raw OS one.
+    muxc::InkSynchronizer m_customDrySynchronizer{ nullptr };
 
     // Ruler / protractor stencils bound to the OS presenter. Thread-affine to the ink
     // thread, so they are only ever constructed and touched inside serialized ink-thread

--- a/controls/dev/InkToolbar/InkToolbar.cpp
+++ b/controls/dev/InkToolbar/InkToolbar.cpp
@@ -891,7 +891,7 @@ int32_t InkToolbar::GetHighContrastAdjustmentValue()
     {
         if (auto proxy = canvas.InkPresenter())
         {
-            return static_cast<int32_t>(proxy.GetHighContrastAdjustment());
+            return static_cast<int32_t>(proxy.HighContrastAdjustment());
         }
     }
     return 0; // UseSystemColorsWhenNecessary

--- a/controls/dev/dll/XamlMetadataProviderGenerated.h
+++ b/controls/dev/dll/XamlMetadataProviderGenerated.h
@@ -1622,6 +1622,14 @@ Entry c_typeEntries[] =
                         false, /* isDependencyProperty */
                         false /* isAttachable */);
                     xamlType.AddMember(
+                        L"HighContrastAdjustment", /* propertyName */
+                        L"Microsoft.UI.Xaml.Controls.InkHighContrastAdjustment", /* propertyType */
+                        [](winrt::IInspectable instance) { return box_value<int>((int)instance.as<winrt::InkPresenter>().HighContrastAdjustment()); },
+                        [](winrt::IInspectable instance, winrt::IInspectable value) { instance.as<winrt::InkPresenter>().HighContrastAdjustment(unbox_value<winrt::InkHighContrastAdjustment>(value)); },
+                        false, /* isContent */
+                        false, /* isDependencyProperty */
+                        false /* isAttachable */);
+                    xamlType.AddMember(
                         L"InputConfiguration", /* propertyName */
                         L"Microsoft.UI.Xaml.Controls.InkInputConfiguration", /* propertyType */
                         [](winrt::IInspectable instance) { return instance.as<winrt::InkPresenter>().InputConfiguration(); },
@@ -1704,6 +1712,35 @@ Entry c_typeEntries[] =
             auto xamlType = winrt::make_self<XamlType>(
                 /* Arg 1 - TypeName */ 
                 (PCWSTR)L"Microsoft.UI.Xaml.Controls.InkStrokeInput",
+                /* Arg 2 - BaseTypeName */ 
+                (PCWSTR)L"Object",
+                /* Arg 3 - Activator func */ 
+                nullptr,
+                /* Arg 4 - Populate properties func */ 
+                (std::function<void(XamlTypeBase&)>)[](XamlTypeBase& xamlType)
+                {
+                    xamlType.AddMember(
+                        L"InkPresenter", /* propertyName */
+                        L"Microsoft.UI.Xaml.Controls.InkPresenter", /* propertyType */
+                        [](winrt::IInspectable instance) { return instance.as<winrt::InkStrokeInput>().InkPresenter(); },
+                        nullptr, /* setter */
+                        false, /* isContent */
+                        false, /* isDependencyProperty */
+                        false /* isAttachable */);
+                });
+
+            return static_cast<winrt::IXamlType>(*xamlType);
+        }
+    },
+    {
+        /* Arg1 TypeName */ 
+        L"Microsoft.UI.Xaml.Controls.InkSynchronizer",
+        /* Arg2 CreateXamlTypeCallback */ 
+        []()
+        {
+            auto xamlType = winrt::make_self<XamlType>(
+                /* Arg 1 - TypeName */ 
+                (PCWSTR)L"Microsoft.UI.Xaml.Controls.InkSynchronizer",
                 /* Arg 2 - BaseTypeName */ 
                 (PCWSTR)L"Object",
                 /* Arg 3 - Activator func */ 
@@ -2378,8 +2415,17 @@ Entry c_typeEntries[] =
                 /* Arg 3 - Activator func */ 
                 nullptr,
                 /* Arg 4 - Populate properties func */ 
-                nullptr
-            );
+                (std::function<void(XamlTypeBase&)>)[](XamlTypeBase& xamlType)
+                {
+                    xamlType.AddMember(
+                        L"InkPresenter", /* propertyName */
+                        L"Microsoft.UI.Xaml.Controls.InkPresenter", /* propertyType */
+                        [](winrt::IInspectable instance) { return instance.as<winrt::InkUnprocessedInput>().InkPresenter(); },
+                        nullptr, /* setter */
+                        false, /* isContent */
+                        false, /* isDependencyProperty */
+                        false /* isAttachable */);
+                });
 
             return static_cast<winrt::IXamlType>(*xamlType);
         }

--- a/controls/dev/inc/CppWinRTIncludes.h
+++ b/controls/dev/inc/CppWinRTIncludes.h
@@ -270,7 +270,8 @@ namespace winrt
 
     // using namespace ::winrt::Windows::UI::Input::Inking;
     using InkDrawingAttributes = ::winrt::Windows::UI::Input::Inking::InkDrawingAttributes;
-    using InkPresenter = ::winrt::Windows::UI::Input::Inking::InkPresenter;
+    // No InkPresenter alias: winrt::InkPresenter must resolve to the WinUI mirror
+    // (Microsoft.UI.Xaml.Controls.InkPresenter). Use the inking namespace alias for the OS type.
     using InkPresenterProtractor = ::winrt::Windows::UI::Input::Inking::InkPresenterProtractor;
     using InkPresenterRuler = ::winrt::Windows::UI::Input::Inking::InkPresenterRuler;
 


### PR DESCRIPTION
Adds custom drying to `InkCanvas`: `InkPresenter.ActivateCustomDrying()` returns an `InkSynchronizer` so the app can take over rendering of committed ("dry") ink via `BeginDry`/`EndDry`.

Supersedes #11703, which was opened from a fork. Fork PRs cannot pass the required `WinUI-GitHub-PR (OneBranch)` check — the pipeline runs with `forks.allowSecrets=False`, so it dies at `Install Pipeline Tools` before checkout and every real stage is skipped. This branch lives in the repo so CI can actually run. Review history and reviewer sign-off are on #11703; the code here is the same work, squashed into one commit and rebased onto current `main`, plus the crash fix noted below.

## What changed

- `InkPresenter.ActivateCustomDrying()` returns an `InkSynchronizer` mirror; the OS synchronizer is thread-affine to the ink thread, so the returned object is a UI-thread proxy.
- Ink-thread failures now propagate instead of being swallowed, so the OS ordering contract surfaces to the app.
- `InkCanvas` sizes the presenter in DIPs (previously multiplied by `rootScale`, which was 1.5x too large at 150% DPI).
- Removed dead custom-drying plumbing (`m_rootVisual`, `m_compositionDevice` and their setters) left over from the removed presenter-rebuild path.
- Removed the deferred first size push so ordering matches UWP.
- `HighContrastAdjustment` is a property, and `InkStrokeInput`/`InkUnprocessedInput` expose `InkPresenter` as a property, matching UWP shapes.
- ScratchPadApp gains a custom-drying demo that renders dried strokes itself.

## Ordering contract

The OS activates ink input on the first non-zero `SetSize`, and rejects `ActivateCustomDrying` afterwards with `E_ILLEGAL_METHOD_CALL` (`CDirectInkImpl::_InitializeCustomDry` gates on `fInputActivated || IsDefaultDryStarted()`). Custom drying must therefore be activated before the canvas is sized — from the page/window constructor. This matches UWP; the app owns the ordering.

## Crash fix included

`InkPresenter.StrokeContainer` maps to `CDirectInkImpl::GetDryInkContainer`, which is annotated `_Outptr_result_maybenull_`. While custom drying is active the app owns dry ink, so the OS holds no dry-ink container and the property returns null. All 16 stroke-container operations dereferenced it unguarded, which took the process down with an access violation (`0xc0000005`) — the synchronous paths rethrew the fault onto the UI thread, and the fire-and-forget paths silently swallowed it.

Added a `RequireStrokeContainer` helper that throws `hresult_illegal_method_call` with a clear message instead. Apps now get a catchable error rather than a process kill.

## Validation

Built and run locally against the ScratchPadApp sample:

- Custom drying activated from the constructor: `ActivateCustomDrying -> OK`, then real pen/mouse input produces `BeginDry=1, app-rendered, EndDry ok` with app-drawn dry strokes visible.
- Activation after load correctly surfaces `E_ILLEGAL_METHOD_CALL`.
- Stroke-container calls while custom drying is active now raise a clean error; previously this was an access violation, reproduced 3/3 and confirmed via the linker map and a product-side trace showing `container IS NULL` on the ink thread.
- Normal drying unaffected: `AddStroke`, `GetStrokes` and `Clear` all behave as before.
- Sizing verified at 150% DPI: canvas reports `498.67 x 384` DIPs with strokes inside bounds.
