### PR TITLE
Enable xaml profiler traces flag in debug mode

### DIFF
--- a/dxaml/Xaml.Cpp.Props
+++ b/dxaml/Xaml.Cpp.Props
@@ -100,11 +100,11 @@
     </XamlCommonPreprocessorDefinitions>
   </PropertyGroup>
 
-  <!-- XamlProfiler producer master switch: set XamlProfilerEnabled to 'true' to compile the ETW
-       tree-tracking instrumentation into Debug builds (retail is always off). Off by default. -->
+  <!-- XamlProfiler producer master switch. The ETW tree-tracking instrumentation is enabled in
+       Debug builds and disabled by default for all other configurations. -->
   <PropertyGroup>
     <XamlProfilerEnabled>false</XamlProfilerEnabled>
-    <XamlProfilerEnabled Condition="'$(Configuration)'!='Debug'">false</XamlProfilerEnabled>
+    <XamlProfilerEnabled Condition="'$(Configuration)'=='Debug'">true</XamlProfilerEnabled>
   </PropertyGroup>
 
 </Project>

--- a/dxaml/xcp/components/comptree/WucVisualTreeProfiler.cpp
+++ b/dxaml/xcp/components/comptree/WucVisualTreeProfiler.cpp
@@ -11,6 +11,7 @@
 
 #include "WucVisualTreeProfiler.h"
 #include <Windows.UI.Composition.h>
+#include "XcpAllocation.h"
 #include "XamlProfilerTracing.h"
 #include <unordered_set>
 
@@ -150,9 +151,15 @@ namespace
     // torn state if a tracing callback ever runs off-thread.
     SRWLOCK g_suppressedCompNodesLock = SRWLOCK_INIT;
 
-    std::unordered_set<uint64_t>& SuppressedCompNodes()
+    using SuppressedCompNodeSet = std::unordered_set<
+        uint64_t,
+        std::hash<uint64_t>,
+        std::equal_to<uint64_t>,
+        XcpAllocation::LeakIgnoringAllocator<uint64_t>>;
+
+    SuppressedCompNodeSet& SuppressedCompNodes()
     {
-        static std::unordered_set<uint64_t> set;
+        static SuppressedCompNodeSet set;
         return set;
     }
 

--- a/dxaml/xcp/components/comptree/WucVisualTreeProfiler.cpp
+++ b/dxaml/xcp/components/comptree/WucVisualTreeProfiler.cpp
@@ -126,18 +126,12 @@ namespace
             return 0;
         }
         wrl::ComPtr<WUComp::IVisual> spVisual;
-        if (SUCCEEDED(pUnknown->QueryInterface(IID_PPV_ARGS(&spVisual))))
+        if (FAILED(pUnknown->QueryInterface(IID_PPV_ARGS(&spVisual))))
         {
-            return reinterpret_cast<uint64_t>(spVisual.Get());
+            return 0;
         }
-        return reinterpret_cast<uint64_t>(pUnknown);
+        return reinterpret_cast<uint64_t>(spVisual.Get());
     }
-
-    // Prefix written into a tracked visual's Comment so an out-of-process tap can locate
-    // this exact live visual by string match. There is no public "find visual by pointer"
-    // API, and dereferencing the raw IVisual* cross-process is unsafe; matching a stamped
-    // Comment on the live object is safe (the object only exists if it's still alive).
-    constexpr const WCHAR* c_visualIdCommentPrefix = L"xpid:";
 
     // Comment marker the tap stamps onto its OWN highlight adorner visual, so the producer
     // can skip emitting tree events for it (otherwise the adorner would surface as a phantom
@@ -154,29 +148,6 @@ namespace
     {
         static std::unordered_set<uint64_t> set;
         return set;
-    }
-
-    // Stamps "xpid:<hex IVisual*>" onto the visual's Comment. The id written here is
-    // identical to the VisualId() emitted over ETW, so a node the profiler clicked
-    // (node.Id) round-trips back to this exact live visual. Idempotent and cheap; only
-    // ever called from the already-IsEnabled()-gated Notify* paths below.
-    void StampVisualId(_In_opt_ WUComp::IVisual* pVisual)
-    {
-        if (pVisual == nullptr)
-        {
-            return;
-        }
-
-        // Comment lives on ICompositionObject2 (CompositionObject), not IVisual directly.
-        wrl::ComPtr<WUComp::ICompositionObject2> spObject2;
-        if (FAILED(pVisual->QueryInterface(IID_PPV_ARGS(&spObject2))))
-        {
-            return;
-        }
-
-        WCHAR comment[32];
-        swprintf_s(comment, _countof(comment), L"%s%llx", c_visualIdCommentPrefix, VisualId(pVisual));
-        spObject2->put_Comment(wrl_wrappers::HStringReference(comment).Get());
     }
 
     // True if the visual is the tap's highlight adorner (its Comment starts with the adorner
