### PR TITLE
Make MuxControlsTestApp debug logging controls order-independent

### DIFF
--- a/controls/dev/ItemsView/TestUI/ItemsViewPage.xaml
+++ b/controls/dev/ItemsView/TestUI/ItemsViewPage.xaml
@@ -25,13 +25,13 @@
                 <ComboBoxItem>Verbose</ComboBoxItem>
             </ComboBox>
             <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.ColumnSpan="2">
-                <CheckBox x:Name="chkItemsView" Content="ItemsView" IsChecked="True" Margin="2"/>
-                <CheckBox x:Name="chkItemsRepeater" Content="ItemsRepeater" Margin="2"/>
-                <CheckBox x:Name="chkItemContainer" Content="ItemContainer" Margin="2"/>
-                <CheckBox x:Name="chkLinedFlowLayout" Content="LinedFlowLayout" Margin="2"/>
-                <CheckBox x:Name="chkScrollView" Content="ScrollView" Margin="2"/>
-                <CheckBox x:Name="chkScrollPresenter" Content="ScrollPresenter" Margin="2"/>
-                <CheckBox x:Name="chkAnnotatedScrollBar" Content="AnnotatedScrollBar" Margin="2"/>
+                <CheckBox x:Name="chkItemsView" Content="ItemsView" IsChecked="True" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkItemsRepeater" Content="ItemsRepeater" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkItemContainer" Content="ItemContainer" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkLinedFlowLayout" Content="LinedFlowLayout" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkScrollView" Content="ScrollView" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkScrollPresenter" Content="ScrollPresenter" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkAnnotatedScrollBar" Content="AnnotatedScrollBar" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
             </StackPanel>
         </Grid>
         <Button x:Name="navigateToSummary" AutomationProperties.Name="navigateToSummary" Margin="2" HorizontalAlignment="Stretch">ItemsView in summary page</Button>

--- a/controls/dev/ItemsView/TestUI/ItemsViewPage.xaml.cs
+++ b/controls/dev/ItemsView/TestUI/ItemsViewPage.xaml.cs
@@ -26,65 +26,47 @@ namespace MUXControlsTestApp
             navigateToBlank.Click += delegate { Frame.NavigateWithoutAnimation(typeof(ItemsViewBlankPage), 0); };
             navigateToTransitionProvider.Click += delegate { Frame.NavigateWithoutAnimation(typeof(ItemsViewTransitionPage), 0); };
             navigateToPictureLibrary.Click += delegate { Frame.NavigateWithoutAnimation(typeof(ItemsViewPictureLibraryPage), 0); };
+
+            ApplyDebugLoggingOptions();
         }
 
         private void CmbItemsViewOutputDebugStringLevel_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (chkItemsView != null && chkItemsView.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ItemsView",
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 1 || cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2);
-            }
+            ApplyDebugLoggingOptions();
+        }
 
-            if (chkScrollView != null && chkScrollView.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ScrollView",
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 1 || cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2);
-            }
+        private void ChkOutputDebugStringLevel_CheckedChanged(object sender, RoutedEventArgs e)
+        {
+            ApplyDebugLoggingOptions();
+        }
 
-            if (chkScrollPresenter != null && chkScrollPresenter.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ScrollPresenter",
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 1 || cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2);
-            }
+        // Applies the OutputDebugString logging level selected in the ComboBox to every checked type, and
+        // turns logging off for unchecked types. Reading the current ComboBox selection together with all
+        // CheckBox states makes the configuration order-independent: the user can toggle the checkboxes and
+        // pick the ComboBox value in any order and still get the requested logging.
+        private void ApplyDebugLoggingOptions()
+        {
+            int selectedLevel = cmbItemsViewOutputDebugStringLevel?.SelectedIndex ?? 0;
+            bool isLoggingInfoLevel = selectedLevel == 1 || selectedLevel == 2;
+            bool isLoggingVerboseLevel = selectedLevel == 2;
 
-            if (chkItemContainer != null && chkItemContainer.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ItemContainer",
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 1 || cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2);
-            }
+            SetOutputDebugStringLevelForType("ItemsView", chkItemsView, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("ScrollView", chkScrollView, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("ScrollPresenter", chkScrollPresenter, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("ItemContainer", chkItemContainer, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("ItemsRepeater", chkItemsRepeater, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("LinedFlowLayout", chkLinedFlowLayout, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("AnnotatedScrollBar", chkAnnotatedScrollBar, isLoggingInfoLevel, isLoggingVerboseLevel);
+        }
 
-            if (chkItemsRepeater != null && chkItemsRepeater.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ItemsRepeater",
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 1 || cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2);
-            }
+        private static void SetOutputDebugStringLevelForType(string type, CheckBox checkBox, bool isLoggingInfoLevel, bool isLoggingVerboseLevel)
+        {
+            bool isChecked = checkBox != null && checkBox.IsChecked == true;
 
-            if (chkLinedFlowLayout != null && chkLinedFlowLayout.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "LinedFlowLayout",
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 1 || cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2);
-            }
-
-            if (chkAnnotatedScrollBar != null && chkAnnotatedScrollBar.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "AnnotatedScrollBar",
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 1 || cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbItemsViewOutputDebugStringLevel.SelectedIndex == 2);
-            }
+            MUXControlsTestHooks.SetOutputDebugStringLevelForType(
+                type,
+                isChecked && isLoggingInfoLevel,
+                isChecked && isLoggingVerboseLevel);
         }
     }
 }

