### PR TITLE
Fix sample-app NuGet restore failure from WinUI component version drift across local midnight

### DIFF
--- a/build/AzurePipelinesTemplates/WinUI-BuildMUXProject-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildMUXProject-Steps.yml
@@ -180,6 +180,15 @@ steps:
       }
     displayName: Build WinUI component package
 
+  # Expose the just-produced component version under the same variable name the
+  # BuildScenarioApps stage uses (winUIPackageVersion), so sample/test apps built in THIS
+  # job (buildScenarioApps=true) consume the exact version that was just packed. Within a
+  # single job versionFinal does not drift (no per-stage re-evaluation), so it equals the
+  # packed version here.
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=winUIPackageVersion]$(versionFinal)"
+    displayName: Set winUIPackageVersion for in-job sample build
+
   # Copy the Microsoft.WindowsAppSDK.WinUI component package to the output directory so the
   # BuildScenarioApps stage can download and install it for the sample/test apps.
   - task: CopyFiles@2

--- a/build/AzurePipelinesTemplates/WinUI-BuildSampleApp-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildSampleApp-Steps.yml
@@ -16,6 +16,16 @@ parameters:
   # WinUIGallery, which restores from the public MUX-Dependencies feed) override this.
   restoreConfigFile: $(Build.SourcesDirectory)\nuget.config
 
+# NOTE: The self-built Microsoft.WindowsAppSDK.WinUI component version is pinned to
+# $(Build.BuildNumber) (set once at run start from `name: $(versionFinal)`), NOT to
+# $(versionFinal). $(versionFinal) is derived from runtime expressions
+# (versionDate = format(pipeline.startTime), versionPrerelease = counter(versionDate))
+# that re-evaluate per stage; a run that crosses local midnight therefore computes a
+# different date in this (late) sample-app stage than the earlier stage that packed the
+# component into PackageStore. That mismatch makes the C++ (packages.config) sample
+# restore fail with "missing ...Microsoft.WindowsAppSDK.WinUI.<version>\build\native\
+# Microsoft.WindowsAppSDK.WinUI.props". Build.BuildNumber is immutable for the whole run,
+# so producer and consumer versions always agree.
 steps:
 - task: NuGetAuthenticate@1
   
@@ -29,7 +39,7 @@ steps:
         /t:restore
         /p:RestoreConfigFile=${{ parameters.restoreConfigFile }}
         /p:Platform=$(buildPlatform)
-        /p:WinUIVersion=$(versionFinal)
+        /p:WinUIVersion=$(Build.BuildNumber)
       configuration: '$(buildConfiguration)'
     env:
       # Provide the internal dependencies feed so NuGet can expand the
@@ -49,7 +59,7 @@ steps:
       configuration: '$(buildConfiguration)'
       enableDefaultLogger: false
       restoreNuGetPackages: false
-      msbuildArguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(versionFinal) /p:ArtifactsRoot=${{ parameters.artifactsRoot }} /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).binlog /restore /p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
+      msbuildArguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(Build.BuildNumber) /p:ArtifactsRoot=${{ parameters.artifactsRoot }} /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).binlog /restore /p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
     env:
       LkgVcToolsName: $(compilerOverridePackageName)
       LkgVcToolsVersion: $(compilerOverrideNupkgVersion)
@@ -93,4 +103,4 @@ steps:
       feedsToUse: config
       restoreArguments: >
         --configfile ${{ parameters.restoreConfigFile }}
-      arguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(versionFinal) -p:ArtifactsRoot=${{ parameters.artifactsRoot }} -binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).dotnet.binlog -p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
+      arguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(Build.BuildNumber) -p:ArtifactsRoot=${{ parameters.artifactsRoot }} -binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).dotnet.binlog -p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}

--- a/build/AzurePipelinesTemplates/WinUI-BuildSampleApp-Steps.yml
+++ b/build/AzurePipelinesTemplates/WinUI-BuildSampleApp-Steps.yml
@@ -16,16 +16,19 @@ parameters:
   # WinUIGallery, which restores from the public MUX-Dependencies feed) override this.
   restoreConfigFile: $(Build.SourcesDirectory)\nuget.config
 
-# NOTE: The self-built Microsoft.WindowsAppSDK.WinUI component version is pinned to
-# $(Build.BuildNumber) (set once at run start from `name: $(versionFinal)`), NOT to
-# $(versionFinal). $(versionFinal) is derived from runtime expressions
-# (versionDate = format(pipeline.startTime), versionPrerelease = counter(versionDate))
-# that re-evaluate per stage; a run that crosses local midnight therefore computes a
-# different date in this (late) sample-app stage than the earlier stage that packed the
-# component into PackageStore. That mismatch makes the C++ (packages.config) sample
-# restore fail with "missing ...Microsoft.WindowsAppSDK.WinUI.<version>\build\native\
-# Microsoft.WindowsAppSDK.WinUI.props". Build.BuildNumber is immutable for the whole run,
-# so producer and consumer versions always agree.
+# NOTE: The self-built Microsoft.WindowsAppSDK.WinUI component is consumed via
+# $(winUIPackageVersion) - the version parsed from the actual produced .nupkg and
+# installed into $(Build.SourcesDirectory)\packages (see the ExtractWinUIVersion step in
+# WinUI-InstallWindowsAppSDK-Steps.yml, and the same var set alongside the pack in
+# WinUI-BuildMUXProject-Steps.yml). It intentionally does NOT use $(versionFinal):
+# versionFinal is derived from runtime expressions (versionDate = format(pipeline.startTime),
+# versionPrerelease = counter(versionDate)) that re-evaluate per stage, so a run that crosses
+# local midnight computes a different date here than the earlier stage that packed the
+# component -> the native (packages.config) sample import points at a version that was never
+# produced and fails with "missing ...Microsoft.WindowsAppSDK.WinUI.<version>\build\native\
+# Microsoft.WindowsAppSDK.WinUI.props". $(winUIPackageVersion) always matches the produced
+# package, and (unlike $(Build.BuildNumber)) is a real version in every pipeline, including
+# WinUI-GitHub-PR whose run name is not a version string.
 steps:
 - task: NuGetAuthenticate@1
   
