### PR TITLE
Fix flickering of the selected SelectorBarItem (#9672)

### DIFF
--- a/controls/dev/SelectorBar/APITests/SelectorBarTests.cs
+++ b/controls/dev/SelectorBar/APITests/SelectorBarTests.cs
@@ -186,10 +186,16 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 Verify.IsNotNull(selectedItem.Background, "SelectorBarItem.Background must not be null, or the item's padding stops hit-testing.");
 
-                // A point in the item's left padding (SelectorBarItemPadding is 12,10,12,7), so it is
-                // never covered by the icon or text and only hit-tests through the container background.
+                // A point inside the item's left padding, so it is never covered by the icon or text
+                // and only hit-tests through the container background. Derived from Padding rather
+                // than hard-coded so re-theming SelectorBarItemPadding cannot invalidate the test.
+                double paddingLeft = selectedItem.Padding.Left;
+                Verify.IsTrue(paddingLeft > 0.0, "Test requires a non-zero left padding to probe, actual: " + paddingLeft);
+
                 Point paddingPoint = selectedItem.TransformToVisual(null).TransformPoint(
-                    new Point(4.0, selectedItem.ActualHeight / 2.0));
+                    new Point(paddingLeft / 2.0, selectedItem.ActualHeight / 2.0));
+
+                Log.Comment("Probing padding point " + paddingPoint.X + "," + paddingPoint.Y);
 
                 foreach (string stateName in new[]
                     {

--- a/controls/dev/SelectorBar/APITests/SelectorBarTests.cs
+++ b/controls/dev/SelectorBar/APITests/SelectorBarTests.cs
@@ -9,6 +9,7 @@ using Microsoft.UI.Private.Controls;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using MUXControlsTestApp.Utilities;
+using Windows.Foundation;
 
 using WEX.TestExecution;
 using WEX.TestExecution.Markup;
@@ -150,6 +151,75 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
                 IdleSynchronizer.Wait();
                 Log.Comment("Done");
             }
+        }
+
+        // Regression test for https://github.com/microsoft/microsoft-ui-xaml/issues/9672.
+        // The item's padding must stay hit-testable in every CombinedStates state. When it is
+        // hit-testable in SelectedNormal but not in SelectedPointerOver, a pointer resting in the
+        // padding enters the item, loses the background that let it hit-test, exits, and repeats -
+        // which shows up as the selected item's text flickering.
+        [TestMethod]
+        public void VerifySelectorBarItemIsHitTestableInAllCombinedStates()
+        {
+            SelectorBar selectorBar = null;
+            SelectorBarItem selectedItem = null;
+            AutoResetEvent selectorBarLoadedEvent = new AutoResetEvent(false);
+
+            RunOnUIThread.Execute(() =>
+            {
+                selectorBar = new SelectorBar();
+
+                selectorBar.Items.Add(new SelectorBarItem() { Text = "Recent" });
+
+                selectedItem = new SelectorBarItem() { Text = "Shared", IsSelected = true };
+                selectorBar.Items.Add(selectedItem);
+
+                selectorBar.Items.Add(new SelectorBarItem() { Text = "Favorites" });
+
+                SetupDefaultUI(selectorBar, selectorBarLoadedEvent);
+            });
+
+            WaitForEvent("Waiting for Loaded event", selectorBarLoadedEvent);
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.IsNotNull(selectedItem.Background, "SelectorBarItem.Background must not be null, or the item's padding stops hit-testing.");
+
+                // A point in the item's left padding (SelectorBarItemPadding is 12,10,12,7), so it is
+                // never covered by the icon or text and only hit-tests through the container background.
+                Point paddingPoint = selectedItem.TransformToVisual(null).TransformPoint(
+                    new Point(4.0, selectedItem.ActualHeight / 2.0));
+
+                foreach (string stateName in new[]
+                    {
+                        "UnselectedNormal", "UnselectedPointerOver", "UnselectedPressed",
+                        "SelectedNormal", "SelectedPointerOver", "SelectedPressed"
+                    })
+                {
+                    Verify.IsTrue(VisualStateManager.GoToState(selectedItem, stateName, false), "Going to state " + stateName);
+
+                    var elements = Microsoft.UI.Xaml.Media.VisualTreeHelper.FindElementsInHostCoordinates(paddingPoint, selectedItem);
+                    bool isHitTestable = false;
+
+                    foreach (var element in elements)
+                    {
+                        isHitTestable = true;
+                        break;
+                    }
+
+                    Log.Comment(" - " + stateName + ": isHitTestable=" + isHitTestable);
+                    Verify.IsTrue(isHitTestable, "SelectorBarItem padding must be hit-testable in state " + stateName);
+                }
+
+                Log.Comment("Resetting window content and SelectorBar");
+                Content = null;
+                selectorBar = null;
+                selectedItem = null;
+            });
+
+            IdleSynchronizer.Wait();
+            Log.Comment("Done");
         }
 
         private void SetupDefaultUI(

--- a/controls/dev/SelectorBar/SelectorBar.xaml
+++ b/controls/dev/SelectorBar/SelectorBar.xaml
@@ -45,6 +45,7 @@
     <Style TargetType="controls:SelectorBarItem" BasedOn="{StaticResource DefaultSelectorBarItemStyle}"/>
 
     <Style x:Key="DefaultSelectorBarItemStyle" TargetType="controls:SelectorBarItem">
+        <Setter Property="Background" Value="{ThemeResource SelectorBarItemBackground}"/>
         <Setter Property="BackgroundSizing" Value="OuterBorderEdge"/>
         <Setter Property="Foreground" Value="{ThemeResource SelectorBarItemForeground}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource SelectorBarItemBorderBrush}"/>

--- a/controls/dev/SelectorBar/SelectorBar.xaml
+++ b/controls/dev/SelectorBar/SelectorBar.xaml
@@ -116,6 +116,9 @@
                                 </VisualState>
                                 <VisualState x:Name="SelectedPointerOver">
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ContainerRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SelectorBarItemBackgroundSelected}"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TextVisual" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SelectorBarItemForegroundPointerOver}"/>
                                         </ObjectAnimationUsingKeyFrames>