--- a/controls/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
+++ b/controls/dev/Repeater/TestUI/RepeaterTestUIPage.xaml
@@ -100,8 +100,8 @@
                     </ComboBox>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox x:Name="chkLinedFlowLayout" Content="LinedFlowLayout" IsChecked="True" Margin="2"/>
-                    <CheckBox x:Name="chkScrollView" Content="ScrollView" Margin="2"/>
+                    <CheckBox x:Name="chkLinedFlowLayout" Content="LinedFlowLayout" IsChecked="True" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                    <CheckBox x:Name="chkScrollView" Content="ScrollView" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
                 </StackPanel>
                 <Button x:Name="linedFlowLayoutDemo" AutomationProperties.Name="LinedFlowLayoutDemo">LinedFlowLayout testing</Button>
             </StackPanel>

--- a/controls/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
+++ b/controls/dev/Repeater/TestUI/RepeaterTestUIPage.xaml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.UI.Private.Controls;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using MUXControlsTestApp.Samples;
 
@@ -248,25 +249,42 @@ namespace MUXControlsTestApp
                         Orientation = orientation.IsOn ? Orientation.Horizontal : Orientation.Vertical,
                     });
             };
+
+            ApplyDebugLoggingOptions();
         }
 
         private void CmbOutputDebugStringLevels_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (chkScrollView != null && chkScrollView.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ScrollView",
-                    cmbOutputDebugStringLevels.SelectedIndex == 1 || cmbOutputDebugStringLevels.SelectedIndex == 2,
-                    cmbOutputDebugStringLevels.SelectedIndex == 2);
-            }
+            ApplyDebugLoggingOptions();
+        }
 
-            if (chkLinedFlowLayout != null && chkLinedFlowLayout.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "LinedFlowLayout",
-                    cmbOutputDebugStringLevels.SelectedIndex == 1 || cmbOutputDebugStringLevels.SelectedIndex == 2,
-                    cmbOutputDebugStringLevels.SelectedIndex == 2);
-            }
+        private void ChkOutputDebugStringLevel_CheckedChanged(object sender, RoutedEventArgs e)
+        {
+            ApplyDebugLoggingOptions();
+        }
+
+        // Applies the OutputDebugString logging level selected in the ComboBox to every checked type, and
+        // turns logging off for unchecked types. Reading the current ComboBox selection together with all
+        // CheckBox states makes the configuration order-independent: the user can toggle the checkboxes and
+        // pick the ComboBox value in any order and still get the requested logging.
+        private void ApplyDebugLoggingOptions()
+        {
+            int selectedLevel = cmbOutputDebugStringLevels?.SelectedIndex ?? 0;
+            bool isLoggingInfoLevel = selectedLevel == 1 || selectedLevel == 2;
+            bool isLoggingVerboseLevel = selectedLevel == 2;
+
+            SetOutputDebugStringLevelForType("ScrollView", chkScrollView, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("LinedFlowLayout", chkLinedFlowLayout, isLoggingInfoLevel, isLoggingVerboseLevel);
+        }
+
+        private static void SetOutputDebugStringLevelForType(string type, CheckBox checkBox, bool isLoggingInfoLevel, bool isLoggingVerboseLevel)
+        {
+            bool isChecked = checkBox != null && checkBox.IsChecked == true;
+
+            MUXControlsTestHooks.SetOutputDebugStringLevelForType(
+                type,
+                isChecked && isLoggingInfoLevel,
+                isChecked && isLoggingVerboseLevel);
         }
 
         private VirtualizingLayout GetStackLayout()

--- a/controls/dev/SelectorBar/TestUI/SelectorBarPage.xaml
+++ b/controls/dev/SelectorBar/TestUI/SelectorBarPage.xaml
@@ -17,10 +17,10 @@
                 <ComboBoxItem>Verbose</ComboBoxItem>
             </ComboBox>
             <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.ColumnSpan="2">
-                <CheckBox x:Name="chkSelectorBar" Content="SelectorBar" IsChecked="True" Margin="2"/>
-                <CheckBox x:Name="chkItemsView" Content="ItemsView" IsChecked="True" Margin="2"/>
-                <CheckBox x:Name="chkItemsRepeater" Content="ItemsRepeater" IsChecked="True" Margin="2"/>
-                <CheckBox x:Name="chkItemContainer" Content="ItemContainer" Margin="2"/>
+                <CheckBox x:Name="chkSelectorBar" Content="SelectorBar" IsChecked="True" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkItemsView" Content="ItemsView" IsChecked="True" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkItemsRepeater" Content="ItemsRepeater" IsChecked="True" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
+                <CheckBox x:Name="chkItemContainer" Content="ItemContainer" Margin="2" Checked="ChkOutputDebugStringLevel_CheckedChanged" Unchecked="ChkOutputDebugStringLevel_CheckedChanged"/>
             </StackPanel>
         </Grid>
         <Button x:Name="navigateToSummary" AutomationProperties.Name="navigateToSummary" Margin="2" HorizontalAlignment="Stretch">SelectorBar in summary page</Button>

--- a/controls/dev/SelectorBar/TestUI/SelectorBarPage.xaml.cs
+++ b/controls/dev/SelectorBar/TestUI/SelectorBarPage.xaml.cs
@@ -22,41 +22,44 @@ namespace MUXControlsTestApp
 
             navigateToSummary.Click += delegate { Frame.NavigateWithoutAnimation(typeof(SelectorBarSummaryPage), 0); };
             navigateToSample.Click += delegate { Frame.NavigateWithoutAnimation(typeof(SelectorBarSamplePage), 0); };
+
+            ApplyDebugLoggingOptions();
         }
 
         private void CmbSelectorBarOutputDebugStringLevel_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (chkSelectorBar != null && chkSelectorBar.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "SelectorBar",
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 1 || cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2);
-            }
+            ApplyDebugLoggingOptions();
+        }
 
