### PR TITLE
PipsPager: don't force a layout pass when NumberOfPages changes

### DIFF
--- a/controls/dev/PipsPager/APITests/PipsPagerTests.cs
+++ b/controls/dev/PipsPager/APITests/PipsPagerTests.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Common;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading;
 using Microsoft.UI.Xaml.Controls;
 using MUXControlsTestApp.Utilities;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Automation.Provider;
 using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Automation;
@@ -122,6 +126,156 @@ namespace Microsoft.UI.Xaml.Tests.MUXControls.ApiTests
             {
                 Verify.AreEqual(expectedNewIndex, newIndex, "Expected PreviousPageIndex:" + expectedNewIndex + ", actual: " + newIndex);
             }
+        }
+
+        // Regression test for microsoft/microsoft-ui-xaml#8299. Pushing a new NumberOfPages onto a
+        // PipsPager hosted in an auto sized Grid row used to fail with an HRESULT thrown out of the
+        // property setter, because OnNumberOfPagesChanged forced a whole tree layout pass from inside
+        // the DependencyProperty changed callback. The reporter saw it go away with a fixed row height.
+        [TestMethod]
+        public void VerifyChangingNumberOfPagesInAutoSizedRowDoesNotCrash()
+        {
+            Grid root = null;
+            PipsPager pager = null;
+            var items = new ObservableCollection<string>();
+            var pagerLoadedEvent = new ManualResetEvent(false);
+            Exception thrownException = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                // x:Bind is compiled binding only and unsupported by XamlReader.Load, so the issue's
+                // {x:Bind Items.Count, Mode=OneWay} is expressed here as a classic {Binding Count}.
+                root = (Grid)XamlReader.Load(
+                    @"<Grid xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                           xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                           xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height='*' />
+                            <RowDefinition Height='Auto' />
+                        </Grid.RowDefinitions>
+                        <FlipView Grid.Row='0' ItemsSource='{Binding}' />
+                        <StackPanel Grid.Row='1'>
+                            <controls:PipsPager x:Name='TestPipsPager'
+                                                NumberOfPages='{Binding Count, Mode=OneWay}'
+                                                HorizontalAlignment='Center' />
+                        </StackPanel>
+                      </Grid>");
+
+                pager = (PipsPager)root.FindName("TestPipsPager");
+                pager.Loaded += (sender, args) => pagerLoadedEvent.Set();
+
+                root.DataContext = items;
+                Content = root;
+                Content.UpdateLayout();
+            });
+
+            // The template has to be applied before mutating: PipsPager::OnPropertyChanged is gated
+            // on Template() != nullptr, so an earlier change would not run the code under test.
+            Verify.IsTrue(pagerLoadedEvent.WaitOne(DefaultWaitTimeInMS), "Waiting for loaded event");
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                try
+                {
+                    items.Add("Hello");
+                    root.UpdateLayout();
+                }
+                catch (Exception e)
+                {
+                    // Captured rather than allowed to escape: the test app installs no
+                    // Application.UnhandledException handler, so an escaping exception on the
+                    // dispatcher thread takes the app down instead of failing this test.
+                    thrownException = e;
+                }
+            });
+
+            IdleSynchronizer.Wait();
+
+            if (thrownException != null)
+            {
+                Verify.Fail("Changing NumberOfPages in an auto sized row threw: " + thrownException.ToString());
+            }
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual(1, pager.NumberOfPages);
+                Verify.AreEqual(0, pager.SelectedPageIndex);
+            });
+        }
+
+        // Companion to the test above: drives NumberOfPages past MaxVisiblePips (5 by default) with no
+        // layout pass in between, so every step selects a pip that the virtualizing layout has not
+        // realized yet - the path that used to depend on the forced synchronous layout. The assertions
+        // at the end guard against a "fix" that simply stops updating the selected pip.
+        [TestMethod]
+        public void VerifyRepeatedNumberOfPagesChangesInAutoSizedRowDoNotCrash()
+        {
+            Grid root = null;
+            PipsPager pager = null;
+            var pagerLoadedEvent = new ManualResetEvent(false);
+            Exception thrownException = null;
+
+            RunOnUIThread.Execute(() =>
+            {
+                root = (Grid)XamlReader.Load(
+                    @"<Grid xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'
+                           xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                           xmlns:controls='using:Microsoft.UI.Xaml.Controls'>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height='*' />
+                            <RowDefinition Height='Auto' />
+                        </Grid.RowDefinitions>
+                        <StackPanel Grid.Row='1'>
+                            <controls:PipsPager x:Name='TestPipsPager' HorizontalAlignment='Center' />
+                        </StackPanel>
+                      </Grid>");
+
+                pager = (PipsPager)root.FindName("TestPipsPager");
+                pager.Loaded += (sender, args) => pagerLoadedEvent.Set();
+
+                Content = root;
+                Content.UpdateLayout();
+            });
+
+            Verify.IsTrue(pagerLoadedEvent.WaitOne(DefaultWaitTimeInMS), "Waiting for loaded event");
+            IdleSynchronizer.Wait();
+
+            RunOnUIThread.Execute(() =>
+            {
+                try
+                {
+                    for (int pageCount = 1; pageCount <= 10; pageCount++)
+                    {
+                        pager.NumberOfPages = pageCount;
+                        pager.SelectedPageIndex = pageCount - 1;
+                    }
+                }
+                catch (Exception e)
+                {
+                    thrownException = e;
+                }
+            });
+
+            IdleSynchronizer.Wait();
+
+            if (thrownException != null)
+            {
+                Verify.Fail("Repeated NumberOfPages changes in an auto sized row threw: " + thrownException.ToString());
+            }
+
+            RunOnUIThread.Execute(() =>
+            {
+                Verify.AreEqual(10, pager.NumberOfPages);
+                Verify.AreEqual(9, pager.SelectedPageIndex);
+
+                var repeater = pager.FindVisualChildByType<ItemsRepeater>();
+                Verify.IsNotNull(repeater, "PipsPagerItemsRepeater should be in the template.");
+
+                var selectedPip = repeater.TryGetElement(pager.SelectedPageIndex) as FrameworkElement;
+                Verify.IsNotNull(selectedPip, "The selected pip should be realized once layout has settled.");
+                Verify.AreEqual(pager.SelectedPipStyle, selectedPip.Style, "The selected pip should carry SelectedPipStyle.");
+            });
         }
     }
 }