@@ -453,6 +424,13 @@ namespace WucVisualTreeProfiler
             return;
         }
 
+        const uint64_t parentVisualId = VisualId(parentVisual);
+        const uint64_t childVisualId = VisualId(childVisual);
+        if (parentVisualId == 0 || childVisualId == 0)
+        {
+            return;
+        }
+
         wrl::ComPtr<WUComp::IVisual> spChild;
         if (childVisual != nullptr)
         {
@@ -465,16 +443,12 @@ namespace WucVisualTreeProfiler
             return;
         }
 
-        // Stamp the child's identity onto its Comment so a Ctrl+Click in the profiler can
-        // resolve this exact live visual in the tap (match by Comment == "xpid:<node.Id>").
-        StampVisualId(spChild.Get());
-
         WCHAR properties[4096];
         BuildPropertiesString(spChild.Get(), properties, _countof(properties));
 
         XamlProfilerTracing::WucVisualChildInserted(
-            VisualId(parentVisual),
-            VisualId(childVisual),
+            parentVisualId,
+            childVisualId,
             ownerCompNodeId,
             index,
             GetWucVisualTypeName(spChild.Get()),
@@ -490,9 +464,16 @@ namespace WucVisualTreeProfiler
             return;
         }
 
+        const uint64_t parentVisualId = VisualId(parentVisual);
+        const uint64_t childVisualId = VisualId(childVisual);
+        if (parentVisualId == 0 || childVisualId == 0)
+        {
+            return;
+        }
+
         XamlProfilerTracing::WucVisualChildRemoved(
-            VisualId(parentVisual),
-            VisualId(childVisual));
+            parentVisualId,
+            childVisualId);
     }
 
     void NotifyChildrenCleared(_In_opt_ IUnknown* parentVisual)
@@ -502,7 +483,13 @@ namespace WucVisualTreeProfiler
             return;
         }
 
-        XamlProfilerTracing::WucVisualChildrenCleared(VisualId(parentVisual));
+        const uint64_t parentVisualId = VisualId(parentVisual);
+        if (parentVisualId == 0)
+        {
+            return;
+        }
+
+        XamlProfilerTracing::WucVisualChildrenCleared(parentVisualId);
     }
 
     void NotifyRootSet(
@@ -521,20 +508,23 @@ namespace WucVisualTreeProfiler
             return;
         }
 
+        const uint64_t visualId = VisualId(visual);
+        if (visualId == 0)
+        {
+            return;
+        }
+
         wrl::ComPtr<WUComp::IVisual> spVisual;
         if (visual != nullptr)
         {
             visual->QueryInterface(IID_PPV_ARGS(&spVisual));
         }
 