-            if (chkItemsView != null && chkItemsView.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ItemsView",
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 1 || cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2);
-            }
+        private void ChkOutputDebugStringLevel_CheckedChanged(object sender, RoutedEventArgs e)
+        {
+            ApplyDebugLoggingOptions();
+        }
 
-            if (chkItemContainer != null && chkItemContainer.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ItemContainer",
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 1 || cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2);
-            }
+        // Applies the OutputDebugString logging level selected in the ComboBox to every checked type, and
+        // turns logging off for unchecked types. Reading the current ComboBox selection together with all
+        // CheckBox states makes the configuration order-independent: the user can toggle the checkboxes and
+        // pick the ComboBox value in any order and still get the requested logging.
+        private void ApplyDebugLoggingOptions()
+        {
+            int selectedLevel = cmbSelectorBarOutputDebugStringLevel?.SelectedIndex ?? 0;
+            bool isLoggingInfoLevel = selectedLevel == 1 || selectedLevel == 2;
+            bool isLoggingVerboseLevel = selectedLevel == 2;
 
-            if (chkItemsRepeater != null && chkItemsRepeater.IsChecked == true)
-            {
-                MUXControlsTestHooks.SetOutputDebugStringLevelForType(
-                    "ItemsRepeater",
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 1 || cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2,
-                    cmbSelectorBarOutputDebugStringLevel.SelectedIndex == 2);
-            }
+            SetOutputDebugStringLevelForType("SelectorBar", chkSelectorBar, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("ItemsView", chkItemsView, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("ItemContainer", chkItemContainer, isLoggingInfoLevel, isLoggingVerboseLevel);
+            SetOutputDebugStringLevelForType("ItemsRepeater", chkItemsRepeater, isLoggingInfoLevel, isLoggingVerboseLevel);
+        }
+
+        private static void SetOutputDebugStringLevelForType(string type, CheckBox checkBox, bool isLoggingInfoLevel, bool isLoggingVerboseLevel)
+        {
+            bool isChecked = checkBox != null && checkBox.IsChecked == true;
+
+            MUXControlsTestHooks.SetOutputDebugStringLevelForType(
+                type,
+                isChecked && isLoggingInfoLevel,
+                isChecked && isLoggingVerboseLevel);
         }
     }
 }


### PR DESCRIPTION

## Issue
On the ItemsView, ItemsRepeater (RepeaterTestUIPage) and SelectorBar test pages, the OutputDebugString logging level was only applied from the ComboBox SelectionChanged handler, which read the CheckBox states at that moment. Picking the level before ticking a type checkbox therefore silently did nothing, so the controls only worked in one order (checkbox first, then level).

## Fix 
Both the ComboBox SelectionChanged and the new CheckBox Checked/Unchecked handlers now route through a single ApplyDebugLoggingOptions() helper that reads the current level together with every checkbox state, making the configuration order-independent. Unchecking a type now also turns its logging off.

ApplyDebugLoggingOptions() is additionally called at the end of each page constructor so the initial state is explicit, and it reads the ComboBox level defensively (?.SelectedIndex ?? 0) so reordering the markup cannot cause a load-time NullReferenceException.