@@ -133,6 +136,9 @@
                                 </VisualState>
                                 <VisualState x:Name="SelectedPressed">
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_ContainerRoot" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SelectorBarItemBackgroundSelected}"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_TextVisual" Storyboard.TargetProperty="Foreground">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SelectorBarItemForegroundPointerOver}"/>
                                         </ObjectAnimationUsingKeyFrames>

--- a/controls/dev/SelectorBar/SelectorBar_perf2026.xaml
+++ b/controls/dev/SelectorBar/SelectorBar_perf2026.xaml
@@ -45,6 +45,7 @@
     <Style TargetType="controls:SelectorBarItem" BasedOn="{StaticResource DefaultSelectorBarItemStyle}"/>
 
     <Style x:Key="DefaultSelectorBarItemStyle" TargetType="controls:SelectorBarItem">
+        <Setter Property="Background" Value="{ThemeResource SelectorBarItemBackground}"/>
         <Setter Property="BackgroundSizing" Value="OuterBorderEdge"/>
         <Setter Property="Foreground" Value="{ThemeResource SelectorBarItemForeground}"/>
         <Setter Property="BorderBrush" Value="{ThemeResource SelectorBarItemBorderBrush}"/>

--- a/controls/dev/SelectorBar/SelectorBar_perf2026.xaml
+++ b/controls/dev/SelectorBar/SelectorBar_perf2026.xaml
@@ -102,6 +102,7 @@
                                 </VisualState>
                                 <VisualState x:Name="SelectedPointerOver">
                                     <VisualState.Setters>
+                                        <Setter Target="PART_ContainerRoot.Background" Value="{ThemeResource SelectorBarItemBackgroundSelected}" />
                                         <Setter Target="PART_TextVisual.Foreground" Value="{ThemeResource SelectorBarItemForegroundPointerOver}" />
                                         <Setter Target="PART_IconVisual.Foreground" Value="{ThemeResource SelectorBarItemForegroundPointerOver}" />
                                     </VisualState.Setters>
@@ -117,6 +118,7 @@
                                 </VisualState>
                                 <VisualState x:Name="SelectedPressed">
                                     <VisualState.Setters>
