### PR TITLE
Batch TitleBar updates and adjust NavigationView recycling and tracing

### DIFF
--- a/controls/dev/NavigationView/NavigationView.cpp
+++ b/controls/dev/NavigationView/NavigationView.cpp
@@ -5260,10 +5260,16 @@ winrt::IndexPath NavigationView::SearchEntireTreeForIndexPath(const winrt::Navig
 
                             if (auto const foundIndexPath = SearchEntireTreeForIndexPath(nvi, data, newIndexPath))
                             {
+                                RecycleContainer(nvib);
                                 return foundIndexPath;
                             }
 
-                            //TODO: Recycle container!
+                            RecycleContainer(nvib);
+                        }
+                        else
+                        {
+                            // Container is not a NavigationViewItem (e.g., header/separator) — still must recycle.
+                            RecycleContainer(nvib);
                         }
                     }
                 }

--- a/controls/dev/TitleBar/TitleBar.cpp
+++ b/controls/dev/TitleBar/TitleBar.cpp
@@ -356,20 +356,14 @@ void TitleBar::OnContentLayoutUpdated(const winrt::IInspectable& /*sender*/, con
 }
 
 // Static callback for IsDragRegion attached property changes.
-// Walks up the visual tree to find the parent TitleBar and triggers an update of its drag regions.
-// This handles dynamic changes to IsDragRegion at runtime (including hot reload scenarios).
-// 
-// Note: If element is not yet in the visual tree (e.g., during initial XAML parsing),
-// GetParent returns null and we exit immediately. The TitleBar will discover the
-// IsDragRegion value later via FindInteractableElements() during layout updates.
+// Walks up the visual tree to find the parent TitleBar and triggers a coalesced update
+// of its drag regions. Multiple IsDragRegion changes in the same tick are batched into
+// a single UpdateInteractableElementsList + UpdateDragRegion pass via the DispatcherQueue
+// to avoid O(changes * treeSize) work on Windows 11 high-frequency updates.
 void TitleBar::OnIsDragRegionPropertyChanged(
     winrt::DependencyObject const& sender,
     winrt::DependencyPropertyChangedEventArgs const& /*args*/)
 {
-    // Walk up from sender to find the owning TitleBar and refresh its drag regions.
-    // Note: If multiple elements have their IsDragRegion changed at the same time,
-    // this will result in duplicate work. A future optimization could defer the update
-    // using CompositionTarget.Rendered to coalesce multiple changes into a single pass.
     auto current = sender.try_as<winrt::DependencyObject>();
     while (current)
     {
@@ -377,8 +371,43 @@ void TitleBar::OnIsDragRegionPropertyChanged(
         {
             if (auto titleBarImpl = winrt::get_self<TitleBar>(titleBar))
             {
-                titleBarImpl->UpdateInteractableElementsList();
-                titleBarImpl->UpdateDragRegion();
+                if (!titleBarImpl->m_isDragRegionUpdatePending)
+                {
+                    titleBarImpl->m_isDragRegionUpdatePending = true;
+                    // Coalesce via DispatcherQueue Low priority (next tick) to batch rapid changes.
+                    // Fallback to immediate update if DispatcherQueue is unavailable (e.g., not yet loaded).
+                    if (auto dispatcherQueue = titleBar.DispatcherQueue())
+                    {
+                        bool enqueued = dispatcherQueue.TryEnqueue(
+                            winrt::Microsoft::UI::Dispatching::DispatcherQueuePriority::Low,
+                            winrt::Microsoft::UI::Dispatching::DispatcherQueueHandler(
+                                [weakTitleBar = winrt::make_weak(titleBar)]()
+                                {
+                                    if (auto strongTitleBar = weakTitleBar.get())
+                                    {
+                                        if (auto impl = winrt::get_self<TitleBar>(strongTitleBar))
+                                        {
+                                            impl->m_isDragRegionUpdatePending = false;
+                                            impl->UpdateInteractableElementsList();
+                                            impl->UpdateDragRegion();
+                                        }
+                                    }
+                                }));
+                        if (!enqueued)
+                        {
+                            // Queue shut down — run immediately.
+                            titleBarImpl->m_isDragRegionUpdatePending = false;
+                            titleBarImpl->UpdateInteractableElementsList();
+                            titleBarImpl->UpdateDragRegion();
+                        }
+                    }
+                    else
+                    {
+                        titleBarImpl->m_isDragRegionUpdatePending = false;
+                        titleBarImpl->UpdateInteractableElementsList();
+                        titleBarImpl->UpdateDragRegion();
+                    }
+                }
             }
             return;
         }

--- a/controls/dev/TitleBar/TitleBar.h
+++ b/controls/dev/TitleBar/TitleBar.h
@@ -104,6 +104,7 @@ private:
     double m_compactModeThresholdWidth{ 0.0 };
     bool m_isCompact{ false };
     bool m_hasDefaultAppWindowTitle{ false };
+    bool m_isDragRegionUpdatePending{ false };
 
     static constexpr std::wstring_view s_leftPaddingColumnName{ L"LeftPaddingColumn"sv };
     static constexpr std::wstring_view s_rightPaddingColumnName{ L"RightPaddingColumn"sv };

--- a/dxaml/xcp/core/hw/hwwalk.cpp
+++ b/dxaml/xcp/core/hw/hwwalk.cpp
@@ -285,7 +285,10 @@ HWWalk::Render(
                     &skipRenderWhileTransformTooSmall
                     ));
 
-                HWWalk::TraceElementAccessibility(pUIElement);
+                if (EventEnabledElementAccessibilityInfo())
+                {
+                    HWWalk::TraceElementAccessibility(pUIElement);
+                }
             }
 
             {

--- a/dxaml/xcp/core/layout/LayoutManager.cpp
+++ b/dxaml/xcp/core/layout/LayoutManager.cpp
@@ -295,17 +295,19 @@ CLayoutManager::UpdateLayout(XUINT32 controlWidth, XUINT32 controlHeight)
                 TraceMeasureEnd();
             });
 