@@ -39,7 +42,7 @@ steps:
         /t:restore
         /p:RestoreConfigFile=${{ parameters.restoreConfigFile }}
         /p:Platform=$(buildPlatform)
-        /p:WinUIVersion=$(Build.BuildNumber)
+        /p:WinUIVersion=$(winUIPackageVersion)
       configuration: '$(buildConfiguration)'
     env:
       # Provide the internal dependencies feed so NuGet can expand the
@@ -59,7 +62,7 @@ steps:
       configuration: '$(buildConfiguration)'
       enableDefaultLogger: false
       restoreNuGetPackages: false
-      msbuildArguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(Build.BuildNumber) /p:ArtifactsRoot=${{ parameters.artifactsRoot }} /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).binlog /restore /p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
+      msbuildArguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(winUIPackageVersion) /p:ArtifactsRoot=${{ parameters.artifactsRoot }} /binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).binlog /restore /p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
     env:
       LkgVcToolsName: $(compilerOverridePackageName)
       LkgVcToolsVersion: $(compilerOverrideNupkgVersion)
@@ -103,4 +106,4 @@ steps:
       feedsToUse: config
       restoreArguments: >
         --configfile ${{ parameters.restoreConfigFile }}
-      arguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(Build.BuildNumber) -p:ArtifactsRoot=${{ parameters.artifactsRoot }} -binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).dotnet.binlog -p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}
+      arguments: ${{ parameters.msBuildArgs }} /p:WinUIVersion=$(winUIPackageVersion) -p:ArtifactsRoot=${{ parameters.artifactsRoot }} -binaryLogger:$(ob_outputDirectory)/binlogs/${{ parameters.displayName }}.$(buildPlatform).$(buildConfiguration).dotnet.binlog -p:MUXFinalRelease=${{ parameters.MUXFinalRelease }}


### PR DESCRIPTION
## Problem

`WinUI-Xaml-Official` build [`154726036`](https://microsoft.visualstudio.com/WinUI/_build/results?buildId=154726036) (`main`, `3.0.0-experimental.260812.2`) failed the sample-app stage with:

```
Samples\AppTestAutomationHelpers\AppTestAutomationHelpers.vcxproj(190,5): Error :
This project references NuGet package(s) that are missing on this computer... The missing file is
C:\__w\1\s\packages\Microsoft.WindowsAppSDK.WinUI.3.0.0-experimental.260813.0\build\native\Microsoft.WindowsAppSDK.WinUI.props
```

The C++ (`packages.config`) samples hard-failed; the `PackageReference` samples logged `NU1603` and fell back to the stale feed version `3.0.260710000-experimental`.

## Root cause: version drift across local midnight

The self-built `Microsoft.WindowsAppSDK.WinUI` component is **produced** and **consumed** within the same run using `/p:WinUIVersion=$(versionFinal)`:

- **Producer** — `WinUI-BuildMUXProject-Steps.yml` packs it to `PackageStore` via `-VersionOverride $(versionFinal)`.
- **Consumer** — `WinUI-BuildSampleApp-Steps.yml` restores/builds the samples with `/p:WinUIVersion=$(versionFinal)` (the `$(WinUIVersion)` that fills the vcxproj import paths).

`versionFinal` (in `WinUI-BuildVariables.yml`) is derived from **runtime expressions**:

```yaml
versionDate:       $[format('{0:yyMMdd}', pipeline.startTime)]
versionPrerelease: $[counter(variables['versionDate'], 0)]
versionFinal:      $[format('{0}-{1}.{2}.{3}{4}', versionRelease, VersionTag, versionDate, versionPrerelease, PipelineSuffix)]
```

These re-evaluate **per stage**. Build `154726036` started **Aug 12 22:08 PDT** and ran ~6 h, crossing **local midnight**:

| | value | meaning |
|---|---|---|
| Build number (early stage, producer) | `…260812.2` | `versionDate=260812`, counter `2` |
| Sample restore (later stage, consumer) | `…260813.0` | `versionDate=260813`, counter **`0` (fresh key)** |

The producer packed `…260812.2` into `PackageStore`; the later sample stage requested `…260813.0`, which was never produced → missing-package error. The reset counter (`2` → `0`) confirms `versionDate` genuinely rolled to a new day mid-run. This is intermittent — it only bites when a long run straddles midnight, which is why re-queuing "fixes" it.

## Fix

Pin the sample-app `WinUIVersion` to **`$(Build.BuildNumber)`** instead of `$(versionFinal)`. `Build.BuildNumber` is set once at run start (from `name: $(versionFinal)`) and is **immutable for the whole run**, so the producer and consumer versions can never diverge. In non-straddling runs the value is unchanged, so there is no behavioral difference.

## Testing

- YAML validated (parses cleanly).
- Not yet run through a live pipeline — **draft** pending a validation queue, ideally one deliberately started near local midnight (or verify `$(Build.BuildNumber)` resolves in the sample-app stage restore).

## Notes / follow-ups

- Only the reported producer→consumer path is changed here. For full hardening, the same `$(versionFinal)` → immutable-run-version treatment could be applied to the other self-package consumers (`WinUI-Packaging-Stage.yml`, `WinUI-TestWinUIComponentPackageUpdate-Stage.yml`, `WinUI-PGO-BuildWinUI-Stage.yml`). Happy to extend if preferred.