+                                        <Setter Target="PART_ContainerRoot.Background" Value="{ThemeResource SelectorBarItemBackgroundSelected}" />
                                         <Setter Target="PART_TextVisual.Foreground" Value="{ThemeResource SelectorBarItemForegroundPointerOver}" />
                                         <Setter Target="PART_IconVisual.Foreground" Value="{ThemeResource SelectorBarItemForegroundPointerOver}" />
                                     </VisualState.Setters>


### PR DESCRIPTION
## Fixes

Fixes #9672

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

`DefaultSelectorBarItemStyle` never set `Background`, so `PART_ContainerRoot`'s background — which is `{TemplateBinding Background}` — stayed `null` in every visual state that does not animate it: `UnselectedNormal`, `SelectedPointerOver` and `SelectedPressed`. A `null` background is not hit-testable, so the item's padding was a pointer target in some states and not in others.

On the selected item that forms a loop:

1. the pointer enters over the padding, which is hit-testable in `SelectedNormal`
2. the state moves to `SelectedPointerOver`, which sets no background, so the padding stops hit-testing
3. the pointer exits, the state returns to `SelectedNormal`, the background comes back
4. the pointer enters again

The fix sets `Background` from `SelectorBarItemBackground` in the default style, in both `SelectorBar.xaml` and `SelectorBar_perf2026.xaml`. This is what the base `ItemContainer` style already does; `DefaultSelectorBarItemStyle` is not `BasedOn` it, so it did not inherit the setter.

### Current Behavior

Resting the pointer in the selected item's padding — the empty space around the label, including the area near the selection pill — makes its text flicker between `SelectorBarItemForegroundSelected` and `SelectorBarItemForegroundPointerOver`, several times per second, without moving the mouse.

Hit-testing a point in the padding, per state, before the change:

| State | Padding hit-testable |
|---|---|
| `UnselectedNormal` | ❌ |
| `UnselectedPointerOver` | ✅ |
| `UnselectedPressed` | ✅ |
| `SelectedNormal` | ✅ |
| `SelectedPointerOver` | ❌ |
| `SelectedPressed` | ❌ |

### New Behavior

The padding is hit-testable in all six states, the pointer enters once and stays, and the text no longer flickers.

As a side effect this also addresses the touch-target point raised in the issue discussion: `UnselectedNormal` goes from ❌ to ✅, so the whole item is a pointer and touch target rather than just its icon and text.

## Customer Impact

User-facing. Removes the flicker reported in #9672, and makes the whole `SelectorBarItem` — not just its icon and text — respond to pointer and touch.

`SelectorBarItemBackground` resolves to `SystemControlTransparentBrush` in all three theme dictionaries, so there is no visual change to the control's appearance.

## Regression Potential

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

Two one-line style setters. The brush is transparent in every theme dictionary, so rendering is unchanged; only hit-testing behaviour changes, and only from "sometimes off" to "consistently on".

One related issue was deliberately left alone to keep this change minimal: `SelectedPointerOver` and `SelectedPressed` still set no `Background` at all, so they now fall back to `SelectorBarItemBackground` rather than keeping `SelectorBarItemBackgroundSelected`. That is invisible today because every one of those brushes is transparent, but it would show if `SelectorBarItemBackgroundSelected` were themed to a real colour. Happy to fold a fix in here if preferred.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [ ] Existing tests pass locally (TBD)

Added `VerifySelectorBarItemIsHitTestableInAllCombinedStates` to the SelectorBar API tests. It walks the `CombinedStates` group with `VisualStateManager.GoToState` and asserts that a point in the selected item's padding is returned by `VisualTreeHelper.FindElementsInHostCoordinates` in every state.

The behaviour itself was verified against shipped WinUI (Windows App SDK 2.4.0) with a standalone app containing two `SelectorBar`s, one with the default style and one with the style setter this PR adds. Counting `CombinedStates` transitions with the cursor injected into the padding and then held completely still for 1.5s:

| | State transitions | PointerEntered / PointerExited |
|---|---|---|
| Default style | 15 — `SelectedPointerOver → SelectedNormal → SelectedPointerOver → …` | 8 / 7 |
| With `Background` setter | 1 | 1 / 0 |

## Screenshots (if appropriate)

No visual change, the brush is transparent in every theme. The animated repro of the flicker in #9672 still applies as the "before".