-            if (StoreLayoutCycleWarningContexts())
+            if (StoreLayoutCycleWarningContexts() && LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
             {
-                extraInfoEntries[extraInfoIndex].append(L" Launching Measure Pass.");
-
-                if (LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
+                if (extraInfoEntries[extraInfoIndex].empty())
                 {
-                    std::wstring trace;
-                    trace.assign(L"[LayoutCycleTracing] ");
-                    trace.append(extraInfoEntries[extraInfoIndex]);
-                    DisplayReleaseMessage(trace.c_str());
+                    extraInfoEntries[extraInfoIndex].assign(L"Layout Iteration Countdown: ");
+                    extraInfoEntries[extraInfoIndex].append(std::to_wstring(count));
+                    extraInfoEntries[extraInfoIndex].append(L".");
                 }
+                extraInfoEntries[extraInfoIndex].append(L" Launching Measure Pass.");
+                std::wstring trace;
+                trace.assign(L"[LayoutCycleTracing] ");
+                trace.append(extraInfoEntries[extraInfoIndex]);
+                DisplayReleaseMessage(trace.c_str());
             }
 
             IFC(pRoot->Measure(m_arrangeRect.Size()));
@@ -327,17 +329,19 @@ CLayoutManager::UpdateLayout(XUINT32 controlWidth, XUINT32 controlHeight)
                 TraceArrangeEnd();
             });
 