-        // Stamp the root visual's identity onto its Comment (see NotifyChildInserted).
-        StampVisualId(spVisual.Get());
-
         WCHAR properties[4096];
         BuildPropertiesString(spVisual.Get(), properties, _countof(properties));
 
         XamlProfilerTracing::WucVisualRootSet(
-            VisualId(visual),
+            visualId,
             targetId,
             ownerCompNodeId,
             GetWucVisualTypeName(spVisual.Get()),

--- a/tools/XamlProfiler/XamlProfilerApp/MainWindow.xaml.cs
+++ b/tools/XamlProfiler/XamlProfilerApp/MainWindow.xaml.cs
@@ -585,9 +585,9 @@ public sealed partial class MainWindow : Window
             {
                 if (node.Kind == TreeNodeKind.WucVisual)
                 {
-                    // WUC IVisual node: node.Id == the live IVisual* the producer stamped
-                    // into Visual.Comment ("xpid:<hex>"). The tap walks the live composition
-                    // tree to find and adorn that exact visual in place.
+                    // WUC IVisual node: node.Id is the live IVisual identity emitted by the
+                    // producer. The in-process tap walks the live composition tree and
+                    // adorns the visual with that identity.
                     _tap.HighlightVisual(node.Id);
                 }
                 else if (node.PeerHandle != 0)

--- a/tools/XamlProfiler/XamlProfilerApp/Models/ProfilerTreeStore.cs
+++ b/tools/XamlProfiler/XamlProfilerApp/Models/ProfilerTreeStore.cs
@@ -960,8 +960,8 @@ public class ProfilerTreeStore
 
     /// <summary>
     /// Pick-mode (IVisual subtree): given a composition visual id (an IVisual* — the clicked
-    /// element's GetElementVisual, by its xpid Comment or raw pointer), find the matching node
-    /// in the IVisual (WucVisual) tree, else the Composition tree, then glow that node AND its
+    /// element's GetElementVisual identity), find the matching node in the IVisual
+    /// (WucVisual) tree, else the Composition tree, then glow that node AND its
     /// entire subtree, expanding the path to it and the subtree so the glow is visible.
     /// Returns the matched node, or null if no node with that id exists in either tree.
     /// Additive: does NOT clear existing link highlights (the pick handler clears once up
@@ -975,8 +975,8 @@ public class ProfilerTreeStore
         if (node is null)
         {
             // Not in the ETW-built store yet. The tap's GetElementVisual frequently CREATES the
-            // element's hand-in visual on the spot, so the producer only emits (and xpid-stamps)
-            // it on the next render frame. Arm a pending highlight that fires the instant that
+            // element's hand-in visual on the spot, so the producer only emits it on the next
+            // render frame. Arm a pending highlight that fires the instant that
             // node arrives over ETW (see TryApplyPendingVisualHighlight).
             _pendingVisualHighlight = visualId;
             return null;

--- a/tools/XamlProfiler/XamlProfilerApp/Services/ProcessResolver.cs
+++ b/tools/XamlProfiler/XamlProfilerApp/Services/ProcessResolver.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace XamlProfiler.Services;
 
@@ -9,14 +11,26 @@ namespace XamlProfiler.Services;
 /// </summary>
 internal static class ProcessResolver
 {
+    private const int ErrorSuccess = 0;
+    private const int ErrorInsufficientBuffer = 122;
+
     /// <summary>
-    /// Heuristic: true when a process's main module path contains the package family name.
+    /// Returns true when Windows reports that the process belongs to the package family.
+    /// This works for both installed packages and loose development registrations.
     /// </summary>
     public static bool ProcessMatchesPackageFamily(Process proc, string packageFamilyName)
     {
         try
         {
-            return proc.MainModule?.FileName?.Contains(packageFamilyName, StringComparison.OrdinalIgnoreCase) == true;
+            uint length = 0;
+            int result = GetPackageFamilyName(proc.Handle, ref length, null);
+            if (result != ErrorInsufficientBuffer || length == 0)
+                return false;
+
+            var familyName = new StringBuilder((int)length);
+            result = GetPackageFamilyName(proc.Handle, ref length, familyName);
+            return result == ErrorSuccess &&
+                string.Equals(familyName.ToString(), packageFamilyName, StringComparison.OrdinalIgnoreCase);
         }
         catch
         {
@@ -26,8 +40,8 @@ internal static class ProcessResolver
     }
 
     /// <summary>
-    /// Finds the first process whose main module path contains the package family name.
-    /// Works for most packaged apps.
+    /// Finds the first process whose OS-reported package identity matches the package
+    /// family name.
     /// </summary>
     public static Process? FindProcessByPackageFamily(string packageFamilyName)
     {
@@ -100,4 +114,10 @@ internal static class ProcessResolver
 
         return fallback ?? (launched != null && match(launched) && !launched.HasExited ? launched : null);
     }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetPackageFamilyName(
+        IntPtr process,
+        ref uint packageFamilyNameLength,
+        StringBuilder? packageFamilyName);
 }

--- a/tools/XamlProfiler/XamlProfilerApp/Services/TapChannel.cs
+++ b/tools/XamlProfiler/XamlProfilerApp/Services/TapChannel.cs
@@ -60,8 +60,8 @@ internal sealed class TapChannel : IDisposable
 
     /// <summary>
     /// Raised on the worker thread alongside <see cref="ElementPicked"/>: the composition
-    /// visual id (an IVisual*, from the clicked element's GetElementVisual — its xpid stamp
-    /// or raw pointer). The profiler glows that visual node's whole subtree.
+    /// visual id (the IVisual identity from the clicked element's GetElementVisual).
+    /// The profiler glows that visual node's whole subtree.
     /// </summary>
     public event Action<ulong>? VisualPicked;
 
@@ -185,9 +185,9 @@ internal sealed class TapChannel : IDisposable
                         ElementPicked?.Invoke(picked);
                     }
 
-                    // The tap also reports the clicked element's composition visual id
-                    // (xpid stamp or raw IVisual*). The profiler uses it to glow that
-                    // visual node's whole subtree in the IVisual/Composition tree.
+                    // The tap also reports the clicked element's IVisual identity. The
+                    // profiler uses it to glow that visual node's whole subtree in the
+                    // IVisual/Composition tree.
                     if (!string.IsNullOrEmpty(msg.VisualId) &&
                         ulong.TryParse(msg.VisualId, System.Globalization.NumberStyles.HexNumber,
                             System.Globalization.CultureInfo.InvariantCulture, out ulong pickedVisual) &&
@@ -243,9 +243,9 @@ internal sealed class TapChannel : IDisposable
     public void StopPick() => WriteToTap("STOP-PICK");
 
     /// <summary>
-    /// Highlight a live IVisual / Composition-only node (no XAML peer handle). The
-    /// producer stamps each live visual's Comment with "xpid:&lt;IVisual* hex&gt;", which
-    /// equals this node's Id; the tap walks the live composition tree to find and adorn it.
+    /// Highlight a live IVisual / Composition-only node (no XAML peer handle). The tap
+    /// walks the live composition tree in-process and finds the visual whose IVisual
+    /// identity equals this node's Id.
     /// </summary>
     public void HighlightVisual(ulong visualId)
     {

--- a/tools/XamlProfiler/XamlProfilerTap/Tap.cpp
+++ b/tools/XamlProfiler/XamlProfilerTap/Tap.cpp
@@ -26,6 +26,17 @@ static void TapLog(const std::wstring& msg)
     OutputDebugString((L"[XamlProfilerTap] " + msg + L"\n").c_str());
 }
 
+static uint64_t GetVisualId(winrt::Microsoft::UI::Composition::Visual const& visual)
+{
+    if (!visual)
+    {
+        return 0;
+    }
+
+    auto visualIdentity = visual.try_as<winrt::Microsoft::UI::Composition::IVisual>();
+    return visualIdentity ? reinterpret_cast<uint64_t>(winrt::get_abi(visualIdentity)) : 0;
+}
+
 BOOL WINAPI DllMain(HMODULE hModule, DWORD reason, LPVOID)
 {
     if (reason == DLL_PROCESS_ATTACH)
@@ -462,12 +473,11 @@ void XamlProfilerTap::HighlightElement(InstanceHandle element)
 
 // Highlight an IVisual / Composition-only node (one with no XAML peer handle).
 //
-// The profiler can't resolve these via XAML Diagnostics, so the producer (in mux's
-// WucVisualTreeProfiler) stamps each live visual's Comment with "xpid:<IVisual* as hex>".
-// That hex is exactly the node.Id the profiler shows. Here we walk the live Composition
-// tree (rooted at the XamlRoot content's element visual), find the visual whose Comment
-// matches, and adorn it in place with a translucent child SpriteVisual. The adorner rides
-// the target's transform (RelativeSizeAdjustment 1,1) so no coordinate math is needed.
+// The profiler can't resolve these via XAML Diagnostics, so the injected tap walks the
+// live Composition tree and compares each visual's in-process IVisual identity with the
+// node id emitted over ETW. The matched visual is adorned in place with a translucent
+// child SpriteVisual. The adorner rides the target's transform
+// (RelativeSizeAdjustment 1,1) so no coordinate math is needed.
 void XamlProfilerTap::HighlightVisual(uint64_t visualId)
 {
     namespace WUC = winrt::Microsoft::UI::Composition;
@@ -494,12 +504,8 @@ void XamlProfilerTap::HighlightVisual(uint64_t visualId)
         return;
     }
 
-    wchar_t targetBuf[40];
-    swprintf_s(targetBuf, L"xpid:%llx", visualId);
-    std::wstring target = targetBuf;
-
     // Search every live window's composition tree (one per XamlRoot) for the visual whose
-    // Comment matches; a picked visual can live in any window, not just the first one seen.
+    // identity matches; a picked visual can live in any window, not just the first one seen.
     std::vector<winrt::Microsoft::UI::Xaml::XamlRoot> roots = m_xamlRoots;
     if (roots.empty())
     {
@@ -507,11 +513,11 @@ void XamlProfilerTap::HighlightVisual(uint64_t visualId)
         return;
     }
 
-    // Depth-first search for the visual whose Comment matches, rooted at a given host visual.
+    // Depth-first search for the visual whose identity matches, rooted at a given host visual.
     WUC::Visual found{ nullptr };
     std::function<bool(WUC::Visual const&)> dfs = [&](WUC::Visual const& v) -> bool
     {
-        if (v.Comment() == winrt::hstring(target))
+        if (GetVisualId(v) == visualId)
         {
             found = v;
             return true;
@@ -544,14 +550,16 @@ void XamlProfilerTap::HighlightVisual(uint64_t visualId)
 
         // Not in this window's tree — tell the profiler which root was searched.
         wchar_t miss[160];
-        swprintf_s(miss, L"HighlightVisual: '%s' not found in root [%zu] XamlRoot=0x%p",
-            target.c_str(), thisIndex, (void*)winrt::get_abi(root));
+        swprintf_s(miss, L"HighlightVisual: visual id 0x%llx not found in root [%zu] XamlRoot=0x%p",
+            visualId, thisIndex, (void*)winrt::get_abi(root));
         SendTapInfo(miss);
     }
 
     if (!found)
     {
-        SendTapInfo(L"HighlightVisual: no live visual with matching Comment '" + target + L"' found in any tracked root");
+        wchar_t miss[96];
+        swprintf_s(miss, L"HighlightVisual: no live visual with id 0x%llx found in any tracked root", visualId);
+        SendTapInfo(miss);
         return;
     }
 
@@ -613,7 +621,9 @@ void XamlProfilerTap::HighlightVisual(uint64_t visualId)
     m_visualAdorner = adorner;
     m_visualAdornerParent = container;
 
-    TapLog(L"HighlightVisual: adorned live visual with Comment '" + target + L"'");
+    wchar_t success[80];
+    swprintf_s(success, L"HighlightVisual: adorned live visual id 0x%llx", visualId);
+    TapLog(success);
 }
 
 void XamlProfilerTap::ClearHighlight()
@@ -829,17 +839,15 @@ void XamlProfilerTap::CommitPick(InstanceHandle handle)
 {
     if (handle)
     {
-        // Report the composition visual responsible for the clicked element (its xpid
-        // comment) to the profiler log, so the user can see the specific sprite/container.
+        // Report the composition visual responsible for the clicked element.
         LogResponsibleVisual(handle);
 
         winrt::Windows::Data::Json::JsonObject obj = winrt::Windows::Data::Json::JsonObject();
         obj.SetNamedValue(L"TapType", winrt::Windows::Data::Json::JsonValue::CreateStringValue(L"Select"));
         SetNamedPointerValue(obj, L"Handle", handle);
 
-        // Also resolve the clicked element's composition visual id (its GetElementVisual:
-        // the xpid Comment if stamped, else the raw IVisual* pointer). The profiler uses
-        // it to find that visual node and glow its whole subtree in the IVisual/Comp tree.
+        // Also resolve GetElementVisual's IVisual identity. The profiler uses it to find
+        // that visual node and glow its whole subtree in the IVisual/Comp tree.
         uint64_t visualId = ResolveElementVisualId(handle);
         if (visualId)
             SetNamedPointerValue(obj, L"VisualId", static_cast<InstanceHandle>(visualId));
@@ -853,10 +861,8 @@ void XamlProfilerTap::CommitPick(InstanceHandle handle)
     StopPick();
 }
 
-// Resolve the clicked element's composition visual to a profiler-recognizable id: the
-// element's own (hand-in) visual from GetElementVisual. If that visual's Comment carries
-// the producer's "xpid:<hex>" stamp we return that hex (matches the profiler's WucVisual
-// node Id); otherwise we return the raw IVisual* pointer (get_abi) as the id.
+// Resolve the clicked element's composition visual to the same IVisual identity emitted
+// by the producer as the WucVisual node id.
 uint64_t XamlProfilerTap::ResolveElementVisualId(InstanceHandle handle)
 {
     namespace WUC = winrt::Microsoft::UI::Composition;
@@ -874,24 +880,10 @@ uint64_t XamlProfilerTap::ResolveElementVisualId(InstanceHandle handle)
         return 0;
 
     auto v = MUXH::ElementCompositionPreview::GetElementVisual(uie);
-
-    auto comment = v.Comment();
-    if (comment.size() >= 5 && std::wstring_view(comment).substr(0, 5) == L"xpid:")
-    {
-        uint64_t id = 0;
-        if (swscanf_s(comment.c_str() + 5, L"%llx", &id) == 1 && id)
-            return id;
-    }
-
-    return reinterpret_cast<uint64_t>(winrt::get_abi(v));
+    return GetVisualId(v);
 }
 
-// Resolve the clicked element to the composition visual responsible for painting it and
-// report that visual's identity + xpid Comment back to the profiler. We start from the
-// element's own (hand-in) visual; that container usually has no xpid stamp, so we descend
-// to the nearest descendant that carries an "xpid:" Comment -- that's the sprite/container
-// the producer recognizes as this element's visual. The id is get_abi(v) == the producer's
-// xpid == the node Id shown in the profiler.
+// Report the clicked element's composition visual identity.
 void XamlProfilerTap::LogResponsibleVisual(InstanceHandle handle)
 {
     namespace WUC = winrt::Microsoft::UI::Composition;
@@ -915,58 +907,16 @@ void XamlProfilerTap::LogResponsibleVisual(InstanceHandle handle)
     }
 
     auto elementVisual = MUXH::ElementCompositionPreview::GetElementVisual(uie);
+    std::wstring kind = L"Visual";
+    if (elementVisual.try_as<WUC::SpriteVisual>())          kind = L"SpriteVisual";
+    else if (elementVisual.try_as<WUC::ContainerVisual>())  kind = L"ContainerVisual";
 
-    // Walk the element's visual subtree for the first visual carrying an "xpid:" Comment.
-    WUC::Visual responsible{ nullptr };
-    std::wstring responsibleType;
-    std::function<bool(WUC::Visual const&)> findStamped = [&](WUC::Visual const& v) -> bool
-    {
-        auto comment = v.Comment();
-        if (comment.size() >= 5 && std::wstring_view(comment).substr(0, 5) == L"xpid:")
-        {
-            responsible = v;
-            if (v.try_as<WUC::SpriteVisual>())          responsibleType = L"SpriteVisual";
-            else if (v.try_as<WUC::ContainerVisual>())  responsibleType = L"ContainerVisual";
-            else                                        responsibleType = L"Visual";
-            return true;
-        }
-        if (auto c = v.try_as<WUC::ContainerVisual>())
-        {
-            for (auto const& child : c.Children())
-            {
-                if (findStamped(child))
-                    return true;
-            }
-        }
-        return false;
-    };
-    findStamped(elementVisual);
-
-    uint64_t elementVisualId = reinterpret_cast<uint64_t>(winrt::get_abi(elementVisual));
-
-    if (responsible)
-    {
-        uint64_t id = reinterpret_cast<uint64_t>(winrt::get_abi(responsible));
-        auto size = responsible.Size();
-        wchar_t msg[256];
-        swprintf_s(msg,
-            L"ResponsibleVisual: %s id=0x%llx comment='%s' size=(%.0f,%.0f)  [elementVisual=0x%llx]",
-            responsibleType.c_str(), id, responsible.Comment().c_str(),
-            size.x, size.y, elementVisualId);
-        SendTapInfo(msg);
-    }
-    else
-    {
-        // No xpid-stamped descendant: report the element's own (hand-in) visual instead.
-        std::wstring kind = L"Visual";
-        if (elementVisual.try_as<WUC::SpriteVisual>())          kind = L"SpriteVisual";
-        else if (elementVisual.try_as<WUC::ContainerVisual>())  kind = L"ContainerVisual";
-        wchar_t msg[256];
-        swprintf_s(msg,
-            L"ResponsibleVisual: no xpid-stamped visual found; element hand-in visual is %s id=0x%llx comment='%s'",
-            kind.c_str(), elementVisualId, elementVisual.Comment().c_str());
-        SendTapInfo(msg);
-    }
+    auto size = elementVisual.Size();
+    wchar_t msg[256];
+    swprintf_s(msg,
+        L"ResponsibleVisual: %s id=0x%llx size=(%.0f,%.0f)",
+        kind.c_str(), GetVisualId(elementVisual), size.x, size.y);
+    SendTapInfo(msg);
 }
 
 // Build the stack of overlapping elements at a point (in XamlRoot/host coordinates),

--- a/tools/XamlProfiler/docs/frameworksidechanges.md
+++ b/tools/XamlProfiler/docs/frameworksidechanges.md
@@ -222,15 +222,18 @@ island, windowed-popup).
 
 ---
 
-## 9. IVisual live-highlight support — `Comment` identity stamping
+## 9. IVisual live-highlight support — in-process identity matching
 
 To make a WUC node highlightable live (it has no DXaml peer and there is no
-"find visual by pointer" API), the producer stamps each live visual's writable
-`Comment` (via `ICompositionObject2`) with `xpid:<hex IVisual*>` — the **same
-hex** the profiler shows as the node id — inside `NotifyChildInserted` /
-`NotifyRootSet`. The tap later DFS-walks the live tree matching that `Comment`.
-An `__xp_adorner` comment prefix marks the tap's own overlay so the producer
-**skips** it (`IsProfilerAdorner`) and it never surfaces as a phantom node.
+"find visual by pointer" API), the producer emits the normalized `IVisual*`
+identity as the node id. The injected tap runs in the target process, so it can
+DFS-walk the live tree and compare the ABI pointer of each candidate's `IVisual`
+interface with that id. This value is a transient, same-process, same-interface
+identity token: the profiler never dereferences it, and the producer suppresses
+the event if the source object cannot be normalized to `IVisual`. An
+`__xp_adorner` comment prefix marks the tap's own overlay so the producer **skips** it
+(`IsProfilerAdorner`) and it never surfaces as a phantom node. App-provided
+visual comments remain unchanged.
 
 **Detailed doc:** `resources/ivisual-live-highlight.md`.
 
@@ -263,7 +266,7 @@ phantom nodes in the very tree being inspected. Suppression is producer-side:
 | --- | --- |
 | `dxaml/xcp/components/base/inc/XamlProfilerTracing.h` | The provider + **all** event schemas; `XamlProfilerGetPeerHandle` declaration |
 | `dxaml/xcp/components/comptree/inc/WucVisualTreeProfiler.h` | **New.** WUC notify API + comp-node suppression API |
-| `dxaml/xcp/components/comptree/WucVisualTreeProfiler.cpp` | **New.** WUC serialization, `IsEnabled()` gating, `Comment` stamping, suppression registry |
+| `dxaml/xcp/components/comptree/WucVisualTreeProfiler.cpp` | **New.** WUC serialization, `IsEnabled()` gating, `IVisual` identity normalization, suppression registry |
 | `dxaml/xcp/components/comptree/lib/Microsoft.UI.Xaml.CompTree.vcxproj` | Registered the new `.cpp` in `ClCompile` |
 | `dxaml/xcp/components/comptree/HWCompNodeWinRT.cpp` | Sync comp-node events; WUC spine/inter-node/hand-in/DManip/reparent/bulk-clear edges |
 | `dxaml/xcp/components/comptree/DCompTreeHost.cpp` | WUC in-proc island + Xaml-island root attach (`WucVisualRootSet`) |
@@ -325,6 +328,6 @@ need rebuilding when only the producer changes.
 | `resources/peer-handle-live-highlight-phase2.md` | §6 tap consumption |
 | `resources/producer-side-sync-comp-node-events.md` | §7 sync comp-node events |
 | `resources/addingisvisualtree.md` | §8 full WUC tree (producer + consumer) |
-| `resources/ivisual-live-highlight.md` | §9 `Comment` stamping + IVisual highlight |
+| `resources/ivisual-live-highlight.md` | §9 in-process IVisual identity matching |
 | `resources/pick-overlay-etl-suppression.md` | §10 pick-overlay suppression |
 | `resources/visual-tree-cross-connection.md` | Consumer cross-tree linkage (uses these ids) |

--- a/tools/XamlProfiler/docs/profilerworking.md
+++ b/tools/XamlProfiler/docs/profilerworking.md
@@ -272,7 +272,7 @@ with `ERROR_NOT_FOUND 0x80070490`):
 | Command | Effect |
 | --- | --- |
 | `HIGHLIGHT: %p` | Resolve `InstanceHandle` → `FrameworkElement`, draw overlay `SpriteVisual`s over its bounds (`TransformToVisual(xamlRoot.Content)` + `ElementCompositionPreview.SetElementChildVisual`) |
-| `HIGHLIGHT-VISUAL: %llx` | IVisual path (§9) — DFS the live comp tree, match `Comment == "xpid:<id>"`, add an in-place translucent child adorner |
+| `HIGHLIGHT-VISUAL: %llx` | IVisual path (§9) — DFS the live comp tree, match the live `IVisual` identity, add an in-place translucent child adorner |
 | `CLEAR-HIGHLIGHT` | Remove element overlay + in-place adorner |
 | `START-PICK` / `STOP-PICK` | Enter / leave app→profiler pick mode (§10) |
 | `CLOSE` | Tear down; profiler then ejects the DLL via remote `CreateRemoteThread(FreeLibrary)` |
@@ -292,19 +292,21 @@ were removed in the UI-cleanup pass; the tap is now just highlight + pick.)
 
 ---
 
-## 9. IVisual live highlight — the `Comment` trick
+## 9. IVisual live highlight — in-process identity matching
 
 A WUC visual has no DXaml peer and there is no "find visual by pointer" API, and
-its `IVisual*` id belongs to the **target** process (unsafe to deref from the
-profiler). So identity is carried in the visual's writable **`Comment`**: the
-producer stamps every live visual `Comment = "xpid:<hex IVisual*>"` — the *same
-hex* the profiler shows as `node.Id`. The tap's `HighlightVisual(id)` DFS-walks
-the live composition tree (from
-`ElementCompositionPreview.GetElementVisual(xamlRoot.Content)`), matches
-`Comment == "xpid:<id>"`, and adds a translucent child `SpriteVisual` stamped
-`Comment = "__xp_adorner"` with `RelativeSizeAdjustment {1,1}` (no coordinate
-math). The `__xp_adorner` sentinel makes the producer **skip** the overlay so it
-never appears as a phantom node. Full detail: `resources/ivisual-live-highlight.md`.
+its `IVisual*` id belongs to the **target** process (unsafe to dereference from
+the profiler). The profiler sends that id to the injected tap, which runs inside
+the target process. `HighlightVisual(id)` DFS-walks the live composition tree
+(from `ElementCompositionPreview.GetElementVisual(xamlRoot.Content)`) and
+explicitly obtains each candidate's `IVisual` interface and compares its ABI
+pointer with the requested id. The id is a transient, same-process,
+same-interface identity token; neither the profiler nor the tap dereferences the
+received value. The tap then adds a
+translucent child `SpriteVisual` stamped `Comment = "__xp_adorner"` with
+`RelativeSizeAdjustment {1,1}` (no coordinate math). The `__xp_adorner`
+sentinel makes the producer **skip** the profiler-owned overlay so it never
+appears as a phantom node. App-provided comments are never modified.
 
 ---
 
@@ -366,6 +368,6 @@ element's `PeerHandle` (or picked `IVisual`) only arrives over ETW a frame later
 | `resources/feature-is-template-child.md` | Developer-only logical tree filter |
 | `resources/feature-resolved-summary-names.md` | Resolved names in the history pane |
 | `resources/peer-handle-live-highlight-phase1.md` / `…phase2.md` | Peer-handle emission + element tap |
-| `resources/ivisual-live-highlight.md` | WUC `Comment` highlight |
+| `resources/ivisual-live-highlight.md` | WUC in-process `IVisual` identity highlight |
 | `resources/pick-overlay-etl-suppression.md` | Pick-overlay suppression |
 | `resources/producer-side-component-labels.md`, `resources/producer-side-sync-comp-node-events.md` | Individual producer changes |


### PR DESCRIPTION
## Fixes

<!-- Link either the public GitHub issue or the internal issue this PR addresses. Remove the unused line. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->

Fixes #
Internal Issue: https://task.ms/<ado-bug-id>

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

Xaml profiler needs traces which are under compile time flag XamlProfilerEnabled. This flag is currently disabled. This change enables it for debug build. It will remain off for release builds.

### Current Behavior
XamlProfilerEnabled disabled

### New Behavior
XamlProfilerEnabled enabled only for debug builds

## Customer Impact

NA

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

## Screenshots (if appropriate)

<!-- If you are making visual changes, include before/after screenshots. -->