--- a/controls/dev/PipsPager/PipsPager.cpp
+++ b/controls/dev/PipsPager/PipsPager.cpp
@@ -72,6 +72,10 @@ void PipsPager::OnApplyTemplate()
 {
     winrt::AutomationProperties::SetName(*this, ResourceAccessor::GetLocalizedStringResource(SR_PipsPagerNameText));
 
+    // A scroll pending against the template we are replacing refers to elements that are about to go away.
+    m_layoutUpdatedRevoker.revoke();
+    m_pendingScrollToPipIndex = -1;
+
     m_previousPageButtonClickRevoker.revoke();
     [this](const winrt::Button button)
     {
@@ -252,20 +256,93 @@ void PipsPager::ScrollToCenterOfViewport(const winrt::UIElement sender, const in
     sender.StartBringIntoView(options);
 }
 
+// A pip that has just been realized has been measured but not arranged, so its render size is still
+// empty and bringing it into view now would centre a degenerate rect. Wait for the layout pass that
+// GetOrCreateElement has already scheduled (it invalidates the repeater's measure) instead of pumping
+// one synchronously.
+void PipsPager::RequestScrollToSelectedPip(const int index)
+{
+    m_pendingScrollToPipIndex = index;
+
+    // The handler is one shot, so always revoke before hooking: re-adding a live handler is a no-op,
+    // and the framework only starts raising LayoutUpdated on the transition from no handler to one.
+    m_layoutUpdatedRevoker.revoke();
+    m_layoutUpdatedRevoker = this->LayoutUpdated(winrt::auto_revoke, { this, &PipsPager::OnLayoutUpdatedAfterPipRealized });
+}
+
+void PipsPager::OnLayoutUpdatedAfterPipRealized(const winrt::IInspectable& /*sender*/, const winrt::IInspectable& /*args*/)
+{
+    // We only need this once, and the scroll below dirties layout again, so revoke first.
+    m_layoutUpdatedRevoker.revoke();
+
+    const auto index = m_pendingScrollToPipIndex;
+    m_pendingScrollToPipIndex = -1;
+
+    // The selection may have moved on, or the pip may have been recycled, while we were waiting.
+    if (index == SelectedPageIndex())
+    {
+        if (const auto repeater = m_pipsPagerRepeater.get())
+        {
+            if (const auto pip = repeater.TryGetElement(index))
+            {
+                ScrollToCenterOfViewport(pip, index);
+            }
+        }
+    }
+}
+
+// GetOrCreateElement validates the index against the repeater's items source, which can hold fewer
+// items than NumberOfPages - the pips collection and the page count are updated in separate steps,
+// and a re-templated pager need not use TemplateSettings.PipsPagerItems - and throws for anything
+// outside it. Only ask for a pip the repeater can actually produce.
+winrt::UIElement PipsPager::GetOrCreatePip(const int index)
+{
+    if (const auto repeater = m_pipsPagerRepeater.get())
+    {
+        if (const auto itemsSourceView = repeater.ItemsSourceView())
+        {
+            if (index >= 0 && index < itemsSourceView.Count())
+            {
+                return repeater.GetOrCreateElement(index);
+            }
+        }
+    }
+    return nullptr;
+}
+
 void PipsPager::UpdateSelectedPip(const int index) {
     if (NumberOfPages() != 0 && MaxVisiblePips() > 0)
     {
         if (const auto repeater = m_pipsPagerRepeater.get())
         {
-            repeater.UpdateLayout();
             if (const auto pip = repeater.TryGetElement(m_lastSelectedPageIndex).try_as<winrt::FrameworkElement>())
             {
                 ApplyStyleToPipAndUpdateOrientation(pip, NormalPipStyle());
             }
-            if (const auto pip = repeater.GetOrCreateElement(index).try_as<winrt::FrameworkElement>())
+
+            // This used to start with repeater.UpdateLayout(). UIElement.UpdateLayout() is not scoped
+            // to the repeater: it runs the whole XamlRoot's layout manager to completion. Calling it
+            // from a property changed handler - right after UpdatePipsItems has changed the repeater's
+            // items and SetScrollViewerMaxSize has changed the ScrollViewer's size - surfaced layout
+            // failures from anywhere in the tree as an HRESULT thrown out of the property setter.
+            // See microsoft/microsoft-ui-xaml#8299.
+            // Whether the pip already existed decides only whether we can scroll to it now: a pip
+            // realized by the call below has been measured but not arranged, so its render size is
+            // still empty. GetOrCreatePip is called either way, so the repeater still sees the same
+            // anchor request it saw before this change.
+            const bool wasPipRealized = repeater.TryGetElement(index) != nullptr;
+
+            if (const auto pip = GetOrCreatePip(index).try_as<winrt::FrameworkElement>())
             {
                 ApplyStyleToPipAndUpdateOrientation(pip, SelectedPipStyle());
-                ScrollToCenterOfViewport(pip, index);
+                if (wasPipRealized)
+                {
+                    ScrollToCenterOfViewport(pip, index);
+                }
+                else
+                {
+                    RequestScrollToSelectedPip(index);
+                }
             }
         }
     }
@@ -598,7 +675,7 @@ void PipsPager::OnPipsAreaGettingFocus(const IInspectable& sender, const winrt::
         {
             if (repeater.GetElementIndex(oldFocusedElement) == -1)
             {
-                if (const auto realizedElement = repeater.GetOrCreateElement(SelectedPageIndex()).try_as<winrt::UIElement>())
+                if (const auto realizedElement = GetOrCreatePip(SelectedPageIndex()))
                 {
                     if (args.TrySetNewFocusedElement(realizedElement))
                     {

--- a/controls/dev/PipsPager/PipsPager.h
+++ b/controls/dev/PipsPager/PipsPager.h
@@ -67,7 +67,9 @@ private:
         const wstring_view& disabledStateName);
     winrt::Size GetDesiredPipSize(const winrt::Style& style);
     void ScrollToCenterOfViewport(const winrt::UIElement sender, const int index);
+    void RequestScrollToSelectedPip(const int index);
     double CalculateScrollViewerSize(const double defaultPipSize, const double selectedPipSize, const int numberOfPages, int maxVisualIndicators);
+    winrt::UIElement GetOrCreatePip(const int index);
     void UpdateSelectedPip(const int index);
     void UpdatePipOrientation(const winrt::Control& pip);
     void ApplyStyleToPipAndUpdateOrientation(const winrt::FrameworkElement& pip, const winrt::Style& style);
@@ -86,6 +88,7 @@ private:
 
     /* Event listeners */
     void OnItemsRepeaterLayoutChanged(const winrt::DependencyObject& /*sender*/, const winrt::DependencyProperty& args);
+    void OnLayoutUpdatedAfterPipRealized(const winrt::IInspectable& sender, const winrt::IInspectable& args);
 
     /* Pips Logic */
     void UpdatePipsItems(const int numberOfPages, int maxVisualIndicators);
@@ -106,6 +109,7 @@ private:
     winrt::ItemsRepeater::BringIntoViewRequested_revoker m_pipsAreaBringIntoViewRequestedRevoker{};
     winrt::FxScrollViewer::BringIntoViewRequested_revoker m_scrollViewerBringIntoViewRequestedRevoker{};
     PropertyChanged_revoker m_itemsRepeaterStackLayoutChangedRevoker{};
+    winrt::FrameworkElement::LayoutUpdated_revoker m_layoutUpdatedRevoker{};
     /* Items */
     winrt::IObservableVector<int> m_pipsPagerItems{};
 
@@ -113,6 +117,7 @@ private:
     winrt::Size m_defaultPipSize{ 0.0,0.0 };
     winrt::Size m_selectedPipSize{ 0.0, 0.0 };
     int m_lastSelectedPageIndex{ -1 };
+    int m_pendingScrollToPipIndex{ -1 };
     bool m_isPointerOver{ false };
     bool m_isFocused{ false };
     winrt::weak_ref<winrt::StackLayout> m_itemsRepeaterStackLayout{ nullptr };


### PR DESCRIPTION
Fixes #8299

## Problem

Setting `PipsPager.NumberOfPages` can throw an HRESULT straight out of the property setter.

In the reported repro the pager sits in an auto sized `Grid` row with `NumberOfPages` bound to
`{x:Bind Items.Count, Mode=OneWay}`, and a `FlipView` in the same `Grid` is bound to the same
`ObservableCollection`. Adding an item takes the app down. The reporter noted that changing the
row height from `Auto` to a fixed value makes the crash go away.

Observed on shipping WinAppSDK 2.4.0:

```
System.ArgumentOutOfRangeException
HRESULT: 0x8000000B (E_BOUNDS)
   at ABI.Microsoft.UI.Xaml.Controls.IPipsPagerMethods.set_NumberOfPages
   at ...MainPage_obj1_BindingsTracking.PropertyChanged_Items
   at System.Collections.ObjectModel.ObservableCollection`1.InsertItem
```

## Cause

`OnNumberOfPagesChanged` reaches `UpdateSelectedPip`, which called `repeater.UpdateLayout()`.

`UIElement.UpdateLayout()` is not scoped to the repeater. It drives the whole `XamlRoot`'s layout
manager to completion, so a failure anywhere in the tree unwinds out of the property setter. It also
ran at the worst possible moment: `UpdatePipsItems` had just changed the repeater's items and
`SetScrollViewerMaxSize` had just changed the `ScrollViewer`'s size.

`ObservableCollection<T>.InsertItem` raises `PropertyChanged("Count")` before `CollectionChanged`, so
the binding pushes the new `NumberOfPages` while the collection has already grown but the `FlipView`
has not been notified yet. Because the row is auto sized, the new pip changes the pager's desired
size, which invalidates the `Grid` and re-measures the `FlipView` inside that forced pass. The
`FlipView` then indexes past what it currently knows about, which is the `E_BOUNDS`.

With a fixed row height the `Grid` absorbs the size change and the `FlipView` is never re-measured in
that pass, which is exactly the reporter's observation.

## Fix

Remove the forced synchronous layout pass:

* When the selected pip is already realized, scroll to it immediately, as before.
* When it has to be realized, defer the scroll to the next `LayoutUpdated`. A pip realized in this
  pass has been measured but not arranged, so its render size is still empty and bringing it into
  view right away would centre a degenerate rect. The handler is one shot and revokes itself first,
  so it cannot loop.
* `GetOrCreateElement` is still called in both cases, so the repeater sees the same anchor request
  it saw before this change.

Second, smaller issue in the same path: `GetOrCreateElement` throws for indices outside the
repeater's items source, and the index was only validated against `NumberOfPages()`. Those two are
updated in separate steps and can briefly disagree. A small `GetOrCreatePip` helper bounds checks
against `ItemsSourceView().Count()`. The identical unguarded call in `OnPipsAreaGettingFocus`, where
an app has no way to catch the failure, now goes through the same helper.

## Verification

The repro was built as a standalone app and run as a variant matrix, one variant per process, to
establish which conditions are actually necessary:

| Variant | Result |
| --- | --- |
| A. Auto row, FlipView bound to the same collection (the issue's tree) | throws `0x8000000B` |
| B. Same, but a fixed 40px row | no crash |
| C. Same, but the FlipView removed | no crash |
| D. Same, but the FlipView bound to its own collection | no crash |
| E. Same, but no `ItemTemplate` | throws `0x8000000B` |
| F. `XamlReader.Load` with classic `{Binding Count}` | throws `0x8000000B` |
| G. F plus an `ItemTemplate` | throws `0x8000000B` |

So three conditions are jointly necessary: the auto sized row, a second control in the tree, and that
control sharing the collection. The `ItemTemplate` is irrelevant, and a classic `{Binding}`
reproduces it the same way `x:Bind` does, which is what makes the added API test meaningful rather
than vacuous.

A/B against a local build of this branch, swapping only `Microsoft.UI.Xaml.Controls.dll` and holding
everything else fixed: variants A, F and G throw before the change and pass after it. Variants B, C
and D stay clean.

## Tests

Two API tests are added in `PipsPagerTests.cs`:

* `VerifyChangingNumberOfPagesInAutoSizedRowDoesNotCrash` builds the issue's tree (variant F above,
  confirmed to throw on the unfixed control) and changes `NumberOfPages`.
* `VerifyRepeatedNumberOfPagesChangesInAutoSizedRowDoNotCrash` drives `NumberOfPages` past
  `MaxVisiblePips` with no layout pass in between, so every step selects a pip the virtualizing
  layout has not realized yet. It asserts the selected pip still ends up realized and carrying
  `SelectedPipStyle`, so a later change cannot satisfy the test by simply dropping the selected pip
  work.

## Still to do before this leaves draft

* Run the added tests plus the existing PipsPager API and interaction suites. They have not been
  executed yet. On the machine used here the entire MUXControlsTestApp API suite is blocked before
  any control code runs: 599 of 599 tests end up `Blocked`, each with a `0xC0000420` crash inside
  `Microsoft.UI.Xaml.dll` during `Setup`, on both `chk` and `fre` local builds. That is a local
  environment problem rather than anything specific to this change, but it does mean the added tests
  are so far validated only by reproducing their exact tree in a standalone app, as described above.
* Manually check the scrolling behaviour the removed call was scaffolding for, with
  `MaxVisiblePips = 5` and `NumberOfPages = 20`, in both orientations, including a programmatic jump
  from page 0 to page 18 (the deferred scroll branch).

## Out of scope

Two related things found while investigating, deliberately not bundled into a crash fix:

* `PagerControl::MoveIdentifierToElement` reaches the same `repeater.UpdateLayout()` from its own
  `OnPropertyChanged` and carries the same latent defect.
* On current `main`, setting a `FlipView`'s `ItemTemplate` to `null` at runtime while it shares a
  collection with the pager fail-fasts with `0xC0000409`. This reproduces identically with and
  without this change, so it is a separate pre-existing issue.
