### PR TITLE
Note that NUGET_PACKAGES overrides globalPackagesFolder in fast inner loop doc

### DIFF
--- a/docs/ad-hoc-testing-of-local-build-with-fast-inner-loop.md
+++ b/docs/ad-hoc-testing-of-local-build-with-fast-inner-loop.md
@@ -70,6 +70,12 @@ cache from the machine (e.g. `C:\Users\alias\.nuget\packages`). This is importan
 being cached globally since that can cause issues. It does mean that ALL the nuget packages that this project depends on 
 will get cached here, which is a little redundant, but it is a worthwhile trade-off.
 
+> [!NOTE]
+> `NUGET_PACKAGES` overrides `globalPackagesFolder`. If it is set, packages are cached machine-globally instead of in
+> the local `packages` folder - silently - so you keep building against stale cached bits (the fixed `3.0.0-dev` version
+> is immutable). In cmd.exe, check with `set NUGET_PACKAGES` (prints the variable if set, nothing if not); if set, clear
+> it and restart Visual Studio.
+
 ### Update the Project Target Platform (e.g. to x64)
 Open the .sln in Visual Studio again. 
 

--- a/docs/ad-hoc-testing-of-local-build-with-fast-inner-loop.md
+++ b/docs/ad-hoc-testing-of-local-build-with-fast-inner-loop.md
@@ -71,10 +71,10 @@ being cached globally since that can cause issues. It does mean that ALL the nug
 will get cached here, which is a little redundant, but it is a worthwhile trade-off.
 
 > [!NOTE]
-> `NUGET_PACKAGES` overrides `globalPackagesFolder`. If it is set, packages are cached machine-globally instead of in
-> the local `packages` folder - silently - so you keep building against stale cached bits (the fixed `3.0.0-dev` version
-> is immutable). In cmd.exe, check with `set NUGET_PACKAGES` (prints the variable if set, nothing if not); if set, clear
-> it and restart Visual Studio.
+> Setting `NUGET_PACKAGES` is not supported for this fast inner-loop workflow and will cause problems with local
+> package-cache isolation. It overrides `globalPackagesFolder`, so a shared/global `NUGET_PACKAGES` location bypasses
+> the app's local `packages` folder and causes stale cached bits to be reused (NuGet treats the fixed `3.0.0-dev`
+> version as immutable). In cmd.exe, check with `set NUGET_PACKAGES`; if set, clear it and restart Visual Studio.
 
 ### Update the Project Target Platform (e.g. to x64)
 Open the .sln in Visual Studio again. 
@@ -211,4 +211,3 @@ cached versions of the package intact.
 
 Now when you build, Visual Studio will pick up the new local WinUI component package from your local repo and unpack it into the local
 package cache again so you can start using the updated build.
-


### PR DESCRIPTION
Ports the NUGET_PACKAGES note from the ADO-side change for the fast inner loop doc.

If NUGET_PACKAGES is set it silently overrides the globalPackagesFolder from nuget.config, so the local component package is cached machine-globally and the immutable 3.0.0-dev version means stale bits are reused indefinitely. Adds a NOTE explaining how to detect and clear it.

Docs-only change. The wrong-folder-name fix was already merged via #11545.

Fixes #11522

(Recreated from a branch on the repo itself instead of a fork, replacing #11816.)