-            if (StoreLayoutCycleWarningContexts())
+            if (StoreLayoutCycleWarningContexts() && LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
             {
-                extraInfoEntries[extraInfoIndex].append(L" Launching Arrange Pass.");
-
-                if (LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
+                if (extraInfoEntries[extraInfoIndex].empty())
                 {
-                    std::wstring trace;
-                    trace.assign(L"[LayoutCycleTracing] ");
-                    trace.append(extraInfoEntries[extraInfoIndex]);
-                    DisplayReleaseMessage(trace.c_str());
+                    extraInfoEntries[extraInfoIndex].assign(L"Layout Iteration Countdown: ");
+                    extraInfoEntries[extraInfoIndex].append(std::to_wstring(count));
+                    extraInfoEntries[extraInfoIndex].append(L".");
                 }
+                extraInfoEntries[extraInfoIndex].append(L" Launching Arrange Pass.");
+                std::wstring trace;
+                trace.assign(L"[LayoutCycleTracing] ");
+                trace.append(extraInfoEntries[extraInfoIndex]);
+                DisplayReleaseMessage(trace.c_str());
             }
 
             IFC(pRoot->Arrange(m_arrangeRect));
@@ -352,17 +356,19 @@ CLayoutManager::UpdateLayout(XUINT32 controlWidth, XUINT32 controlHeight)
                 TraceFireEffectiveViewportChangedEnd();
             });
 
-            if (StoreLayoutCycleWarningContexts())
+            if (StoreLayoutCycleWarningContexts() && LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
             {
-                extraInfoEntries[extraInfoIndex].append(L" Launching EffectiveViewport Pass.");
-
-                if (LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
+                if (extraInfoEntries[extraInfoIndex].empty())
                 {
-                    std::wstring trace;
-                    trace.assign(L"[LayoutCycleTracing] ");
-                    trace.append(extraInfoEntries[extraInfoIndex]);
-                    DisplayReleaseMessage(trace.c_str());
+                    extraInfoEntries[extraInfoIndex].assign(L"Layout Iteration Countdown: ");
+                    extraInfoEntries[extraInfoIndex].append(std::to_wstring(count));
+                    extraInfoEntries[extraInfoIndex].append(L".");
                 }
+                extraInfoEntries[extraInfoIndex].append(L" Launching EffectiveViewport Pass.");
+                std::wstring trace;
+                trace.assign(L"[LayoutCycleTracing] ");
+                trace.append(extraInfoEntries[extraInfoIndex]);
+                DisplayReleaseMessage(trace.c_str());
             }
 
             m_horizontalViewports.clear();
@@ -397,17 +403,19 @@ CLayoutManager::UpdateLayout(XUINT32 controlWidth, XUINT32 controlHeight)
                     TraceFireSizeChangedEnd();
                 });
 
-                if (StoreLayoutCycleWarningContexts())
+                if (StoreLayoutCycleWarningContexts() && LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
                 {
-                    extraInfoEntries[extraInfoIndex].append(L" Raising SizeChanged Events.");
-
-                    if (LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
+                    if (extraInfoEntries[extraInfoIndex].empty())
                     {
-                        std::wstring trace;
-                        trace.assign(L"[LayoutCycleTracing] ");
-                        trace.append(extraInfoEntries[extraInfoIndex]);
-                        DisplayReleaseMessage(trace.c_str());
+                        extraInfoEntries[extraInfoIndex].assign(L"Layout Iteration Countdown: ");
+                        extraInfoEntries[extraInfoIndex].append(std::to_wstring(count));
+                        extraInfoEntries[extraInfoIndex].append(L".");
                     }
+                    extraInfoEntries[extraInfoIndex].append(L" Raising SizeChanged Events.");
+                    std::wstring trace;
+                    trace.assign(L"[LayoutCycleTracing] ");
+                    trace.append(extraInfoEntries[extraInfoIndex]);
+                    DisplayReleaseMessage(trace.c_str());
                 }
 
                 RaiseSizeChangedEvents();
@@ -426,17 +434,19 @@ CLayoutManager::UpdateLayout(XUINT32 controlWidth, XUINT32 controlHeight)
                     TraceFireLayoutUpdatedEnd();
                 });
 
