### PR TITLE
SvgImageDecoder::DecodeFrame: add opt-in hardware rasterization

### DIFF
--- a/dxaml/xcp/components/graphics/unittests/D3D11DeviceInstanceUnitTests.cpp
+++ b/dxaml/xcp/components/graphics/unittests/D3D11DeviceInstanceUnitTests.cpp
@@ -446,6 +446,7 @@ void D3D11DeviceInstanceUnitTests::CheckForStaleDeviceSubTest(_In_ CreateDXGIFac
     VERIFY_SUCCEEDED(deviceInstance->EnsureResources());
 
     // Invalidate the current factory and populate with new adapters
+    const bool wasWarpDevice = deviceInstance->IsWarpDevice();
     DXGIMock.InvalidateCurrentFactory();
     if (newAdapter1 != nullptr) DXGIMock.Factory->AddAdapter(newAdapter1);
     if (newAdapter2 != nullptr) DXGIMock.Factory->AddAdapter(newAdapter2);
@@ -455,6 +456,7 @@ void D3D11DeviceInstanceUnitTests::CheckForStaleDeviceSubTest(_In_ CreateDXGIFac
     {
         VERIFY_SUCCEEDED(deviceInstance->EnsureDXGIAdapters());
         VERIFY_ARE_EQUAL(CD3D11DeviceInstance::s_sharedDeviceWeak.lock().get(), deviceInstance.get());
+        VERIFY_ARE_EQUAL(wasWarpDevice, deviceInstance->IsWarpDevice());
     }
     else
     {

--- a/dxaml/xcp/components/imaging/ImageDecoderFactory.cpp
+++ b/dxaml/xcp/components/imaging/ImageDecoderFactory.cpp
@@ -12,6 +12,7 @@
 #include <WicService.h>
 #include <corep.h>
 #include "GraphicsUtility.h"
+#include <RuntimeEnabledFeatures.h>
 
 namespace ImageDecoderFactory
 {
@@ -55,7 +56,9 @@ _Check_return_ HRESULT CreateDecoder(
             // The decoder should take a reference on the factory.
             ctl::ComPtr<ID2D1Factory1> d2dFactory(deviceNoRef->GetD2DFactory()->GetFactory());
 
-            decoder = std::make_unique<SvgImageDecoder>(std::move(d2dFactory));
+            const bool useDevice = RuntimeFeatureBehavior::GetRuntimeEnabledFeatureDetector()->IsFeatureEnabled(
+                RuntimeFeatureBehavior::RuntimeEnabledFeature::EnableSvgDeviceRendering);
+            decoder = std::make_unique<SvgImageDecoder>(std::move(d2dFactory), useDevice ? deviceNoRef : nullptr);
         }
     }
     else

--- a/dxaml/xcp/components/imaging/SvgImageDecoder.cpp
+++ b/dxaml/xcp/components/imaging/SvgImageDecoder.cpp
@@ -20,15 +20,19 @@
 #include <Corep.h>
 #include <d2d1_3.h>
 #include <WicService.h>
+#include <d3d11device.h>
+#include <D3D11SharedDeviceGuard.h>
 
 using namespace DirectUI;
 
 bool SvgImageDecoder::s_testHook_ForceDeviceLostOnCreatingSvgDecoder = false;
 
 SvgImageDecoder::SvgImageDecoder(
-    ctl::ComPtr<ID2D1Factory1> d2dFactory
+    ctl::ComPtr<ID2D1Factory1> d2dFactory,
+    _In_opt_ CD3D11Device* graphicsDevice
     )
     : m_d2dFactory(std::move(d2dFactory))
+    , m_graphicsDevice(xref::get_weakref(graphicsDevice))
 {
 }
 
@@ -59,6 +63,14 @@ _Check_return_ HRESULT SvgImageDecoder::DecodeFrame(
 
     ASSERT(width > 0 && height > 0);
 
+    if (auto graphicsDevice = m_graphicsDevice.lock())
+    {
+        if (SUCCEEDED(DecodeFrameWithDevice(graphicsDevice.get(), encodedImageData, width, height, bitmapSource)))
+        {
+            return S_OK;
+        }
+    }
+
     auto spWicFactory = WicService::GetInstance().GetFactory();
     WICPixelFormatGUID pixelFormat = GUID_WICPixelFormat32bppPBGRA;
     wrl::ComPtr<IWICBitmap> wicBitmap;
@@ -83,6 +95,17 @@ _Check_return_ HRESULT SvgImageDecoder::DecodeFrame(
     wrl::ComPtr<ID2D1DeviceContext5> d2dDeviceContext5;
     IFC_RETURN(renderTarget.As(&d2dDeviceContext5));
 
+    IFC_RETURN(DrawSvg(encodedImageData, width, height, d2dDeviceContext5.Get()));
+    bitmapSource = std::move(wicBitmap);
+    return S_OK;
+}
+
+_Check_return_ HRESULT SvgImageDecoder::DrawSvg(
+    _In_ EncodedImageData& encodedImageData,
+    uint32_t width,
+    uint32_t height,
+    _In_ ID2D1DeviceContext5* d2dDeviceContext5)
+{
     wrl::ComPtr<IStream> istream;
     IFC_RETURN(encodedImageData.CreateIStream(istream));
 
@@ -248,6 +271,55 @@ _Check_return_ HRESULT SvgImageDecoder::DecodeFrame(
     d2dDeviceContext5->DrawSvgDocument(svgContainerDocument.Get());
     IFC_RETURN(d2dDeviceContext5->EndDraw());
 
-    bitmapSource = std::move(wicBitmap);
+    return S_OK;
+}
+
+_Check_return_ HRESULT SvgImageDecoder::DecodeFrameWithDevice(
+    _In_ CD3D11Device* graphicsDevice,
+    _In_ EncodedImageData& encodedImageData,
+    uint32_t width,
+    uint32_t height,
+    _Out_ wrl::ComPtr<IWICBitmapSource>& bitmapSource)
+{
+    IFC_RETURN(graphicsDevice->EnsureD2DResources());
+    wrl::ComPtr<ID2D1DeviceContext> context;
+    {
+        CD3D11SharedDeviceGuard guard;
+        IFC_RETURN(graphicsDevice->TakeLockAndCheckDeviceLost(&guard));
+        // Keep WARP on the WIC path to avoid the extra readback surfaces.
+        if (graphicsDevice->IsWarpDevice())
+        {
+            return DXGI_ERROR_UNSUPPORTED;
+        }
+        IFC_RETURN(graphicsDevice->GetD2DDevice(&guard)->CreateDeviceContext(
+            D2D1_DEVICE_CONTEXT_OPTIONS_ENABLE_MULTITHREADED_OPTIMIZATIONS, &context));
+    }
+
+    // Like DrawDummyText, use a private context without holding the shared lock over drawing/readback.
+    wrl::ComPtr<ID2D1DeviceContext5> svgContext;
+    IFC_RETURN(context.As(&svgContext));
+    const auto format = D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED);
+    const auto targetProperties = D2D1::BitmapProperties1(D2D1_BITMAP_OPTIONS_TARGET, format, 96.0f, 96.0f);
+    wrl::ComPtr<ID2D1Bitmap1> target;
+    IFC_RETURN(svgContext->CreateBitmap(D2D1::SizeU(width, height), nullptr, 0, &targetProperties, &target));
+    svgContext->SetTarget(target.Get());
+    IFC_RETURN(DrawSvg(encodedImageData, width, height, svgContext.Get()));
+    svgContext->SetTarget(nullptr);
+
+    const auto readbackProperties = D2D1::BitmapProperties1(
+        D2D1_BITMAP_OPTIONS_CPU_READ | D2D1_BITMAP_OPTIONS_CANNOT_DRAW, format, 96.0f, 96.0f);
+    wrl::ComPtr<ID2D1Bitmap1> readback;
+    IFC_RETURN(svgContext->CreateBitmap(D2D1::SizeU(width, height), nullptr, 0, &readbackProperties, &readback));
+    IFC_RETURN(readback->CopyFromBitmap(nullptr, target.Get(), nullptr));
+
+    D2D1_MAPPED_RECT mapped = {};
+    IFC_RETURN(readback->Map(D2D1_MAP_OPTIONS_READ, &mapped));
+    auto unmap = wil::scope_exit([&] { IGNOREHR(readback->Unmap()); });
+    uint32_t bufferSize = 0;
+    IFC_RETURN(UInt32Mult(mapped.pitch, height, &bufferSize));
+    wrl::ComPtr<IWICBitmap> bitmap;
+    IFC_RETURN(WicService::GetInstance().GetFactory()->CreateBitmapFromMemory(
+        width, height, GUID_WICPixelFormat32bppPBGRA, mapped.pitch, bufferSize, mapped.bits, &bitmap));
+    bitmapSource = std::move(bitmap);
     return S_OK;
 }

--- a/dxaml/xcp/components/imaging/inc/SvgImageDecoder.h
+++ b/dxaml/xcp/components/imaging/inc/SvgImageDecoder.h
@@ -3,15 +3,18 @@
 
 #pragma once
 #include "ImagingInterfaces.h"
+#include <weakref_ptr.h>
 
 class CCoreServices;
+class CD3D11Device;
 struct ID2D1Factory1;
+struct ID2D1DeviceContext5;
 
 class SvgImageDecoder final
     : public IImageDecoder
 {
 public:
-    SvgImageDecoder(ctl::ComPtr<ID2D1Factory1> d2dFactory);
+    SvgImageDecoder(ctl::ComPtr<ID2D1Factory1> d2dFactory, _In_opt_ CD3D11Device* graphicsDevice = nullptr);
 
     _Check_return_ HRESULT DecodeFrame(
         _In_ EncodedImageData& encodedImageData,
@@ -26,5 +29,19 @@ public:
     static bool s_testHook_ForceDeviceLostOnCreatingSvgDecoder;
 
 private:
+    _Check_return_ HRESULT DrawSvg(
+        _In_ EncodedImageData& encodedImageData,
+        uint32_t width,
+        uint32_t height,
+        _In_ ID2D1DeviceContext5* d2dDeviceContext5);
+
+    _Check_return_ HRESULT DecodeFrameWithDevice(
+        _In_ CD3D11Device* graphicsDevice,
+        _In_ EncodedImageData& encodedImageData,
+        uint32_t width,
+        uint32_t height,
+        _Out_ wrl::ComPtr<IWICBitmapSource>& bitmapSource);
+
     ctl::ComPtr<ID2D1Factory1> m_d2dFactory;
+    xref::weakref_ptr<CD3D11Device> m_graphicsDevice;
 };

--- a/dxaml/xcp/components/runtimeEnabledFeatures/RuntimeFeatureData.cpp
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/RuntimeFeatureData.cpp
@@ -84,5 +84,6 @@ namespace RuntimeFeatureBehavior
         // If XAML dispatch is paused, then to allow process without creating the reentrancy guard, else to enable the reentrancy checks.
         { L"EnableReentrancyChecksAllowPaused", RuntimeEnabledFeature::EnableReentrancyChecksAllowPaused, false, 0, 0 },
         { L"ForcePerfOptIn", RuntimeEnabledFeature::ForcePerfOptIn, true /*opt-in by default in perf branch for now*/, 0, 1 },
+        { L"EnableSvgDeviceRendering", RuntimeEnabledFeature::EnableSvgDeviceRendering, false, 0, 0 },
     };
 }

--- a/dxaml/xcp/components/runtimeEnabledFeatures/inc/RuntimeEnabledFeaturesEnum.h
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/inc/RuntimeEnabledFeaturesEnum.h
@@ -76,6 +76,7 @@ namespace RuntimeFeatureBehavior
         ForceDWriteTypographicModel,        // overides DisableDWriteTypographicModel
         EnableReentrancyChecksAllowPaused, // If XAML dispatch is paused, then to allow process without creating the reentrancy guard, else to enable the reentrancy checks.
         ForcePerfOptIn, // Opts in to perf optimizations gated behind this flag (e.g. inline DO accessor in PropertyAccessPathStep).
+        EnableSvgDeviceRendering,
 
         // Insert new enum values before this one.
         // This is used to initialize the lengths of the

--- a/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.cpp
+++ b/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.cpp
@@ -668,7 +668,6 @@ CD3D11DeviceInstance::EnsureDXGIAdapters()
     IFC(pfnCreateDXGIFactory1(__uuidof(IDXGIFactory1), reinterpret_cast<void **>(m_dxgiFactory.ReleaseAndGetAddressOf())));
 
     // Find the best hardware and warp adapters available
-    m_fIsWarpDevice = false;
     m_fIsHardwareOutput = false;
 
     for (UINT i = 0; SUCCEEDED(m_dxgiFactory->EnumAdapters1(i, enumeratedAdapter.ReleaseAndGetAddressOf())); i++)

--- a/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.h
+++ b/dxaml/xcp/plat/win/desktop/D3D11DeviceInstance.h
@@ -155,6 +155,7 @@ public:
     _Check_return_ HRESULT IsHdrOutput(_In_ HMONITOR monitor, _Out_ bool* isHDR);
     bool ShouldAttemptToUseA8Textures() const { return !m_fIsWarpDevice || !m_fIsHardwareOutput; }
     bool UseIntermediateUploadSurface() const { return m_fUseIntermediateUploadSurface; }
+    bool IsWarpDevice() { return m_fIsWarpDevice; }
 
     void TrimMemory(const UINT64 currentTime);
 
@@ -186,7 +187,6 @@ private:
         return pointerWithLock;
     }
 
-    bool IsWarpDevice() { return m_fIsWarpDevice; }
     D3D_FEATURE_LEVEL GetFeatureLevel() { return m_featureLevel; }
     bool IsOnSameAdapter(_In_ const LUID *pOtherLuid);
 

--- a/dxaml/xcp/plat/win/desktop/d3d11device.cpp
+++ b/dxaml/xcp/plat/win/desktop/d3d11device.cpp
@@ -365,6 +365,11 @@ CD3D11Device::ShouldAttemptToUseA8Textures() const
     return m_deviceInstance->ShouldAttemptToUseA8Textures();
 }
 
+bool CD3D11Device::IsWarpDevice() const
+{
+    return m_deviceInstance->IsWarpDevice();
+}
+
 //------------------------------------------------------------------------------
 //
 //  Synopsis:

--- a/dxaml/xcp/plat/win/desktop/d3d11device.h
+++ b/dxaml/xcp/plat/win/desktop/d3d11device.h
@@ -115,6 +115,7 @@ public:
     _Check_return_ HRESULT ReleaseScratchResources();
 
     bool ShouldAttemptToUseA8Textures() const;
+    bool IsWarpDevice() const;
 
     void ReturnToSysMemBitsPool(_In_ SystemMemoryBits *pSysMemBits);
 


### PR DESCRIPTION
Description:
SVG decoding creates a software WIC render target even when XAML already has a hardware device.

Root cause:
The WIC target routes SVG rasterization through WARP and pays its shader/JIT allocation cost.

Fix:
Reuse the existing graphics device through a weak reference, render with a private D2D context, and copy the result with IWICImagingFactory::CreateBitmapFromMemory. Preserve SVG sizing and fall back on WARP or a device/readback failure. Preserve WARP classification when an adapter refresh keeps the current device.

Behavior:
EnableSvgDeviceRendering remains off by default. Local AppPopup main/fix checks cover nine loading cases, seven pixel fixtures, malformed input, device recovery and forced fallback; all six device-instance tests pass. The readback path was exercised on WARP under a debugger override, not on a hardware GPU. Hardware memory savings and readback latency still require validation.