-                if (StoreLayoutCycleWarningContexts())
+                if (StoreLayoutCycleWarningContexts() && LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
                 {
-                    extraInfoEntries[extraInfoIndex].append(L" Raising LayoutUpdated Events.");
-
-                    if (LayoutCycleDebugSettings::ShouldTrace(DirectUI::LayoutCycleTracingLevel::Low))
+                    if (extraInfoEntries[extraInfoIndex].empty())
                     {
-                        std::wstring trace;
-                        trace.assign(L"[LayoutCycleTracing] ");
-                        trace.append(extraInfoEntries[extraInfoIndex]);
-                        DisplayReleaseMessage(trace.c_str());
+                        extraInfoEntries[extraInfoIndex].assign(L"Layout Iteration Countdown: ");
+                        extraInfoEntries[extraInfoIndex].append(std::to_wstring(count));
+                        extraInfoEntries[extraInfoIndex].append(L".");
                     }
+                    extraInfoEntries[extraInfoIndex].append(L" Raising LayoutUpdated Events.");
+                    std::wstring trace;
+                    trace.assign(L"[LayoutCycleTracing] ");
+                    trace.append(extraInfoEntries[extraInfoIndex]);
+                    DisplayReleaseMessage(trace.c_str());
                 }
 
                 IGNOREHR(FxCallbacks::JoltHelper_RaiseEvent(


### PR DESCRIPTION
## Fixes

No linked issue yet. This is a work-in-progress draft; a matching issue or prior discussion is needed before this nontrivial change is ready for review under the contribution workflow.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Performance changes to drag-region updates and tracing.

## Description

This draft batches TitleBar drag-region updates, adds NavigationView container recycling, and changes tracing in the rendering and layout paths. These affect separate components; the scope needs review before the PR is ready.

### Current Behavior

- Each `IsDragRegion` property change immediately rebuilds the owning TitleBar's interactable-element list and drag regions.
- Some recursive NavigationView index-path search paths leave temporary containers unrecycled.
- The render walk calls `TraceElementAccessibility` without checking whether its ETW event is enabled at the call site.
- LayoutManager records layout-phase text for layout-cycle warning contexts independently of whether debugger tracing is enabled.

### New Behavior

- TitleBar schedules one pending update through a low-priority DispatcherQueue callback, using a weak reference. It falls back to an immediate update if the queue is unavailable or rejects the callback.
- NavigationView recycles temporary containers after recursive searches and for non-item containers.
- The render walk checks `EventEnabledElementAccessibilityInfo()` before calling the tracing helper.
- LayoutManager gates phase-text recording and debugger output together on low-level tracing. This currently also suppresses exception diagnostic text when tracing is disabled and needs correction.

## Customer Impact

The intended benefits are less repeated work during rapid drag-region changes, recycling of temporary NavigationView containers, and reduced tracing work. No performance measurements or Windows runtime validation have been collected for this PR. Drag-region refresh becomes asynchronous, which can affect hit testing between the property change and callback execution.

## Regression Potential

- [ ] Low risk — isolated change, limited scope
- [x] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

Open review findings requiring investigation and regression coverage:

- A queued callback on an unloaded/replaced TitleBar may clear the replacement's clickable regions.
- Recycling a NavigationView template-selector wrapper may reach a null dereference in the template recycler.
- Gating layout-phase recording on debugger tracing loses phase information from layout-cycle exceptions.

## How Has This Been Tested?

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

The submitted diff was inspected to prepare this description, and `git diff HEAD^ HEAD --check` passed. These are not substitutes for build or runtime validation. No regression tests were added. The current host is macOS; the documented build requires Windows and Visual Studio/MSBuild. A Windows build and relevant tests are still required, as are resolution of the review findings, the CLA check, and team approvals. At the time of this update, the only reported check was the pending CLA check.

## Screenshots (if appropriate)

Not applicable: this draft does not intentionally change visual styling.
