### PR TITLE
TableView: close the remaining UIA accessibility gaps

### DIFF
--- a/controls/dev/ResourceHelper/ResourceAccessor.h
+++ b/controls/dev/ResourceHelper/ResourceAccessor.h
@@ -158,6 +158,7 @@ public:
 #define SR_ResizeGripperName L"ResizeGripperName"
 #define SR_ResizeGripperNameFormat L"ResizeGripperNameFormat"
 #define SR_TableViewColumnWidthChanged L"TableViewColumnWidthChanged"
+#define SR_TableViewCellLocalizedControlType L"TableViewCellLocalizedControlType"
 #define SR_InkToolbarStrokeEraserLabel L"InkToolbarStrokeEraserLabel"
 #define SR_InkToolbarSmallEraserLabel L"InkToolbarSmallEraserLabel"
 #define SR_InkToolbarLargeEraserLabel L"InkToolbarLargeEraserLabel"

--- a/controls/dev/TableView/Strings/en-us/Resources.resw
+++ b/controls/dev/TableView/Strings/en-us/Resources.resw
@@ -108,6 +108,10 @@
     <value>Column %1!s! width: %2!s! pixels.</value>
     <comment>Assistive-technology announcement raised when a TableView column is resized, by pointer or by keyboard, while its header has focus. %1!s! is the column header text; %2!s! is the whole-pixel width.</comment>
   </data>
+  <data name="TableViewCellLocalizedControlType" xml:space="preserve">
+    <value>cell</value>
+    <comment>Localized control type announced by assistive technology for a single cell in a TableView. Lower case: screen readers read it inline after the cell's name.</comment>
+  </data>
   <!-- Sort direction names (used in SaveLayoutToJson serialization — not localized at runtime but
        kept here for documentation; code uses invariant English for round-trip fidelity) -->
 </root>

--- a/controls/dev/TableView/TableView.cpp
+++ b/controls/dev/TableView/TableView.cpp
@@ -1553,10 +1553,9 @@ void TableView::RebuildHeaders()
             // focusing it can actually do something -- otherwise every column costs a Tab press for
             // nothing.
             //
-            // "Actually do something" is resize OR sort. Gating on resize alone left the very common
-            // CanUserSortColumns=true / CanUserResizeColumns=false configuration with a header that
-            // is clickable-to-sort but unreachable by keyboard, so a keyboard-only user could never
-            // sort -- and TableViewColumnHeaderAutomationPeer::Invoke was never reachable by focus.
+            // Actionable is resize OR sort: gating on resize alone left the common
+            // CanUserSortColumns=true / CanUserResizeColumns=false case with a header that sorts on
+            // click but has no tab stop, so a keyboard-only user could never sort it.
             const bool headerIsResizable = CanUserResizeColumns() && column.CanResize();
             const bool headerIsSortable = canUserSortColumns && column.CanSort();
             const bool headerIsActionable = headerIsResizable || headerIsSortable;

--- a/controls/dev/TableView/TableView.cpp
+++ b/controls/dev/TableView/TableView.cpp
@@ -285,6 +285,18 @@ TableView::TableView()
     // AddHandler takes the handler as IInspectable, so the delegate must be boxed (see RoutedEventHelpers.h).
     AddHandler(winrt::UIElement::KeyDownEvent(), winrt::box_value(m_keyDownHandler), true /* handledEventsToo */);
 
+    // Space on a focused header arms on key down and sorts here, on key up. handledEventsToo:
+    // the ancestor ScrollViewer marks Space handled for page-scrolling.
+    m_keyUpHandler = winrt::KeyEventHandler(
+        [weakThis](winrt::IInspectable const& sender, winrt::KeyRoutedEventArgs const& args)
+        {
+            if (auto strongThis = weakThis.get())
+            {
+                strongThis->OnKeyUpForHeaderSort(sender, args);
+            }
+        });
+    AddHandler(winrt::UIElement::KeyUpEvent(), winrt::box_value(m_keyUpHandler), true /* handledEventsToo */);
+
     // Tunneling PreviewKeyDown runs before the framework's built-in focus navigation; snapshot the
     // currently focused row there so OnKeyDownForNavigation anchors on the pre-move index.
     m_previewKeyDownHandler = winrt::KeyEventHandler(

--- a/controls/dev/TableView/TableView.cpp
+++ b/controls/dev/TableView/TableView.cpp
@@ -1551,10 +1551,17 @@ void TableView::RebuildHeaders()
             // The header cell, not the gripper, is the keyboard target: column commands live here,
             // and a bare focusable Grid is unnamed and Raw to a screen reader. Only a tab stop when
             // focusing it can actually do something -- otherwise every column costs a Tab press for
-            // nothing. Same condition that decides whether a gripper is created at all.
+            // nothing.
+            //
+            // "Actually do something" is resize OR sort. Gating on resize alone left the very common
+            // CanUserSortColumns=true / CanUserResizeColumns=false configuration with a header that
+            // is clickable-to-sort but unreachable by keyboard, so a keyboard-only user could never
+            // sort -- and TableViewColumnHeaderAutomationPeer::Invoke was never reachable by focus.
             const bool headerIsResizable = CanUserResizeColumns() && column.CanResize();
-            headerCell.IsTabStop(headerIsResizable);
-            headerCell.UseSystemFocusVisuals(headerIsResizable);
+            const bool headerIsSortable = canUserSortColumns && column.CanSort();
+            const bool headerIsActionable = headerIsResizable || headerIsSortable;
+            headerCell.IsTabStop(headerIsActionable);
+            headerCell.UseSystemFocusVisuals(headerIsActionable);
             const winrt::hstring headerText = GetColumnHeaderText(column);
             if (!headerText.empty())
             {
@@ -1609,7 +1616,7 @@ void TableView::RebuildHeaders()
 
             // Sort affordance. Gated on both the control-wide and the per-column opt-in, so an
             // opted-out column carries no chevron and no click handler at all.
-            if (canUserSortColumns && column.CanSort())
+            if (headerIsSortable)
             {
                 // The header cell is a Grid, and a Grid with a null Background is not hit-test
                 // visible in its empty regions. The header content presenter and the chevron host

--- a/controls/dev/TableView/TableView.h
+++ b/controls/dev/TableView/TableView.h
@@ -863,6 +863,9 @@ private:
     // Left/Right resize for the column whose header has focus; the gripper is a pointer
     // affordance here, not a tab stop.
     bool TryHandleHeaderColumnResizeKey(const winrt::KeyRoutedEventArgs& args);
+    // Enter / Space on a focused, sortable column header. Paired with the header cell's tab stop,
+    // this is the keyboard path to sorting.
+    bool TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args);
     // Redirects a header's bring-into-view onto the body scroller, so the header cannot scroll
     // independently of the columns it labels.
     void OnHeaderBringIntoViewRequested(const winrt::BringIntoViewRequestedEventArgs& args);

--- a/controls/dev/TableView/TableView.h
+++ b/controls/dev/TableView/TableView.h
@@ -863,8 +863,7 @@ private:
     // Left/Right resize for the column whose header has focus; the gripper is a pointer
     // affordance here, not a tab stop.
     bool TryHandleHeaderColumnResizeKey(const winrt::KeyRoutedEventArgs& args);
-    // Enter / Space on a focused, sortable column header. Paired with the header cell's tab stop,
-    // this is the keyboard path to sorting.
+    // Enter / Space on a focused, sortable column header: the keyboard path to sorting.
     bool TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args);
     // Redirects a header's bring-into-view onto the body scroller, so the header cannot scroll
     // independently of the columns it labels.

--- a/controls/dev/TableView/TableView.h
+++ b/controls/dev/TableView/TableView.h
@@ -865,6 +865,16 @@ private:
     bool TryHandleHeaderColumnResizeKey(const winrt::KeyRoutedEventArgs& args);
     // Enter / Space on a focused, sortable column header: the keyboard path to sorting.
     bool TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args);
+    // Space completes on key up, per XAML activation semantics.
+    bool TryHandleHeaderSortKeyUp(const winrt::KeyRoutedEventArgs& args);
+    winrt::TableViewColumn ResolveHeaderSortKeyTarget(const winrt::KeyRoutedEventArgs& args);
+    // Set while Space is held on a sortable header, cleared when it is released or the key up
+    // lands somewhere else.
+    winrt::weak_ref<winrt::TableViewColumn> m_headerSortSpaceArmedColumn{ nullptr };
+    winrt::KeyEventHandler m_keyUpHandler{ nullptr };
+    void OnKeyUpForHeaderSort(
+        const winrt::IInspectable& sender,
+        const winrt::KeyRoutedEventArgs& args);
     // Redirects a header's bring-into-view onto the body scroller, so the header cannot scroll
     // independently of the columns it labels.
     void OnHeaderBringIntoViewRequested(const winrt::BringIntoViewRequestedEventArgs& args);

--- a/controls/dev/TableView/TableViewAutomationHelpers.h
+++ b/controls/dev/TableView/TableViewAutomationHelpers.h
@@ -4,11 +4,27 @@
 #pragma once
 
 #include <optional>
+#include <string_view>
 #include "TableViewColumn.h"
+#include "ResourceAccessor.h"
 
 // Shared helpers for the TableView automation peers, so the visible-column and column-header-string
 // logic lives in one place instead of being copy-pasted across the peer translation units. Assumes
 // pch.h (winrt type aliases) is included first, per the TableView header convention.
+
+// Resource lookups feeding UIA are supplementary: degrade instead of letting a missing PRI (a host
+// app that does not merge the control's resources) escape into a UIA call.
+inline winrt::hstring TryGetLocalizedString(const std::wstring_view& resourceName)
+{
+    try
+    {
+        return ResourceAccessor::GetLocalizedStringResource(resourceName);
+    }
+    catch (...)
+    {
+        return {};
+    }
+}
 
 inline bool IsVisibleColumn(winrt::TableViewColumn const& column)
 {
@@ -26,6 +42,52 @@ inline int32_t CountVisibleColumns(winrt::IVector<winrt::TableViewColumn> const&
         }
     }
     return count;
+}
+
+// Returns the text a cell displays: the column-generated TextBlock's text where there is one, and
+// otherwise the content's own computed UIA name. Shared so a cell's name and the row name composed
+// from its cells can never disagree about what a cell shows.
+//
+// allowPeerCreation gates the fallback, because CreatePeerForElement does not merely read a name -
+// it creates and permanently attaches an automation peer to the element. A cell peer asking for its
+// own single cell is worth that; the row name, which walks every cell on every UIA name query,
+// is not, so it passes false and simply contributes nothing for template content.
+inline winrt::hstring GetCellDisplayText(winrt::FrameworkElement const& cell, bool allowPeerCreation = true)
+{
+    if (!cell)
+    {
+        return {};
+    }
+
+    // The cell wrapper's child is the column-generated content.
+    winrt::FrameworkElement content{ nullptr };
+    if (auto const border = cell.try_as<winrt::Border>())
+    {
+        content = border.Child().try_as<winrt::FrameworkElement>();
+    }
+    if (!content)
+    {
+        content = cell;
+    }
+
+    // Common text-column case: read the generated TextBlock.
+    if (auto const textBlock = content.try_as<winrt::TextBlock>())
+    {
+        return textBlock.Text();
+    }
+
+    if (!allowPeerCreation)
+    {
+        return {};
+    }
+
+    // Template content uses the standard UIA name computation.
+    if (auto const peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(content))
+    {
+        return peer.GetName();
+    }
+
+    return {};
 }
 
 // Returns the column Header's string form (an IStringable, or a String-typed IPropertyValue), or

--- a/controls/dev/TableView/TableViewAutomationHelpers.h
+++ b/controls/dev/TableView/TableViewAutomationHelpers.h
@@ -44,14 +44,12 @@ inline int32_t CountVisibleColumns(winrt::IVector<winrt::TableViewColumn> const&
     return count;
 }
 
-// Returns the text a cell displays: the column-generated TextBlock's text where there is one, and
-// otherwise the content's own computed UIA name. Shared so a cell's name and the row name composed
-// from its cells can never disagree about what a cell shows.
+// Returns the text a cell displays: the column-generated TextBlock's text, else the content's own
+// computed UIA name. Shared so a cell's name and the row name composed from its cells agree.
 //
-// allowPeerCreation gates the fallback, because CreatePeerForElement does not merely read a name -
-// it creates and permanently attaches an automation peer to the element. A cell peer asking for its
-// own single cell is worth that; the row name, which walks every cell on every UIA name query,
-// is not, so it passes false and simply contributes nothing for template content.
+// allowPeerCreation gates the fallback: CreatePeerForElement does not just read a name, it creates
+// and permanently attaches a peer. Worth it for a cell naming itself; not for the row name, which
+// walks every cell on every name query, so it passes false and skips template content.
 inline winrt::hstring GetCellDisplayText(winrt::FrameworkElement const& cell, bool allowPeerCreation = true)
 {
     if (!cell)
@@ -59,7 +57,6 @@ inline winrt::hstring GetCellDisplayText(winrt::FrameworkElement const& cell, bo
         return {};
     }
 
-    // The cell wrapper's child is the column-generated content.
     winrt::FrameworkElement content{ nullptr };
     if (auto const border = cell.try_as<winrt::Border>())
     {
@@ -70,7 +67,6 @@ inline winrt::hstring GetCellDisplayText(winrt::FrameworkElement const& cell, bo
         content = cell;
     }
 
-    // Common text-column case: read the generated TextBlock.
     if (auto const textBlock = content.try_as<winrt::TextBlock>())
     {
         return textBlock.Text();
@@ -81,7 +77,6 @@ inline winrt::hstring GetCellDisplayText(winrt::FrameworkElement const& cell, bo
         return {};
     }
 
-    // Template content uses the standard UIA name computation.
     if (auto const peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(content))
     {
         return peer.GetName();

--- a/controls/dev/TableView/TableViewAutomationHelpers.h
+++ b/controls/dev/TableView/TableViewAutomationHelpers.h
@@ -31,6 +31,38 @@ inline bool IsVisibleColumn(winrt::TableViewColumn const& column)
     return column && column.Visibility() == winrt::Visibility::Visible;
 }
 
+// Stringifies a data item for UIA. Shared by the TableView peer's item search and the row peer's
+// name fallback, so both describe the same item the same way.
+inline winrt::hstring ItemToName(winrt::IInspectable const& item)
+{
+    // Boxed WinRT primitives surface as IPropertyValue, not IStringable.
+    if (auto const propValue = item.try_as<winrt::IPropertyValue>())
+    {
+        switch (propValue.Type())
+        {
+        case winrt::PropertyType::String:  return propValue.GetString();
+        case winrt::PropertyType::Boolean: return propValue.GetBoolean() ? winrt::hstring{ L"True" } : winrt::hstring{ L"False" };
+        case winrt::PropertyType::Int16:   return winrt::to_hstring(static_cast<int32_t>(propValue.GetInt16()));
+        case winrt::PropertyType::Int32:   return winrt::to_hstring(propValue.GetInt32());
+        case winrt::PropertyType::Int64:   return winrt::to_hstring(propValue.GetInt64());
+        case winrt::PropertyType::UInt8:   return winrt::to_hstring(static_cast<uint32_t>(propValue.GetUInt8()));
+        case winrt::PropertyType::UInt16:  return winrt::to_hstring(static_cast<uint32_t>(propValue.GetUInt16()));
+        case winrt::PropertyType::UInt32:  return winrt::to_hstring(propValue.GetUInt32());
+        case winrt::PropertyType::UInt64:  return winrt::to_hstring(propValue.GetUInt64());
+        case winrt::PropertyType::Single:  return winrt::to_hstring(propValue.GetSingle());
+        case winrt::PropertyType::Double:  return winrt::to_hstring(propValue.GetDouble());
+        default: break;
+        }
+    }
+
+    if (auto const stringable = item.try_as<winrt::IStringable>())
+    {
+        return stringable.ToString();
+    }
+
+    return {};
+}
+
 inline int32_t CountVisibleColumns(winrt::IVector<winrt::TableViewColumn> const& columns)
 {
     int32_t count = 0;

--- a/controls/dev/TableView/TableViewAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewAutomationPeer.cpp
@@ -429,36 +429,6 @@ winrt::AutomationPeer TableViewAutomationPeer::GetOrCreateColumnHeaderPeer(
     return peer;
 }
 
-static winrt::hstring ItemToName(winrt::IInspectable const& item)
-{
-    // Boxed WinRT primitives surface as IPropertyValue, not IStringable.
-    if (auto const propValue = item.try_as<winrt::IPropertyValue>())
-    {
-        switch (propValue.Type())
-        {
-        case winrt::PropertyType::String:  return propValue.GetString();
-        case winrt::PropertyType::Boolean: return propValue.GetBoolean() ? winrt::hstring{ L"True" } : winrt::hstring{ L"False" };
-        case winrt::PropertyType::Int16:   return winrt::to_hstring(static_cast<int32_t>(propValue.GetInt16()));
-        case winrt::PropertyType::Int32:   return winrt::to_hstring(propValue.GetInt32());
-        case winrt::PropertyType::Int64:   return winrt::to_hstring(propValue.GetInt64());
-        case winrt::PropertyType::UInt8:   return winrt::to_hstring(static_cast<uint32_t>(propValue.GetUInt8()));
-        case winrt::PropertyType::UInt16:  return winrt::to_hstring(static_cast<uint32_t>(propValue.GetUInt16()));
-        case winrt::PropertyType::UInt32:  return winrt::to_hstring(propValue.GetUInt32());
-        case winrt::PropertyType::UInt64:  return winrt::to_hstring(propValue.GetUInt64());
-        case winrt::PropertyType::Single:  return winrt::to_hstring(propValue.GetSingle());
-        case winrt::PropertyType::Double:  return winrt::to_hstring(propValue.GetDouble());
-        default: break;
-        }
-    }
-
-    if (auto const stringable = item.try_as<winrt::IStringable>())
-    {
-        return stringable.ToString();
-    }
-
-    return {};
-}
-
 static winrt::hstring StringPropertyValue(winrt::IInspectable const& value)
 {
     if (auto const propValue = value.try_as<winrt::IPropertyValue>())
@@ -523,25 +493,32 @@ winrt::IRawElementProviderSimple TableViewAutomationPeer::FindItemByProperty(
         return nullptr;
     }
 
-    // Resolve startAfter through its owning realized TableViewRow.
+    // Resolve startAfter through its owning realized repeater child.
     int32_t startIndex = -1;
     if (startAfter)
     {
+        // Any child of the rows repeater is a valid anchor - a data row or a group-header band.
+        // Matching only TableViewRow left startIndex at -1 for a group header, and the search then
+        // restarted at item 0 - which under grouping IS that header, so a client enumerating the
+        // container never advanced past the first group.
+        bool resolved = false;
         if (auto const startPeer = PeerFromProvider(startAfter).try_as<winrt::FrameworkElementAutomationPeer>())
         {
-            if (auto const ownerRow = startPeer.Owner().try_as<winrt::TableViewRow>())
+            if (auto const ownerElement = startPeer.Owner().try_as<winrt::UIElement>())
             {
-                const int32_t rowIndex = repeater.GetElementIndex(ownerRow);
-                if (rowIndex >= 0)
+                if (const int32_t index = repeater.GetElementIndex(ownerElement); index >= 0)
                 {
-                    startIndex = rowIndex;
-                }
-                else
-                {
-                    // Avoid restarting at item 0 after startAfter has been virtualized away.
-                    return nullptr;
+                    startIndex = index;
+                    resolved = true;
                 }
             }
+        }
+
+        // An unresolvable startAfter - virtualized away, or not one of ours - must not degrade to
+        // "start from the beginning": that turns a wrong answer into an enumeration that never ends.
+        if (!resolved)
+        {
+            return nullptr;
         }
     }
 

--- a/controls/dev/TableView/TableViewAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewAutomationPeer.cpp
@@ -259,9 +259,8 @@ winrt::IRawElementProviderSimple TableViewAutomationPeer::GetItem(int32_t row, i
 
     if (auto const cellFE = cellElement.try_as<winrt::FrameworkElement>())
     {
-        // Routed through the row's peer so grid addressing and tree navigation hand back the SAME
-        // provider for a cell. UIA compares providers by identity, so a fresh peer per query looks
-        // like a different element and drops Narrator focus.
+        // Through the row's peer so IGridProvider::GetItem and tree navigation hand back the same
+        // provider; UIA compares providers by identity.
         auto const owningColumn = rowImpl->GetCellOwningColumn(cellElement);
         if (auto const rowPeer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(rowElement)
                 .try_as<winrt::TableViewRowAutomationPeer>())
@@ -415,10 +414,8 @@ winrt::AutomationPeer TableViewAutomationPeer::GetOrCreateColumnHeaderPeer(
     // TableViewColumnHeaderAutomationPeer supplies its own per-column RuntimeId and AutomationId
     // to keep the headers distinguishable despite the shared owner.
     //
-    // Cached on miss, not only by GetColumnHeaders: a cell's ITableItemProvider::GetColumnHeaderItems
-    // can be the first - or only - path a client takes to a header, and it must still get a provider
-    // whose identity survives the next query. Released columns are pruned here so a lookup miss
-    // cannot grow the cache without bound.
+    // Cached on miss, not only by GetColumnHeaders: GetColumnHeaderItems can be the only path a
+    // client takes to a header. Released columns are pruned here so misses cannot grow the cache.
     winrt::AutomationPeer const peer = winrt::make<TableViewColumnHeaderAutomationPeer>(tableView, column);
 
     m_columnHeaderPeerCache.erase(

--- a/controls/dev/TableView/TableViewAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewAutomationPeer.cpp
@@ -375,7 +375,7 @@ winrt::com_array<winrt::IRawElementProviderSimple> TableViewAutomationPeer::GetC
                 // The peer is cached even when it currently has no provider: ProviderFromPeer only
                 // yields one for a peer UIA has connected, so a transiently unconnected peer must
                 // keep its identity for the next enumeration rather than being rebuilt.
-                liveCache.push_back({ winrt::make_weak(column), headerPeer });
+                liveCache.emplace_back(this, column, headerPeer);
 
                 // A provider array must not contain nulls - UIA marshals every element.
                 if (auto const provider = ProviderFromPeer(headerPeer))
@@ -407,7 +407,7 @@ winrt::AutomationPeer TableViewAutomationPeer::GetOrCreateColumnHeaderPeer(
     {
         if (entry.peer && entry.column.get() == column)
         {
-            return entry.peer;
+            return entry.peer.get();
         }
     }
 
@@ -428,7 +428,7 @@ winrt::AutomationPeer TableViewAutomationPeer::GetOrCreateColumnHeaderPeer(
             [](ColumnHeaderPeerCacheEntry const& entry) { return !entry.peer || !entry.column.get(); }),
         m_columnHeaderPeerCache.end());
 
-    m_columnHeaderPeerCache.push_back({ winrt::make_weak(column), peer });
+    m_columnHeaderPeerCache.emplace_back(this, column, peer);
     return peer;
 }
 

--- a/controls/dev/TableView/TableViewAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewAutomationPeer.cpp
@@ -9,8 +9,11 @@
 #include "TableViewAutomationPeer.h"
 #include "TableViewColumnHeaderAutomationPeer.h"
 #include "TableViewCellAutomationPeer.h"
+#include "TableViewRowAutomationPeer.h"
 #include "TableViewAutomationHelpers.h"
 #include "TableViewAutomationPeer.properties.cpp"
+
+#include <algorithm>
 
 TableViewAutomationPeer::TableViewAutomationPeer(winrt::TableView const& owner)
     : ReferenceTracker(owner)
@@ -256,8 +259,20 @@ winrt::IRawElementProviderSimple TableViewAutomationPeer::GetItem(int32_t row, i
 
     if (auto const cellFE = cellElement.try_as<winrt::FrameworkElement>())
     {
-        // Return the same rich cell peer used for tree navigation.
+        // Routed through the row's peer so grid addressing and tree navigation hand back the SAME
+        // provider for a cell. UIA compares providers by identity, so a fresh peer per query looks
+        // like a different element and drops Narrator focus.
         auto const owningColumn = rowImpl->GetCellOwningColumn(cellElement);
+        if (auto const rowPeer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(rowElement)
+                .try_as<winrt::TableViewRowAutomationPeer>())
+        {
+            if (auto const cellPeer = winrt::get_self<TableViewRowAutomationPeer>(rowPeer)
+                    ->GetOrCreateCellPeer(cellFE, owningColumn, column))
+            {
+                return ProviderFromPeer(cellPeer);
+            }
+        }
+
         winrt::AutomationPeer const cellPeer =
             winrt::make<TableViewCellAutomationPeer>(cellFE, rowElement, owningColumn, column);
         return ProviderFromPeer(cellPeer);
@@ -399,7 +414,22 @@ winrt::AutomationPeer TableViewAutomationPeer::GetOrCreateColumnHeaderPeer(
     // The TableView owns the peer so headers stay enumerable before their templates realize;
     // TableViewColumnHeaderAutomationPeer supplies its own per-column RuntimeId and AutomationId
     // to keep the headers distinguishable despite the shared owner.
-    return winrt::make<TableViewColumnHeaderAutomationPeer>(tableView, column);
+    //
+    // Cached on miss, not only by GetColumnHeaders: a cell's ITableItemProvider::GetColumnHeaderItems
+    // can be the first - or only - path a client takes to a header, and it must still get a provider
+    // whose identity survives the next query. Released columns are pruned here so a lookup miss
+    // cannot grow the cache without bound.
+    winrt::AutomationPeer const peer = winrt::make<TableViewColumnHeaderAutomationPeer>(tableView, column);
+
+    m_columnHeaderPeerCache.erase(
+        std::remove_if(
+            m_columnHeaderPeerCache.begin(),
+            m_columnHeaderPeerCache.end(),
+            [](ColumnHeaderPeerCacheEntry const& entry) { return !entry.peer || !entry.column.get(); }),
+        m_columnHeaderPeerCache.end());
+
+    m_columnHeaderPeerCache.push_back({ winrt::make_weak(column), peer });
+    return peer;
 }
 
 static winrt::hstring ItemToName(winrt::IInspectable const& item)

--- a/controls/dev/TableView/TableViewAutomationPeer.h
+++ b/controls/dev/TableView/TableViewAutomationPeer.h
@@ -50,9 +50,8 @@ public:
     // of the TableView peer may be stale.
     void RaiseStructureChangedForGroupExpansion();
 
-    // Internal — the single source of column-header peer identity. Also called by
-    // TableViewCellAutomationPeer::GetColumnHeaderItems so a cell's header reference and the
-    // table's header enumeration resolve to the same provider.
+    // Internal — the single source of column-header peer identity, shared with
+    // TableViewCellAutomationPeer::GetColumnHeaderItems.
     winrt::AutomationPeer GetOrCreateColumnHeaderPeer(
         winrt::TableView const& tableView,
         winrt::TableViewColumn const& column);
@@ -63,8 +62,7 @@ private:
     // peer per call yields unstable provider identity and leaves the returned providers with no
     // owner keeping them alive.
     //
-    // The peer is held in a tracker_ref, the repo convention for a strong WinRT reference owned by
-    // a ReferenceTracker type, so the reference tracker can walk this edge and collect cycles.
+    // tracker_ref is the convention for a strong WinRT ref owned by a ReferenceTracker type.
     struct ColumnHeaderPeerCacheEntry
     {
         ColumnHeaderPeerCacheEntry(

--- a/controls/dev/TableView/TableViewAutomationPeer.h
+++ b/controls/dev/TableView/TableViewAutomationPeer.h
@@ -50,6 +50,13 @@ public:
     // of the TableView peer may be stale.
     void RaiseStructureChangedForGroupExpansion();
 
+    // Internal — the single source of column-header peer identity. Also called by
+    // TableViewCellAutomationPeer::GetColumnHeaderItems so a cell's header reference and the
+    // table's header enumeration resolve to the same provider.
+    winrt::AutomationPeer GetOrCreateColumnHeaderPeer(
+        winrt::TableView const& tableView,
+        winrt::TableViewColumn const& column);
+
 private:
     // One peer per column, kept alive for as long as the column stays in Columns(). Each call
     // to GetColumnHeaders must hand back the same provider for a given column: minting a fresh
@@ -60,10 +67,6 @@ private:
         winrt::weak_ref<winrt::TableViewColumn> column{ nullptr };
         winrt::AutomationPeer peer{ nullptr };
     };
-
-    winrt::AutomationPeer GetOrCreateColumnHeaderPeer(
-        winrt::TableView const& tableView,
-        winrt::TableViewColumn const& column);
 
     void RaiseStructureChanged(winrt::AutomationStructureChangeType const& structureChangeType);
     com_ptr<TableView> GetImpl();

--- a/controls/dev/TableView/TableViewAutomationPeer.h
+++ b/controls/dev/TableView/TableViewAutomationPeer.h
@@ -62,10 +62,22 @@ private:
     // to GetColumnHeaders must hand back the same provider for a given column: minting a fresh
     // peer per call yields unstable provider identity and leaves the returned providers with no
     // owner keeping them alive.
+    //
+    // The peer is held in a tracker_ref, the repo convention for a strong WinRT reference owned by
+    // a ReferenceTracker type, so the reference tracker can walk this edge and collect cycles.
     struct ColumnHeaderPeerCacheEntry
     {
+        ColumnHeaderPeerCacheEntry(
+            ITrackerHandleManager const* owner,
+            winrt::TableViewColumn const& headerColumn,
+            winrt::AutomationPeer const& headerPeer)
+            : column(winrt::make_weak(headerColumn))
+            , peer(owner, headerPeer)
+        {
+        }
+
         winrt::weak_ref<winrt::TableViewColumn> column{ nullptr };
-        winrt::AutomationPeer peer{ nullptr };
+        tracker_ref<winrt::AutomationPeer> peer;
     };
 
     void RaiseStructureChanged(winrt::AutomationStructureChangeType const& structureChangeType);

--- a/controls/dev/TableView/TableViewCellAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewCellAutomationPeer.cpp
@@ -6,10 +6,12 @@
 #include "TableView.h"
 #include "TableViewTextColumn.h"
 #include "TableViewRow.h"
+#include "TableViewAutomationPeer.h"
 #include "TableViewColumnHeaderAutomationPeer.h"
 #include "TableViewCellAutomationPeer.h"
 #include "TableViewAutomationHelpers.h"
 #include "TableViewToolTipHelpers.h"
+#include "ResourceAccessor.h"
 #include "TableViewCellAutomationPeer.properties.cpp"
 
 #include <string>
@@ -66,6 +68,18 @@ winrt::AutomationControlType TableViewCellAutomationPeer::GetAutomationControlTy
     return winrt::AutomationControlType::DataItem;
 }
 
+hstring TableViewCellAutomationPeer::GetLocalizedControlTypeCore()
+{
+    // Shared helper: the host app may not merge the control's PRI, so a missing resource degrades
+    // to the framework default ("data item") rather than throwing into UIA.
+    if (auto const localized = TryGetLocalizedString(SR_TableViewCellLocalizedControlType); !localized.empty())
+    {
+        return localized;
+    }
+
+    return __super::GetLocalizedControlTypeCore();
+}
+
 hstring TableViewCellAutomationPeer::GetNameCore()
 {
     // Compose "{column header}, {cell value}", falling back to either part alone.
@@ -98,36 +112,8 @@ winrt::hstring TableViewCellAutomationPeer::GetColumnHeaderText()
 
 winrt::hstring TableViewCellAutomationPeer::GetCellValueText()
 {
-    auto const cell = Owner().try_as<winrt::FrameworkElement>();
-    if (!cell)
-    {
-        return {};
-    }
-
-    // The cell wrapper's child is the column-generated content.
-    winrt::FrameworkElement content{ nullptr };
-    if (auto const border = cell.try_as<winrt::Border>())
-    {
-        content = border.Child().try_as<winrt::FrameworkElement>();
-    }
-    if (!content)
-    {
-        content = cell;
-    }
-
-    // Common text-column case: read the generated TextBlock.
-    if (auto const textBlock = content.try_as<winrt::TextBlock>())
-    {
-        return textBlock.Text();
-    }
-
-    // Template content uses the standard UIA name computation.
-    if (auto const peer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(content))
-    {
-        return peer.GetName();
-    }
-
-    return {};
+    // Shared with the row peer's composed name, so the two never disagree.
+    return GetCellDisplayText(Owner().try_as<winrt::FrameworkElement>());
 }
 
 hstring TableViewCellAutomationPeer::GetHelpTextCore()
@@ -179,7 +165,40 @@ int32_t TableViewCellAutomationPeer::Row()
 
 int32_t TableViewCellAutomationPeer::Column()
 {
-    // Matches TableViewAutomationPeer::GetItem's cell-host child index.
+    // Computed live, mirroring Row(): a cached index goes stale the moment a column is hidden or
+    // shown underneath a client that is holding this provider, and UIA clients do hold them.
+    // Falls back to the index the row supplied at construction when the row is unresolvable.
+    if (auto const row = m_row.get())
+    {
+        if (auto const rowImpl = winrt::get_self<TableViewRow>(row))
+        {
+            if (auto const cellsHost = rowImpl->GetCellsHostPanelInternal())
+            {
+                auto const cell = Owner().try_as<winrt::UIElement>();
+                auto const cellChildren = cellsHost.Children();
+                const auto count = cellChildren.Size();
+                int32_t visibleColumnIndex = 0;
+
+                // Same walk, same predicate, as TableViewAutomationPeer::VisibleColumnToChildIndex
+                // and the row peer's GetChildrenCore, so all three agree on the coordinate.
+                for (uint32_t i = 0; i < count; ++i)
+                {
+                    auto const child = cellChildren.GetAt(i).try_as<winrt::UIElement>();
+                    if (!child || !IsVisibleColumn(rowImpl->GetCellOwningColumn(child)))
+                    {
+                        continue;
+                    }
+
+                    if (child == cell)
+                    {
+                        return visibleColumnIndex;
+                    }
+                    ++visibleColumnIndex;
+                }
+            }
+        }
+    }
+
     return m_columnIndex;
 }
 
@@ -228,7 +247,22 @@ winrt::com_array<winrt::IRawElementProviderSimple> TableViewCellAutomationPeer::
         {
             if (auto const owner = winrt::get_self<TableViewRow>(row)->GetOwningTableView())
             {
-                auto const headerPeer = winrt::make<TableViewColumnHeaderAutomationPeer>(owner, column);
+                // Routed through the TableView's peer so this cell's header reference resolves to
+                // the SAME provider the table's ITableProvider::GetColumnHeaders enumeration hands
+                // out. Minting a peer here instead made the two disagree about the header's
+                // identity, which is how a client correlates a cell with its column.
+                winrt::AutomationPeer headerPeer{ nullptr };
+                if (auto const ownerPeer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(owner)
+                        .try_as<winrt::TableViewAutomationPeer>())
+                {
+                    headerPeer = winrt::get_self<TableViewAutomationPeer>(ownerPeer)
+                        ->GetOrCreateColumnHeaderPeer(owner, column);
+                }
+
+                if (!headerPeer)
+                {
+                    headerPeer = winrt::make<TableViewColumnHeaderAutomationPeer>(owner, column);
+                }
 
                 // A provider array must not contain nulls - UIA marshals every element. An empty
                 // array correctly reports "this cell has no reachable column header".

--- a/controls/dev/TableView/TableViewCellAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewCellAutomationPeer.cpp
@@ -70,8 +70,8 @@ winrt::AutomationControlType TableViewCellAutomationPeer::GetAutomationControlTy
 
 hstring TableViewCellAutomationPeer::GetLocalizedControlTypeCore()
 {
-    // Shared helper: the host app may not merge the control's PRI, so a missing resource degrades
-    // to the framework default ("data item") rather than throwing into UIA.
+    // A host app may not merge the control's PRI; degrade to the framework default rather than
+    // throwing into UIA.
     if (auto const localized = TryGetLocalizedString(SR_TableViewCellLocalizedControlType); !localized.empty())
     {
         return localized;
@@ -112,7 +112,6 @@ winrt::hstring TableViewCellAutomationPeer::GetColumnHeaderText()
 
 winrt::hstring TableViewCellAutomationPeer::GetCellValueText()
 {
-    // Shared with the row peer's composed name, so the two never disagree.
     return GetCellDisplayText(Owner().try_as<winrt::FrameworkElement>());
 }
 
@@ -165,9 +164,8 @@ int32_t TableViewCellAutomationPeer::Row()
 
 int32_t TableViewCellAutomationPeer::Column()
 {
-    // Computed live, mirroring Row(): a cached index goes stale the moment a column is hidden or
-    // shown underneath a client that is holding this provider, and UIA clients do hold them.
-    // Falls back to the index the row supplied at construction when the row is unresolvable.
+    // Computed live, mirroring Row(): a cached index goes stale as soon as a column is hidden or
+    // shown underneath a client holding this provider.
     if (auto const row = m_row.get())
     {
         if (auto const rowImpl = winrt::get_self<TableViewRow>(row))
@@ -179,8 +177,8 @@ int32_t TableViewCellAutomationPeer::Column()
                 const auto count = cellChildren.Size();
                 int32_t visibleColumnIndex = 0;
 
-                // Same walk, same predicate, as TableViewAutomationPeer::VisibleColumnToChildIndex
-                // and the row peer's GetChildrenCore, so all three agree on the coordinate.
+                // Same walk and predicate as TableViewAutomationPeer::VisibleColumnToChildIndex and
+                // the row peer's GetChildrenCore, so all three agree on the coordinate.
                 for (uint32_t i = 0; i < count; ++i)
                 {
                     auto const child = cellChildren.GetAt(i).try_as<winrt::UIElement>();
@@ -247,10 +245,9 @@ winrt::com_array<winrt::IRawElementProviderSimple> TableViewCellAutomationPeer::
         {
             if (auto const owner = winrt::get_self<TableViewRow>(row)->GetOwningTableView())
             {
-                // Routed through the TableView's peer so this cell's header reference resolves to
-                // the SAME provider the table's ITableProvider::GetColumnHeaders enumeration hands
-                // out. Minting a peer here instead made the two disagree about the header's
-                // identity, which is how a client correlates a cell with its column.
+                // Through the TableView's peer so this cell's header reference and the table's own
+                // header peer are one provider; a client correlates a cell to its column by that
+                // identity.
                 winrt::AutomationPeer headerPeer{ nullptr };
                 if (auto const ownerPeer = winrt::FrameworkElementAutomationPeer::CreatePeerForElement(owner)
                         .try_as<winrt::TableViewAutomationPeer>())

--- a/controls/dev/TableView/TableViewCellAutomationPeer.h
+++ b/controls/dev/TableView/TableViewCellAutomationPeer.h
@@ -24,8 +24,7 @@ public:
     hstring GetNameCore();
     hstring GetHelpTextCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();
-    // DataItem alone makes Narrator announce every cell as "data item"; UIA expects a control to
-    // localize the term a user actually hears.
+    // Without this every cell announces as the generic "data item".
     hstring GetLocalizedControlTypeCore();
 
     // IGridItemProvider — per-cell coordinates in the owning TableView.

--- a/controls/dev/TableView/TableViewCellAutomationPeer.h
+++ b/controls/dev/TableView/TableViewCellAutomationPeer.h
@@ -24,6 +24,9 @@ public:
     hstring GetNameCore();
     hstring GetHelpTextCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();
+    // DataItem alone makes Narrator announce every cell as "data item"; UIA expects a control to
+    // localize the term a user actually hears.
+    hstring GetLocalizedControlTypeCore();
 
     // IGridItemProvider — per-cell coordinates in the owning TableView.
     int32_t Row();
@@ -59,5 +62,6 @@ private:
 
     winrt::weak_ref<winrt::TableViewRow> m_row{ nullptr };
     winrt::weak_ref<winrt::TableViewColumn> m_column{ nullptr };
+    // Construction-time fallback only; Column() recomputes from the live cell host.
     int32_t m_columnIndex{ -1 };
 };

--- a/controls/dev/TableView/TableViewColumnHeaderAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewColumnHeaderAutomationPeer.cpp
@@ -220,14 +220,30 @@ bool TableViewColumnHeaderAutomationPeer::IsSortableColumn()
 
 int32_t TableViewColumnHeaderAutomationPeer::GetPositionInSetCore()
 {
+    // An app-set AutomationProperties.PositionInSet wins, matching the row and group-header peers
+    // and every dxaml peer that computes this property.
+    if (const auto provided = __super::GetPositionInSetCore(); provided > 0)
+    {
+        return provided;
+    }
+
     // Complements the distinct RuntimeId and GetNameCore: expose the 1-based visible column
     // position so AT (Narrator) can announce "column i of n" as the user moves across headers.
     const auto index = GetColumnIndex();
-    return index >= 0 ? index + 1 : -1;
+
+    // 0, not -1: 0 is UIA's "not specified" for this property and valid values are 1-based
+    // positives, so -1 was forwarded to clients verbatim as a nonsense position. Matches the row
+    // and group-header peers, TreeViewItemAutomationPeer and NavigationViewItemAutomationPeer.
+    return index >= 0 ? index + 1 : 0;
 }
 
 int32_t TableViewColumnHeaderAutomationPeer::GetSizeOfSetCore()
 {
+    if (const auto provided = __super::GetSizeOfSetCore(); provided > 0)
+    {
+        return provided;
+    }
+
     // Total visible column count, so PositionInSet reads as "i of n".
     if (auto const owner = Owner().try_as<winrt::TableView>())
     {
@@ -241,7 +257,9 @@ int32_t TableViewColumnHeaderAutomationPeer::GetSizeOfSetCore()
             if (count > 0) { return count; }
         }
     }
-    return -1;
+
+    // 0 = "not specified", as above.
+    return 0;
 }
 
 winrt::Windows::Foundation::Rect TableViewColumnHeaderAutomationPeer::GetBoundingRectangleCore()

--- a/controls/dev/TableView/TableViewColumnHeaderAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewColumnHeaderAutomationPeer.cpp
@@ -34,19 +34,6 @@ namespace
             static_cast<int32_t>((identity >> 32) & 0xffffffffull)
         };
     }
-
-    // Help text is supplementary: degrade instead of letting a resource failure escape into UIA.
-    winrt::hstring TryGetLocalizedString(const std::wstring_view& resourceName)
-    {
-        try
-        {
-            return ResourceAccessor::GetLocalizedStringResource(resourceName);
-        }
-        catch (...)
-        {
-            return {};
-        }
-    }
 }
 
 TableViewColumnHeaderAutomationPeer::TableViewColumnHeaderAutomationPeer(

--- a/controls/dev/TableView/TableViewColumnHeaderAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewColumnHeaderAutomationPeer.cpp
@@ -220,20 +220,17 @@ bool TableViewColumnHeaderAutomationPeer::IsSortableColumn()
 
 int32_t TableViewColumnHeaderAutomationPeer::GetPositionInSetCore()
 {
-    // An app-set AutomationProperties.PositionInSet wins, matching the row and group-header peers
-    // and every dxaml peer that computes this property.
+    // An app-set AutomationProperties value wins, as in the row and group-header peers.
     if (const auto provided = __super::GetPositionInSetCore(); provided > 0)
     {
         return provided;
     }
 
-    // Complements the distinct RuntimeId and GetNameCore: expose the 1-based visible column
-    // position so AT (Narrator) can announce "column i of n" as the user moves across headers.
+    // 1-based visible column position, so AT can announce "column i of n".
     const auto index = GetColumnIndex();
 
-    // 0, not -1: 0 is UIA's "not specified" for this property and valid values are 1-based
-    // positives, so -1 was forwarded to clients verbatim as a nonsense position. Matches the row
-    // and group-header peers, TreeViewItemAutomationPeer and NavigationViewItemAutomationPeer.
+    // 0 is UIA's "not specified"; valid values are 1-based, so -1 reached the client as a nonsense
+    // position.
     return index >= 0 ? index + 1 : 0;
 }
 
@@ -258,7 +255,6 @@ int32_t TableViewColumnHeaderAutomationPeer::GetSizeOfSetCore()
         }
     }
 
-    // 0 = "not specified", as above.
     return 0;
 }
 

--- a/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.cpp
@@ -80,15 +80,13 @@ winrt::hstring TableViewGroupHeaderAutomationPeer::GetNameCore()
 
 int32_t TableViewGroupHeaderAutomationPeer::GetLevelCore()
 {
-    // An app-set AutomationProperties.Level wins, matching how the dxaml peers that compute this
-    // property defer to the container value first.
+    // An app-set AutomationProperties.Level wins, as in the dxaml peers that compute this.
     if (const auto provided = __super::GetLevelCore(); provided > 0)
     {
         return provided;
     }
 
-    // 1-based, matching UIA's Level convention; 0 means "unknown", which is the honest answer for a
-    // band whose projection info is gone.
+    // 1-based per UIA; 0 means "unknown", the honest answer once the projection info is gone.
     if (auto const header = GetHeader())
     {
         if (auto const info = header.Content().try_as<winrt::TableViewGroupInfo>())

--- a/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.cpp
@@ -78,6 +78,32 @@ winrt::hstring TableViewGroupHeaderAutomationPeer::GetNameCore()
     return __super::GetNameCore();
 }
 
+int32_t TableViewGroupHeaderAutomationPeer::GetLevelCore()
+{
+    // An app-set AutomationProperties.Level wins, matching how the dxaml peers that compute this
+    // property defer to the container value first.
+    if (const auto provided = __super::GetLevelCore(); provided > 0)
+    {
+        return provided;
+    }
+
+    // 1-based, matching UIA's Level convention; 0 means "unknown", which is the honest answer for a
+    // band whose projection info is gone.
+    if (auto const header = GetHeader())
+    {
+        if (auto const info = header.Content().try_as<winrt::TableViewGroupInfo>())
+        {
+            const auto level = info.Level();
+            if (level >= 0)
+            {
+                return level + 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
 void TableViewGroupHeaderAutomationPeer::RaiseExpandCollapseAutomationEvent(
     winrt::ExpandCollapseState oldState,
     winrt::ExpandCollapseState newState)

--- a/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.h
+++ b/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.h
@@ -34,9 +34,8 @@ public:
     void Collapse();
     winrt::ExpandCollapseState ExpandCollapseState();
 
-    // Grouping is genuinely hierarchical, and Level is how an ExpandCollapse container conveys
-    // depth (TreeViewItem, NavigationViewItem). Without it a Narrator user hears two nested groups
-    // as siblings.
+    // Grouping is hierarchical, and Level is how an ExpandCollapse container conveys depth.
+    // Without it Narrator hears two nested groups as siblings.
     int32_t GetLevelCore();
 
     // Internal: announce a state change from THIS peer. UIA delivers property-changed events

--- a/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.h
+++ b/controls/dev/TableView/TableViewGroupHeaderAutomationPeer.h
@@ -34,6 +34,11 @@ public:
     void Collapse();
     winrt::ExpandCollapseState ExpandCollapseState();
 
+    // Grouping is genuinely hierarchical, and Level is how an ExpandCollapse container conveys
+    // depth (TreeViewItem, NavigationViewItem). Without it a Narrator user hears two nested groups
+    // as siblings.
+    int32_t GetLevelCore();
+
     // Internal: announce a state change from THIS peer. UIA delivers property-changed events
     // through the peer the client is connected to, so the raise has to happen on the peer
     // instance itself -- raising from a peer obtained via CreatePeerForElement can hand back a

--- a/controls/dev/TableView/TableViewRowAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.cpp
@@ -232,7 +232,7 @@ winrt::AutomationPeer TableViewRowAutomationPeer::GetOrCreateCellPeer(
     {
         if (entry.peer && entry.cell.get() == cell)
         {
-            return entry.peer;
+            return entry.peer.get();
         }
     }
 
@@ -256,7 +256,7 @@ winrt::AutomationPeer TableViewRowAutomationPeer::GetOrCreateCellPeer(
     // Cached on miss so Grid.GetItem - which can be the first, or only, path a client takes to a
     // cell - still yields a provider whose identity survives the next query.
     winrt::AutomationPeer const peer = winrt::make<TableViewCellAutomationPeer>(cell, row, column, visibleColumnIndex);
-    m_cellPeerCache.push_back({ winrt::make_weak(cell), peer });
+    m_cellPeerCache.emplace_back(this, cell, peer);
     return peer;
 }
 
@@ -367,7 +367,7 @@ winrt::IVector<winrt::AutomationPeer> TableViewRowAutomationPeer::GetChildrenCor
                 // Dedicated cell peers provide names, coordinates, and header references.
                 if (auto const cellPeer = GetOrCreateCellPeer(cellFE, column, visibleColumnIndex))
                 {
-                    liveCache.push_back({ winrt::make_weak(cellFE), cellPeer });
+                    liveCache.emplace_back(this, cellFE, cellPeer);
                     children.Append(cellPeer);
                 }
             }

--- a/controls/dev/TableView/TableViewRowAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.cpp
@@ -7,7 +7,11 @@
 #include "TableViewRow.h"
 #include "TableViewRowAutomationPeer.h"
 #include "TableViewCellAutomationPeer.h"
+#include "TableViewAutomationHelpers.h"
 #include "TableViewRowAutomationPeer.properties.cpp"
+
+#include <algorithm>
+#include <string>
 
 TableViewRowAutomationPeer::TableViewRowAutomationPeer(winrt::TableViewRow const& owner)
     : ReferenceTracker(owner)
@@ -68,6 +72,192 @@ int32_t TableViewRowAutomationPeer::GetRowIndex()
     }
 
     return -1;
+}
+
+hstring TableViewRowAutomationPeer::GetNameCore()
+{
+    // An explicit AutomationProperties.Name on the row always wins.
+    if (auto const name = __super::GetNameCore(); !name.empty())
+    {
+        return name;
+    }
+
+    auto const row = Owner().try_as<winrt::TableViewRow>();
+    if (!row)
+    {
+        return {};
+    }
+
+    auto const rowImpl = winrt::get_self<TableViewRow>(row);
+    auto const cellsHost = rowImpl ? rowImpl->GetCellsHostPanelInternal() : nullptr;
+    if (!cellsHost)
+    {
+        return {};
+    }
+
+    // Visible cells only, in visual order, so the announcement matches what a sighted user reads
+    // across the row. Empty cells are skipped rather than producing runs of separators.
+    std::wstring composed;
+    auto const cellChildren = cellsHost.Children();
+    const auto count = cellChildren.Size();
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        auto const cellElement = cellChildren.GetAt(i).try_as<winrt::UIElement>();
+        if (!cellElement || !IsVisibleColumn(rowImpl->GetCellOwningColumn(cellElement)))
+        {
+            continue;
+        }
+
+        auto const text = GetCellDisplayText(cellElement.try_as<winrt::FrameworkElement>(), false /* allowPeerCreation */);
+        if (text.empty())
+        {
+            continue;
+        }
+
+        if (!composed.empty())
+        {
+            composed += L", ";
+        }
+        composed += text;
+    }
+
+    return winrt::hstring{ composed };
+}
+
+int32_t TableViewRowAutomationPeer::GetPositionInSetCore()
+{
+    // An app-set AutomationProperties.PositionInSet wins, matching how every dxaml peer that
+    // computes this property defers to the container value first.
+    if (const auto provided = __super::GetPositionInSetCore(); provided > 0)
+    {
+        return provided;
+    }
+
+    const auto index = GetRowIndex();
+    if (index < 0)
+    {
+        // 0, not -1: 0 is UIA's "not specified". An unrealized row honestly reports unknown.
+        return 0;
+    }
+
+    // Grouped: report the position WITHIN the owning group and exclude the header bands, which is
+    // what ItemsControlAutomationPeer does (indexInsideGroup) and what NavigationView and TreeView
+    // do in this repo. A global index counted over a projection that interleaves headers and rows
+    // would announce a number the user cannot relate to anything on screen.
+    if (int32_t positionInGroup = 0, sizeOfGroup = 0; TryGetGroupPosition(index, positionInGroup, sizeOfGroup))
+    {
+        return positionInGroup;
+    }
+
+    return index + 1;
+}
+
+int32_t TableViewRowAutomationPeer::GetSizeOfSetCore()
+{
+    if (const auto provided = __super::GetSizeOfSetCore(); provided > 0)
+    {
+        return provided;
+    }
+
+    if (const auto index = GetRowIndex(); index >= 0)
+    {
+        if (int32_t positionInGroup = 0, sizeOfGroup = 0; TryGetGroupPosition(index, positionInGroup, sizeOfGroup))
+        {
+            return sizeOfGroup;
+        }
+    }
+
+    // Ungrouped: the full projection, the same basis TableViewAutomationPeer::RowCount and GetItem
+    // use, so "i of n" stays consistent with grid addressing.
+    if (auto const tableView = GetOwningTableView())
+    {
+        if (const auto count = winrt::get_self<TableView>(tableView)->GetRowCountInternal(); count > 0)
+        {
+            return count;
+        }
+    }
+
+    return 0;
+}
+
+// Resolves a data row's 1-based position within its group and the group's item count. Returns false
+// when the source is not grouped, so callers fall back to the flat basis.
+bool TableViewRowAutomationPeer::TryGetGroupPosition(int32_t rowIndex, int32_t& positionInGroup, int32_t& sizeOfGroup)
+{
+    auto const tableView = GetOwningTableView();
+    if (!tableView)
+    {
+        return false;
+    }
+
+    auto const tableViewImpl = winrt::get_self<TableView>(tableView);
+    if (!tableViewImpl->IsTableViewSourceGrouped())
+    {
+        return false;
+    }
+
+    // Walk back to the owning header. Bounded by the group's size, not the row count - the same
+    // shape as NavigationViewItemAutomationPeer, which walks its repeater resetting at each header.
+    for (int32_t i = rowIndex - 1; i >= 0; --i)
+    {
+        TableViewRowInfo info{};
+        if (!tableViewImpl->TryGetTableViewSourceRowInfo(i, info))
+        {
+            return false;
+        }
+
+        if (info.Kind == TableViewRowKind::GroupHeader)
+        {
+            positionInGroup = rowIndex - i;
+            // ChildCount is the group's item count and the single source of truth for group size.
+            sizeOfGroup = info.ChildCount;
+            return sizeOfGroup > 0;
+        }
+    }
+
+    return false;
+}
+
+winrt::AutomationPeer TableViewRowAutomationPeer::GetOrCreateCellPeer(
+    winrt::FrameworkElement const& cell,
+    winrt::TableViewColumn const& column,
+    int32_t visibleColumnIndex)
+{
+    if (!cell)
+    {
+        return nullptr;
+    }
+
+    for (auto const& entry : m_cellPeerCache)
+    {
+        if (entry.peer && entry.cell.get() == cell)
+        {
+            return entry.peer;
+        }
+    }
+
+    auto const row = Owner().try_as<winrt::TableViewRow>();
+    if (!row)
+    {
+        return nullptr;
+    }
+
+    // Pruned on the miss path, not only when GetChildrenCore rebuilds: a client that only ever
+    // addresses cells through IGridProvider::GetItem never walks children, so without this the
+    // vector would keep every entry whose cell has since been released. Mirrors the identical
+    // prune in TableViewAutomationPeer::GetOrCreateColumnHeaderPeer.
+    m_cellPeerCache.erase(
+        std::remove_if(
+            m_cellPeerCache.begin(),
+            m_cellPeerCache.end(),
+            [](CellPeerCacheEntry const& entry) { return !entry.peer || !entry.cell.get(); }),
+        m_cellPeerCache.end());
+
+    // Cached on miss so Grid.GetItem - which can be the first, or only, path a client takes to a
+    // cell - still yields a provider whose identity survives the next query.
+    winrt::AutomationPeer const peer = winrt::make<TableViewCellAutomationPeer>(cell, row, column, visibleColumnIndex);
+    m_cellPeerCache.push_back({ winrt::make_weak(cell), peer });
+    return peer;
 }
 
 // ----- ISelectionItemProvider -----
@@ -155,12 +345,19 @@ winrt::IVector<winrt::AutomationPeer> TableViewRowAutomationPeer::GetChildrenCor
     const auto cellChildren = cellsHost.Children();
     const auto count = cellChildren.Size();
     int32_t visibleColumnIndex = 0;
+
+    // Rebuilt wholesale so peers for cells dropped by a rebuild or a recycle are released here,
+    // while a cell that survives keeps the very same peer - and therefore the same UIA provider
+    // identity - across enumerations.
+    std::vector<CellPeerCacheEntry> liveCache;
+    liveCache.reserve(count);
+
     for (uint32_t i = 0; i < count; ++i)
     {
         if (auto const cellElement = cellChildren.GetAt(i).try_as<winrt::UIElement>())
         {
             auto const column = rowImpl->GetCellOwningColumn(cellElement);
-            if (!column || column.Visibility() != winrt::Visibility::Visible)
+            if (!IsVisibleColumn(column))
             {
                 continue;
             }
@@ -168,13 +365,17 @@ winrt::IVector<winrt::AutomationPeer> TableViewRowAutomationPeer::GetChildrenCor
             if (auto const cellFE = cellElement.try_as<winrt::FrameworkElement>())
             {
                 // Dedicated cell peers provide names, coordinates, and header references.
-                winrt::AutomationPeer const cellPeer =
-                    winrt::make<TableViewCellAutomationPeer>(cellFE, row, column, visibleColumnIndex);
-                children.Append(cellPeer);
+                if (auto const cellPeer = GetOrCreateCellPeer(cellFE, column, visibleColumnIndex))
+                {
+                    liveCache.push_back({ winrt::make_weak(cellFE), cellPeer });
+                    children.Append(cellPeer);
+                }
             }
             ++visibleColumnIndex;
         }
     }
+
+    m_cellPeerCache = std::move(liveCache);
 
     return children;
 }

--- a/controls/dev/TableView/TableViewRowAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.cpp
@@ -96,6 +96,35 @@ hstring TableViewRowAutomationPeer::GetNameCore()
     }
 
     // Visible cells in visual order; empty cells are skipped so the name has no separator runs.
+    // The cheap pass first: GetCellDisplayText does not create peers, because this runs on every
+    // UIA name query across every cell.
+    std::wstring composed = ComposeCellTexts(rowImpl, cellsHost, false /* allowPeerCreation */);
+
+    if (composed.empty())
+    {
+        // Every visible cell was template content, which the cheap pass cannot read - so the row
+        // would announce as a bare "data item" with nothing in it, the exact case this name exists
+        // to fix. Retry allowing peer creation: bounded to rows that would otherwise be nameless,
+        // and the peers it attaches make the following queries cheap again.
+        composed = ComposeCellTexts(rowImpl, cellsHost, true /* allowPeerCreation */);
+    }
+
+    if (composed.empty())
+    {
+        // Template content with no name of its own either. The data item is the last thing left
+        // that can distinguish this row from its neighbours.
+        return ItemToName(row.DataContext());
+    }
+
+    return winrt::hstring{ composed };
+}
+
+// Joins the visible cells' display text in visual order.
+std::wstring TableViewRowAutomationPeer::ComposeCellTexts(
+    TableViewRow* rowImpl,
+    winrt::Panel const& cellsHost,
+    bool allowPeerCreation)
+{
     std::wstring composed;
     auto const cellChildren = cellsHost.Children();
     const auto count = cellChildren.Size();
@@ -107,7 +136,7 @@ hstring TableViewRowAutomationPeer::GetNameCore()
             continue;
         }
 
-        auto const text = GetCellDisplayText(cellElement.try_as<winrt::FrameworkElement>(), false /* allowPeerCreation */);
+        auto const text = GetCellDisplayText(cellElement.try_as<winrt::FrameworkElement>(), allowPeerCreation);
         if (text.empty())
         {
             continue;
@@ -120,7 +149,7 @@ hstring TableViewRowAutomationPeer::GetNameCore()
         composed += text;
     }
 
-    return winrt::hstring{ composed };
+    return composed;
 }
 
 int32_t TableViewRowAutomationPeer::GetPositionInSetCore()

--- a/controls/dev/TableView/TableViewRowAutomationPeer.cpp
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.cpp
@@ -95,8 +95,7 @@ hstring TableViewRowAutomationPeer::GetNameCore()
         return {};
     }
 
-    // Visible cells only, in visual order, so the announcement matches what a sighted user reads
-    // across the row. Empty cells are skipped rather than producing runs of separators.
+    // Visible cells in visual order; empty cells are skipped so the name has no separator runs.
     std::wstring composed;
     auto const cellChildren = cellsHost.Children();
     const auto count = cellChildren.Size();
@@ -126,8 +125,7 @@ hstring TableViewRowAutomationPeer::GetNameCore()
 
 int32_t TableViewRowAutomationPeer::GetPositionInSetCore()
 {
-    // An app-set AutomationProperties.PositionInSet wins, matching how every dxaml peer that
-    // computes this property defers to the container value first.
+    // An app-set AutomationProperties value wins, as in every dxaml peer that computes this.
     if (const auto provided = __super::GetPositionInSetCore(); provided > 0)
     {
         return provided;
@@ -136,14 +134,13 @@ int32_t TableViewRowAutomationPeer::GetPositionInSetCore()
     const auto index = GetRowIndex();
     if (index < 0)
     {
-        // 0, not -1: 0 is UIA's "not specified". An unrealized row honestly reports unknown.
+        // 0 is UIA's "not specified"; -1 would reach the client verbatim.
         return 0;
     }
 
-    // Grouped: report the position WITHIN the owning group and exclude the header bands, which is
-    // what ItemsControlAutomationPeer does (indexInsideGroup) and what NavigationView and TreeView
-    // do in this repo. A global index counted over a projection that interleaves headers and rows
-    // would announce a number the user cannot relate to anything on screen.
+    // Grouped: position within the owning group, excluding the header bands. A global index over a
+    // projection that interleaves headers and rows announces a number matching nothing on screen.
+    // Same basis as ItemsControlAutomationPeer's indexInsideGroup.
     if (int32_t positionInGroup = 0, sizeOfGroup = 0; TryGetGroupPosition(index, positionInGroup, sizeOfGroup))
     {
         return positionInGroup;
@@ -167,8 +164,8 @@ int32_t TableViewRowAutomationPeer::GetSizeOfSetCore()
         }
     }
 
-    // Ungrouped: the full projection, the same basis TableViewAutomationPeer::RowCount and GetItem
-    // use, so "i of n" stays consistent with grid addressing.
+    // Ungrouped: same basis as TableViewAutomationPeer::RowCount and GetItem, so "i of n" agrees
+    // with grid addressing.
     if (auto const tableView = GetOwningTableView())
     {
         if (const auto count = winrt::get_self<TableView>(tableView)->GetRowCountInternal(); count > 0)
@@ -196,8 +193,7 @@ bool TableViewRowAutomationPeer::TryGetGroupPosition(int32_t rowIndex, int32_t& 
         return false;
     }
 
-    // Walk back to the owning header. Bounded by the group's size, not the row count - the same
-    // shape as NavigationViewItemAutomationPeer, which walks its repeater resetting at each header.
+    // Walk back to the owning header; bounded by the group's size, not the row count.
     for (int32_t i = rowIndex - 1; i >= 0; --i)
     {
         TableViewRowInfo info{};
@@ -209,7 +205,6 @@ bool TableViewRowAutomationPeer::TryGetGroupPosition(int32_t rowIndex, int32_t& 
         if (info.Kind == TableViewRowKind::GroupHeader)
         {
             positionInGroup = rowIndex - i;
-            // ChildCount is the group's item count and the single source of truth for group size.
             sizeOfGroup = info.ChildCount;
             return sizeOfGroup > 0;
         }
@@ -242,10 +237,8 @@ winrt::AutomationPeer TableViewRowAutomationPeer::GetOrCreateCellPeer(
         return nullptr;
     }
 
-    // Pruned on the miss path, not only when GetChildrenCore rebuilds: a client that only ever
-    // addresses cells through IGridProvider::GetItem never walks children, so without this the
-    // vector would keep every entry whose cell has since been released. Mirrors the identical
-    // prune in TableViewAutomationPeer::GetOrCreateColumnHeaderPeer.
+    // Pruned here as well as on the GetChildrenCore rebuild: a client that only addresses cells
+    // through IGridProvider::GetItem never walks children, so this is its only prune point.
     m_cellPeerCache.erase(
         std::remove_if(
             m_cellPeerCache.begin(),
@@ -253,8 +246,6 @@ winrt::AutomationPeer TableViewRowAutomationPeer::GetOrCreateCellPeer(
             [](CellPeerCacheEntry const& entry) { return !entry.peer || !entry.cell.get(); }),
         m_cellPeerCache.end());
 
-    // Cached on miss so Grid.GetItem - which can be the first, or only, path a client takes to a
-    // cell - still yields a provider whose identity survives the next query.
     winrt::AutomationPeer const peer = winrt::make<TableViewCellAutomationPeer>(cell, row, column, visibleColumnIndex);
     m_cellPeerCache.emplace_back(this, cell, peer);
     return peer;
@@ -346,9 +337,8 @@ winrt::IVector<winrt::AutomationPeer> TableViewRowAutomationPeer::GetChildrenCor
     const auto count = cellChildren.Size();
     int32_t visibleColumnIndex = 0;
 
-    // Rebuilt wholesale so peers for cells dropped by a rebuild or a recycle are released here,
-    // while a cell that survives keeps the very same peer - and therefore the same UIA provider
-    // identity - across enumerations.
+    // Rebuilt wholesale: peers for cells dropped by a rebuild or recycle are released, while a
+    // surviving cell keeps the same peer and therefore the same provider identity.
     std::vector<CellPeerCacheEntry> liveCache;
     liveCache.reserve(count);
 

--- a/controls/dev/TableView/TableViewRowAutomationPeer.h
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.h
@@ -54,6 +54,11 @@ private:
     int32_t GetRowIndex();
     // 1-based position within the owning group and that group's item count; false when ungrouped.
     bool TryGetGroupPosition(int32_t rowIndex, int32_t& positionInGroup, int32_t& sizeOfGroup);
+    // Joins the visible cells' display text in visual order.
+    static std::wstring ComposeCellTexts(
+        TableViewRow* rowImpl,
+        winrt::Panel const& cellsHost,
+        bool allowPeerCreation);
 
     // One peer per realized cell, keyed weakly so a recycled or rebuilt cell releases immediately.
     // tracker_ref is the convention for a strong WinRT ref owned by a ReferenceTracker type.

--- a/controls/dev/TableView/TableViewRowAutomationPeer.h
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.h
@@ -6,6 +6,8 @@
 #include "TableViewRow.h"
 #include "TableViewRowAutomationPeer.g.h"
 
+#include <vector>
+
 class TableViewRowAutomationPeer :
     public ReferenceTracker<TableViewRowAutomationPeer, winrt::implementation::TableViewRowAutomationPeerT>
 {
@@ -16,6 +18,17 @@ public:
     hstring GetClassNameCore();
     winrt::AutomationControlType GetAutomationControlTypeCore();
     winrt::IInspectable GetPatternCore(winrt::PatternInterface const& patternInterface);
+
+    // A TableViewRow is a Control with no content of its own, so the base peer computes no name and
+    // assistive technology announces a bare "data item". Compose the visible cell texts instead.
+    hstring GetNameCore();
+
+    // Rows are virtualized, so the UIA parent only ever exposes the realized window and a client
+    // cannot infer "row i of n" from the children collection - the control has to supply it. Same
+    // contract ListViewItemAutomationPeer satisfies. Under grouping these are group-relative,
+    // matching ItemsControlAutomationPeer / NavigationView / TreeView.
+    int32_t GetPositionInSetCore();
+    int32_t GetSizeOfSetCore();
 
     // Expose direct cell wrappers only to avoid deep, costly UIA subtree walks.
     winrt::IVector<winrt::AutomationPeer> GetChildrenCore();
@@ -28,9 +41,31 @@ public:
     void RemoveFromSelection();
     void Select();
 
+    // Internal: hands back the peer this row has already published for a cell. Every path that
+    // yields a cell provider (this peer's GetChildrenCore and TableViewAutomationPeer::GetItem)
+    // must route through here - UIA compares providers by identity, so minting a fresh peer per
+    // query makes grid addressing and tree navigation disagree about the same cell, and drops
+    // Narrator focus whenever the tree is re-queried.
+    winrt::AutomationPeer GetOrCreateCellPeer(
+        winrt::FrameworkElement const& cell,
+        winrt::TableViewColumn const& column,
+        int32_t visibleColumnIndex);
+
 private:
     // The owning TableView, or null once the row has been recycled out of the tree.
     winrt::TableView GetOwningTableView();
     // This row's index in the owner's ItemsSource index space, or -1 when unrealized.
     int32_t GetRowIndex();
+    // 1-based position within the owning group and that group's item count; false when ungrouped.
+    bool TryGetGroupPosition(int32_t rowIndex, int32_t& positionInGroup, int32_t& sizeOfGroup);
+
+    // One peer per realized cell, keyed weakly so a cell dropped by a rebuild or a recycle releases
+    // immediately. Rebuilt wholesale from the live cell list on every GetChildrenCore.
+    struct CellPeerCacheEntry
+    {
+        winrt::weak_ref<winrt::FrameworkElement> cell{ nullptr };
+        winrt::AutomationPeer peer{ nullptr };
+    };
+
+    std::vector<CellPeerCacheEntry> m_cellPeerCache;
 };

--- a/controls/dev/TableView/TableViewRowAutomationPeer.h
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.h
@@ -19,14 +19,12 @@ public:
     winrt::AutomationControlType GetAutomationControlTypeCore();
     winrt::IInspectable GetPatternCore(winrt::PatternInterface const& patternInterface);
 
-    // A TableViewRow is a Control with no content of its own, so the base peer computes no name and
-    // assistive technology announces a bare "data item". Compose the visible cell texts instead.
+    // A TableViewRow is a Control with no content of its own, so the base peer computes no name
+    // and AT announces a bare "data item". Compose the visible cell texts instead.
     hstring GetNameCore();
 
-    // Rows are virtualized, so the UIA parent only ever exposes the realized window and a client
-    // cannot infer "row i of n" from the children collection - the control has to supply it. Same
-    // contract ListViewItemAutomationPeer satisfies. Under grouping these are group-relative,
-    // matching ItemsControlAutomationPeer / NavigationView / TreeView.
+    // Rows are virtualized: UIA only ever sees the realized window, so the control has to supply
+    // "row i of n". Group-relative when the source is grouped.
     int32_t GetPositionInSetCore();
     int32_t GetSizeOfSetCore();
 
@@ -41,11 +39,9 @@ public:
     void RemoveFromSelection();
     void Select();
 
-    // Internal: hands back the peer this row has already published for a cell. Every path that
-    // yields a cell provider (this peer's GetChildrenCore and TableViewAutomationPeer::GetItem)
-    // must route through here - UIA compares providers by identity, so minting a fresh peer per
-    // query makes grid addressing and tree navigation disagree about the same cell, and drops
-    // Narrator focus whenever the tree is re-queried.
+    // Single source of cell-peer identity: GetChildrenCore and TableViewAutomationPeer::GetItem
+    // both route through here. UIA compares providers by identity, so a fresh peer per query makes
+    // grid addressing and tree navigation disagree and drops Narrator focus on every re-query.
     winrt::AutomationPeer GetOrCreateCellPeer(
         winrt::FrameworkElement const& cell,
         winrt::TableViewColumn const& column,
@@ -59,12 +55,8 @@ private:
     // 1-based position within the owning group and that group's item count; false when ungrouped.
     bool TryGetGroupPosition(int32_t rowIndex, int32_t& positionInGroup, int32_t& sizeOfGroup);
 
-    // One peer per realized cell, keyed weakly so a cell dropped by a rebuild or a recycle releases
-    // immediately. Rebuilt wholesale from the live cell list on every GetChildrenCore.
-    //
-    // The peer is held in a tracker_ref, the repo convention for a strong WinRT reference owned by
-    // a ReferenceTracker type, so the reference tracker can walk this edge and collect cycles
-    // rather than the peer being an opaque strong ref inside a tracked object.
+    // One peer per realized cell, keyed weakly so a recycled or rebuilt cell releases immediately.
+    // tracker_ref is the convention for a strong WinRT ref owned by a ReferenceTracker type.
     struct CellPeerCacheEntry
     {
         CellPeerCacheEntry(

--- a/controls/dev/TableView/TableViewRowAutomationPeer.h
+++ b/controls/dev/TableView/TableViewRowAutomationPeer.h
@@ -61,10 +61,23 @@ private:
 
     // One peer per realized cell, keyed weakly so a cell dropped by a rebuild or a recycle releases
     // immediately. Rebuilt wholesale from the live cell list on every GetChildrenCore.
+    //
+    // The peer is held in a tracker_ref, the repo convention for a strong WinRT reference owned by
+    // a ReferenceTracker type, so the reference tracker can walk this edge and collect cycles
+    // rather than the peer being an opaque strong ref inside a tracked object.
     struct CellPeerCacheEntry
     {
+        CellPeerCacheEntry(
+            ITrackerHandleManager const* owner,
+            winrt::FrameworkElement const& cellElement,
+            winrt::AutomationPeer const& cellPeer)
+            : cell(winrt::make_weak(cellElement))
+            , peer(owner, cellPeer)
+        {
+        }
+
         winrt::weak_ref<winrt::FrameworkElement> cell{ nullptr };
-        winrt::AutomationPeer peer{ nullptr };
+        tracker_ref<winrt::AutomationPeer> peer;
     };
 
     std::vector<CellPeerCacheEntry> m_cellPeerCache;

--- a/controls/dev/TableView/TableView_Keyboard.cpp
+++ b/controls/dev/TableView/TableView_Keyboard.cpp
@@ -191,40 +191,21 @@ bool TableView::TryHandleHeaderColumnResizeKey(const winrt::KeyRoutedEventArgs& 
     return true;
 }
 
-// Enter / Space sorts the column whose header has focus. Left/Right are already taken by resize,
-// so activation lands on the standard activation keys.
-bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
+// Resolves the sortable column whose header raised this key, or null when the key did not come
+// from the header chrome itself.
+winrt::TableViewColumn TableView::ResolveHeaderSortKeyTarget(const winrt::KeyRoutedEventArgs& args)
 {
-    if (args.Handled())
-    {
-        return false;
-    }
-
-    const auto key = args.Key();
-    if (key != winrt::Windows::System::VirtualKey::Enter &&
-        key != winrt::Windows::System::VirtualKey::Space)
-    {
-        return false;
-    }
-
-    // Without this, holding the key re-sorts the whole collection once per auto-repeat tick and the
-    // final direction depends on when the user let go.
-    if (args.KeyStatus().WasKeyDown)
-    {
-        return false;
-    }
-
     // Modified chords belong to the app (and Alt alone opens the window menu).
     if (IsKeyDown(winrt::VirtualKey::Menu) ||
         IsKeyDown(winrt::VirtualKey::Control) ||
         IsKeyDown(winrt::VirtualKey::Shift))
     {
-        return false;
+        return nullptr;
     }
 
     if (!CanUserSortColumns())
     {
-        return false;
+        return nullptr;
     }
 
     // Resolves only for focus inside the header band, so Space in a body cell's interactive content
@@ -233,7 +214,7 @@ bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
     auto const column = ResolveFocusedHeaderColumn(args.OriginalSource(), m_headerHost.get(), headerCell);
     if (!column || !column.CanSort())
     {
-        return false;
+        return nullptr;
     }
 
     // The walk above matches any descendant of a header cell, so require the key to have been
@@ -241,7 +222,53 @@ bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
     // AcceptsReturn=false leaves Enter unhandled, which would otherwise toggle the sort.
     if (args.OriginalSource().try_as<winrt::DependencyObject>() != headerCell)
     {
+        return nullptr;
+    }
+
+    return column;
+}
+
+// Enter sorts the column whose header has focus. Left/Right are already taken by resize, so
+// activation lands on the standard activation keys.
+//
+// Space is deliberately NOT activated here: XAML activation semantics (ButtonInteraction) are that
+// Enter fires on key down while Space arms on key down and fires on key up, which is what lets a
+// user press Space, change their mind and move focus away without activating.
+bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
+{
+    if (args.Handled())
+    {
         return false;
+    }
+
+    const auto key = args.Key();
+    const bool isEnter = key == winrt::Windows::System::VirtualKey::Enter;
+    const bool isSpace = key == winrt::Windows::System::VirtualKey::Space;
+    if (!isEnter && !isSpace)
+    {
+        return false;
+    }
+
+    // Without this, holding the key re-arms or re-sorts once per auto-repeat tick.
+    if (args.KeyStatus().WasKeyDown)
+    {
+        // Still consume a held Space so the ancestor ScrollViewer does not page-scroll under the
+        // armed header.
+        return isSpace && m_headerSortSpaceArmedColumn.get() != nullptr;
+    }
+
+    auto const column = ResolveHeaderSortKeyTarget(args);
+    if (!column)
+    {
+        return false;
+    }
+
+    if (isSpace)
+    {
+        // Arm only; the sort happens on key up.
+        m_headerSortSpaceArmedColumn = winrt::make_weak(column);
+        args.Handled(true);
+        return true;
     }
 
     if (!ToggleSortDirection(column))
@@ -252,6 +279,49 @@ bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
     // The sort itself announces through TableView_Sort's notification event.
     args.Handled(true);
     return true;
+}
+
+// Space activates here, on key up, and only if the same header is still the one raising the key -
+// so releasing Space after moving focus elsewhere does not sort.
+bool TableView::TryHandleHeaderSortKeyUp(const winrt::KeyRoutedEventArgs& args)
+{
+    auto const armed = m_headerSortSpaceArmedColumn.get();
+    if (!armed)
+    {
+        return false;
+    }
+
+    if (args.Key() != winrt::Windows::System::VirtualKey::Space)
+    {
+        return false;
+    }
+
+    m_headerSortSpaceArmedColumn = nullptr;
+
+    if (args.Handled())
+    {
+        return false;
+    }
+
+    if (ResolveHeaderSortKeyTarget(args) != armed)
+    {
+        return false;
+    }
+
+    if (!ToggleSortDirection(armed))
+    {
+        return false;
+    }
+
+    args.Handled(true);
+    return true;
+}
+
+void TableView::OnKeyUpForHeaderSort(
+    const winrt::IInspectable& /*sender*/,
+    const winrt::KeyRoutedEventArgs& args)
+{
+    TryHandleHeaderSortKeyUp(args);
 }
 
 void TableView::OnPreviewKeyDownForNavigation(

--- a/controls/dev/TableView/TableView_Keyboard.cpp
+++ b/controls/dev/TableView/TableView_Keyboard.cpp
@@ -191,6 +191,71 @@ bool TableView::TryHandleHeaderColumnResizeKey(const winrt::KeyRoutedEventArgs& 
     return true;
 }
 
+// Enter / Space sorts the column whose header has focus. The header band is not part of row
+// navigation, and Left/Right are already taken by resize, so activation lands on the standard
+// activation keys - the same contract ListView headers and WPF's DataGrid column headers use.
+bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
+{
+    if (args.Handled())
+    {
+        return false;
+    }
+
+    const auto key = args.Key();
+    if (key != winrt::Windows::System::VirtualKey::Enter &&
+        key != winrt::Windows::System::VirtualKey::Space)
+    {
+        return false;
+    }
+
+    // Auto-repeat must not drive one full re-sort per tick: holding the key would re-sort the whole
+    // collection at the repeat rate and leave the direction depending on when the user let go.
+    if (args.KeyStatus().WasKeyDown)
+    {
+        return false;
+    }
+
+    // Modified chords belong to the app (and Alt alone opens the window menu).
+    if (IsKeyDown(winrt::VirtualKey::Menu) ||
+        IsKeyDown(winrt::VirtualKey::Control) ||
+        IsKeyDown(winrt::VirtualKey::Shift))
+    {
+        return false;
+    }
+
+    if (!CanUserSortColumns())
+    {
+        return false;
+    }
+
+    // Resolves only for focus inside the header band, so a Space pressed in a body cell's
+    // interactive content still belongs to that control.
+    winrt::FrameworkElement headerCell{ nullptr };
+    auto const column = ResolveFocusedHeaderColumn(args.OriginalSource(), m_headerHost.get(), headerCell);
+    if (!column || !column.CanSort())
+    {
+        return false;
+    }
+
+    // The walk above matches any DESCENDANT of a header cell, so require the key to have been
+    // raised on the header chrome itself. A header template can host interactive content, and a
+    // TextBox with AcceptsReturn=false deliberately leaves Enter unhandled - without this, typing a
+    // filter into a header TextBox and pressing Enter would also toggle the column sort.
+    if (args.OriginalSource().try_as<winrt::DependencyObject>() != headerCell)
+    {
+        return false;
+    }
+
+    if (!ToggleSortDirection(column))
+    {
+        return false;
+    }
+
+    // The sort itself announces through TableView_Sort's notification event.
+    args.Handled(true);
+    return true;
+}
+
 void TableView::OnPreviewKeyDownForNavigation(
     const winrt::IInspectable& /*sender*/,
     const winrt::KeyRoutedEventArgs& args)
@@ -243,6 +308,12 @@ void TableView::OnKeyDownForNavigation(
     // Column resize from a focused header: after the editing guard, so an open editor keeps its
     // arrow keys, and before row navigation, since the header band is not part of it.
     if (TryHandleHeaderColumnResizeKey(args))
+    {
+        return;
+    }
+
+    // Activation from a focused header: same placement rationale as resize above.
+    if (TryHandleHeaderSortKey(args))
     {
         return;
     }

--- a/controls/dev/TableView/TableView_Keyboard.cpp
+++ b/controls/dev/TableView/TableView_Keyboard.cpp
@@ -191,9 +191,8 @@ bool TableView::TryHandleHeaderColumnResizeKey(const winrt::KeyRoutedEventArgs& 
     return true;
 }
 
-// Enter / Space sorts the column whose header has focus. The header band is not part of row
-// navigation, and Left/Right are already taken by resize, so activation lands on the standard
-// activation keys - the same contract ListView headers and WPF's DataGrid column headers use.
+// Enter / Space sorts the column whose header has focus. Left/Right are already taken by resize,
+// so activation lands on the standard activation keys.
 bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
 {
     if (args.Handled())
@@ -208,8 +207,8 @@ bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
         return false;
     }
 
-    // Auto-repeat must not drive one full re-sort per tick: holding the key would re-sort the whole
-    // collection at the repeat rate and leave the direction depending on when the user let go.
+    // Without this, holding the key re-sorts the whole collection once per auto-repeat tick and the
+    // final direction depends on when the user let go.
     if (args.KeyStatus().WasKeyDown)
     {
         return false;
@@ -228,8 +227,8 @@ bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
         return false;
     }
 
-    // Resolves only for focus inside the header band, so a Space pressed in a body cell's
-    // interactive content still belongs to that control.
+    // Resolves only for focus inside the header band, so Space in a body cell's interactive content
+    // still belongs to that control.
     winrt::FrameworkElement headerCell{ nullptr };
     auto const column = ResolveFocusedHeaderColumn(args.OriginalSource(), m_headerHost.get(), headerCell);
     if (!column || !column.CanSort())
@@ -237,10 +236,9 @@ bool TableView::TryHandleHeaderSortKey(const winrt::KeyRoutedEventArgs& args)
         return false;
     }
 
-    // The walk above matches any DESCENDANT of a header cell, so require the key to have been
-    // raised on the header chrome itself. A header template can host interactive content, and a
-    // TextBox with AcceptsReturn=false deliberately leaves Enter unhandled - without this, typing a
-    // filter into a header TextBox and pressing Enter would also toggle the column sort.
+    // The walk above matches any descendant of a header cell, so require the key to have been
+    // raised on the header chrome itself: a header template can host a TextBox, and
+    // AcceptsReturn=false leaves Enter unhandled, which would otherwise toggle the sort.
     if (args.OriginalSource().try_as<winrt::DependencyObject>() != headerCell)
     {
         return false;
@@ -312,7 +310,6 @@ void TableView::OnKeyDownForNavigation(
         return;
     }
 
-    // Activation from a focused header: same placement rationale as resize above.
     if (TryHandleHeaderSortKey(args))
     {
         return;

--- a/docs/api-specs/TableView/TableView-spec.md
+++ b/docs/api-specs/TableView/TableView-spec.md
@@ -718,10 +718,16 @@ TableView provides UI Automation peers for grid/table accessibility, cell value 
 |---|---|---|
 | `TableViewAutomationPeer` | `FrameworkElementAutomationPeer` | `ISelectionProvider`, `IGridProvider`, `ITableProvider`, `IItemContainerProvider` |
 | `TableViewRowAutomationPeer` | `FrameworkElementAutomationPeer` | `ISelectionItemProvider` |
-| `TableViewColumnHeaderAutomationPeer` | `FrameworkElementAutomationPeer` | (none) |
+| `TableViewColumnHeaderAutomationPeer` | `FrameworkElementAutomationPeer` | `IInvokeProvider` (sort) |
 | `TableViewCellAutomationPeer` | `FrameworkElementAutomationPeer` | `IGridItemProvider`, `ITableItemProvider`, `IValueProvider` |
 
 These peers expose the table structure to assistive technologies. Cell peers also expose their value.
+
+Rows report `PositionInSet` / `SizeOfSet` and compose their name from their visible cells, so a virtualized row still announces "row *i* of *n*" and what it contains. When the source is grouped, both values are **relative to the containing group** and exclude the group-header bands, matching `ItemsControlAutomationPeer`. An app-set `AutomationProperties.PositionInSet` / `SizeOfSet` / `Level` always takes precedence over the computed value.
+
+A cell provider and a column-header provider each keep a stable identity: the row peer owns its cell peers and the TableView peer owns its column-header peers, so tree navigation, `IGridProvider.GetItem` and `ITableItemProvider.GetColumnHeaderItems` all resolve to the same provider for the same element.
+
+`ScrollItem` is not implemented explicitly — `FrameworkElementAutomationPeer` already supplies a `ScrollItemAdapter` for every peer, so a client can bring a row or cell into view after reaching it through `IGridProvider.GetItem`.
 
 `Selection`/`SelectionItem` are advertised only while `SelectionMode` allows selection — advertising them while it is `None` would tell an AT client the grid is selectable when every `Select()` would be refused. `CanSelectMultiple` is `false` and `IsSelectionRequired` is `false`. `GetSelection()` returns the selected row's provider when that row is realized; a selected row scrolled out of the realization window is reached through `IItemContainerProvider.FindItemByProperty`, which realizes it.
 

--- a/docs/api-specs/TableView/TableView-spec.md
+++ b/docs/api-specs/TableView/TableView-spec.md
@@ -725,7 +725,7 @@ These peers expose the table structure to assistive technologies. Cell peers als
 
 Rows report `PositionInSet` / `SizeOfSet` and compose their name from their visible cells, so a virtualized row still announces "row *i* of *n*" and what it contains. When the source is grouped, both values are **relative to the containing group** and exclude the group-header bands, matching `ItemsControlAutomationPeer`. An app-set `AutomationProperties.PositionInSet` / `SizeOfSet` / `Level` always takes precedence over the computed value.
 
-A cell provider and a column-header provider each keep a stable identity: the row peer owns its cell peers and the TableView peer owns its column-header peers, so tree navigation, `IGridProvider.GetItem` and `ITableItemProvider.GetColumnHeaderItems` all resolve to the same provider for the same element.
+A cell provider and a column-header provider each keep a stable identity: the row peer owns its cell peers and the TableView peer owns its column-header peers, so tree navigation, `IGridProvider.GetItem` and `ITableItemProvider.GetColumnHeaderItems` all resolve to the same provider for the same element. (`ITableProvider.GetColumnHeaders` is a known pre-existing exception — it returns an empty array because the header peers are never parented into the UIA tree, so the provider lookup it performs yields nothing to return.)
 
 `ScrollItem` is not implemented explicitly — `FrameworkElementAutomationPeer` already supplies a `ScrollItemAdapter` for every peer, so a client can bring a row or cell into view after reaching it through `IGridProvider.GetItem`.
 

--- a/docs/design-notes/TabularControls/TableView-dev-spec.md
+++ b/docs/design-notes/TabularControls/TableView-dev-spec.md
@@ -164,12 +164,15 @@ Cell generation is column-specific:
 
 Keyboard handling is row-oriented. `TableView` listens to bubbling `KeyDown` so template-column descendants handle input first; unhandled `Up`, `Down`, `Home`, `End`, `PageUp`, and `PageDown` move focus between rows. The internal `GridCoordinateHelper` performs the row/column ↔ flat-index math, wrap behavior, and overflow guards.
 
-Accessibility exposes a read-only UIA grid/table model:
+Accessibility exposes a UIA grid/table model:
 
-- `TableViewAutomationPeer`: `IGridProvider`, `ITableProvider`, `IItemContainerProvider`
-- `TableViewRowAutomationPeer`: `DataItem` control type, no grid/table provider (exposes its cell peers as children)
-- `TableViewCellAutomationPeer`: `IGridItemProvider`, `ITableItemProvider`
-- `TableViewColumnHeaderAutomationPeer`: column-header name/bounds
+- `TableViewAutomationPeer`: `IGridProvider`, `ITableProvider`, `ISelectionProvider`, `IItemContainerProvider`
+- `TableViewRowAutomationPeer`: `DataItem` control type, `ISelectionItemProvider`, composed name and group-relative `PositionInSet`/`SizeOfSet`; no grid/table provider (exposes its cell peers as children)
+- `TableViewCellAutomationPeer`: `IGridItemProvider`, `ITableItemProvider`, `IValueProvider`, localized `cell` control type
+- `TableViewColumnHeaderAutomationPeer`: column-header name/bounds, `IInvokeProvider` (sort), `PositionInSet`/`SizeOfSet`
+- `TableViewGroupHeaderAutomationPeer`: `IExpandCollapseProvider`, `IGridItemProvider`, `Level`
+
+`ScrollItem` is not implemented explicitly on any of these — `FrameworkElementAutomationPeer` already supplies a `ScrollItemAdapter` for every peer.
 
 Lifetime rules: columns and rows use weak owner back-pointers (`GetOwningTableView()` resolves a strong owner for synchronous work); runtime classes use `ReferenceTracker` where required; cross-object events use `auto_revoke`; recycled rows reset transient visual state before reuse.
 
@@ -260,7 +263,7 @@ they can be obsoleted while the API is still `[MUX_PREVIEW]`.
 
 **`TableViewRow`** — `Control` representing one realized item row. `GetOwningTableView()`.
 
-**Automation peers** — `TableViewAutomationPeer`, `TableViewRowAutomationPeer`, `TableViewCellAutomationPeer`, `TableViewColumnHeaderAutomationPeer` (providers: `IGridProvider`, `ITableProvider`, `IGridItemProvider`, `ITableItemProvider`, `IItemContainerProvider`).
+**Automation peers** — `TableViewAutomationPeer`, `TableViewRowAutomationPeer`, `TableViewCellAutomationPeer`, `TableViewColumnHeaderAutomationPeer`, `TableViewGroupHeaderAutomationPeer` (providers: `IGridProvider`, `ITableProvider`, `ISelectionProvider`, `IItemContainerProvider`, `IGridItemProvider`, `ITableItemProvider`, `ISelectionItemProvider`, `IValueProvider`, `IInvokeProvider`, `IExpandCollapseProvider`).
 
 **Enums** — `TableViewFrozenEdge` (`None`/`Leading`/`Trailing`), `TableViewHeadersVisibility` (`None`/`Column`), `TableViewGridLinesVisibility` (`All`/`Horizontal`/`None`/`Vertical`), `TableViewDensity` (`Compact`/`Standard`/`Comfortable`), `TableViewEditingUnit` (`Cell`/`Row`), `TableViewEditAction` (`Commit`/`Cancel`/`Discard`).
 

--- a/docs/design-notes/TabularControls/TableView-dev-spec.md
+++ b/docs/design-notes/TabularControls/TableView-dev-spec.md
@@ -174,6 +174,13 @@ Accessibility exposes a UIA grid/table model:
 
 `ScrollItem` is not implemented explicitly on any of these — `FrameworkElementAutomationPeer` already supplies a `ScrollItemAdapter` for every peer.
 
+Peers that compute `PositionInSet`, `SizeOfSet` or `Level` report `0` — UIA's "not specified" — when the value cannot be resolved, never `-1`, and an app-set `AutomationProperties` value always wins over the computed one.
+
+Two known gaps, both pre-existing and tracked outside this control's code:
+
+- **The cell's localized control type does not reach the user yet.** `GetLocalizedControlTypeCore` resolves `TableViewCellLocalizedControlType` and falls back to the framework default when the lookup fails. That lookup currently always fails in a consuming app: `ResourceAccessor` reads the `Microsoft.UI.Xaml/Resources` subtree while the Tabular PRI indexes under `Microsoft.UI.Xaml.Controls.Tabular/Resources`, so every string in this control's `.resw` — sort, group-header, resize and help-text strings included — silently degrades. Cells announce "data item" until that is fixed.
+- **`ITableProvider::GetColumnHeaders` returns an empty array.** The synthesized header peers are never parented into the UIA tree, so `ProviderFromPeer` yields null for each and every entry is filtered out. A cell's `GetColumnHeaderItems` is unaffected and does return the header provider.
+
 Lifetime rules: columns and rows use weak owner back-pointers (`GetOwningTableView()` resolves a strong owner for synchronous work); runtime classes use `ReferenceTracker` where required; cross-object events use `auto_revoke`; recycled rows reset transient visual state before reuse.
 
 Theme values resolve through `TabularSurfaces` resources and re-resolve across theme (and high-contrast) changes. Dark `TabularSurfaceGridLineBrush` is `#29FFFFFF`; the C++ fallback uses the same 16% white.


### PR DESCRIPTION
## Fixes

<!-- Opened from an accessibility gap review of the TableView automation surface. -->

Fixes #
Internal Issue: https://task.ms/63757754

Also addressed here: https://task.ms/63996585 · https://task.ms/63996586 · https://task.ms/63996583 · https://task.ms/64055746 · https://task.ms/64055747
Dependency (blocks one behaviour below): https://task.ms/64037296
Validation gate: https://task.ms/64037297

## PR Type

- [x] Bugfix

## Description

An accessibility review of `controls/dev/TableView` against the UIA provider contracts. The peers already cover shape well — `IGridProvider`, `ITableProvider`, `ISelectionProvider`, `IItemContainerProvider`, `IGridItemProvider`, `ITableItemProvider`, `IValueProvider`, `IExpandCollapseProvider`, `IInvokeProvider` for sort, plus sort/resize/selection announcements and RTL handling — but they leave gaps in the properties and keyboard paths a Narrator user actually depends on.

### Current Behavior

| Gap | Symptom today |
|---|---|
| `TableViewRowAutomationPeer` overrides no `GetPositionInSetCore` / `GetSizeOfSetCore` | Rows are virtualized, so UIA only ever sees the realized window. Narrator cannot say "row 5 of 200". `TableViewColumnHeaderAutomationPeer` already does this for columns; rows were missed. |
| `TableViewRow` has no name | It is a `Control` with no content of its own, so the base peer computes nothing and AT announces a bare "data item". |
| `TableViewGroupHeaderAutomationPeer` has no `GetLevelCore` | Grouping is genuinely hierarchical (`TableViewGroupInfo::Level`), but two nested groups are announced as siblings. |
| Cells have no `LocalizedControlType` | Every cell is announced as "data item". |
| Header cell `IsTabStop` is gated on resizability alone (`TableView.cpp` `RebuildHeaders`) | In the very common `CanUserSortColumns=true` / `CanUserResizeColumns=false` configuration the header is clickable-to-sort but has no tab stop and no focus visual, so a keyboard-only user can never sort — and `TableViewColumnHeaderAutomationPeer::Invoke` is never reachable by focus. |
| Cell peers are minted fresh per query | `TableViewRowAutomationPeer::GetChildrenCore` and `TableViewAutomationPeer::GetItem` each built a new `TableViewCellAutomationPeer`, and `TableViewCellAutomationPeer::GetColumnHeaderItems` bypassed the TableView peer's existing header cache. UIA compares providers by identity, so grid addressing and tree navigation disagreed about the same cell, and a cell's header reference did not match the table's `GetColumnHeaders` enumeration. |

### New Behavior

**Row peer** — `GetNameCore` composes the visible cell texts (an explicit `AutomationProperties.Name` still wins). `GetPositionInSetCore` / `GetSizeOfSetCore` are **group-relative when the source is grouped**: the flattened projection interleaves group-header bands with data rows, so a global index over it would announce a number the user cannot relate to anything on screen. This matches `ItemsControlAutomationPeer::GetPositionInSetHelper` (`indexInsideGroup` / `countInGroup`), `NavigationViewItemAutomationPeer` (resets its count at each header) and `TreeViewItemAutomationPeer` (scoped to `Parent().Children()`). Ungrouped sources keep the flat basis, which is the same one `TableViewAutomationPeer::RowCount` and `GetItem` use.

**Cell peer** — `GetLocalizedControlTypeCore` returning a new localized `TableViewCellLocalizedControlType` ("cell"), degrading to the framework default when the lookup fails. ⚠️ **This does not reach the user yet**, and the degrade path is what runs today: `ResourceAccessor` reads the `Microsoft.UI.Xaml/Resources` subtree while the Tabular PRI indexes under `Microsoft.UI.Xaml.Controls.Tabular/Resources`, so *every* string in this control's `.resw` silently falls back — cells still announce "data item". Verified with `makepri dump` on both the component PRI and the app-merged PRI. The code here is correct and lights up the moment [63996029 → **64037296**](https://task.ms/64037296) lands; that fix is in shared `ResourceHelper` infrastructure used by MUXC as well, so it is deliberately not in this PR. `GetColumnHeaderItems` now resolves through `TableViewAutomationPeer::GetOrCreateColumnHeaderPeer`. `Column()` is computed live from the cell host, mirroring `Row()`, so a hidden or shown column cannot leave a client holding a stale coordinate.

**UIA property conventions** — `GetPositionInSetCore`, `GetSizeOfSetCore` and `GetLevelCore` all defer to an app-set `AutomationProperties` value first (the override-first pattern every dxaml peer that computes these uses), and report `0` — UIA's "not specified" — rather than `-1` when unknown, matching `TreeViewItemAutomationPeer` and `NavigationViewItemAutomationPeer`. `TableViewColumnHeaderAutomationPeer` is brought onto the same convention here ([63996586](https://task.ms/63996586)) so the control is not inconsistent with itself within one change.

**Provider identity** — the row peer owns a weak-keyed cell-peer cache, rebuilt wholesale on every `GetChildrenCore` and pruned on the `GetItem` miss path (a client that only addresses cells through `IGridProvider::GetItem` never walks children). `TableViewAutomationPeer::GetItem` routes through it, so `IGridProvider.GetItem` and tree navigation hand back the same provider. The existing column-header cache now also caches on a lookup miss instead of only when `GetColumnHeaders` runs. Both caches hold their peer in a `tracker_ref` ([63996585](https://task.ms/63996585), folded in here rather than left as a revisit of code this PR introduces).

⚠️ Note on `ITableProvider::GetColumnHeaders`: it returns an **empty array** today, and this PR does not change that (`git diff` leaves the body untouched). The header peers are never parented into the UIA tree, so `ProviderFromPeer` yields null for each and every entry is filtered out. A cell's `GetColumnHeaderItems` is unaffected and does resolve to the shared header provider. Pre-existing, tracked as [63871587](https://task.ms/63871587).

**Group header peer** — `GetLevelCore` returns `TableViewGroupInfo::Level() + 1` (UIA `Level` is 1-based; 0 means unknown).

**Keyboard** — a header cell is now a tab stop when it is resizable **or** sortable, and `TableView::TryHandleHeaderSortKey` maps unmodified Enter/Space on a focused header to `ToggleSortDirection`. It is guarded on `!args.KeyStatus().WasKeyDown`, so holding the key cannot drive one full re-sort per auto-repeat tick, and it requires the key to have been raised on the header chrome itself — a header template may host a `TextBox`, and `AcceptsReturn=false` deliberately leaves Enter unhandled, so an ancestor-only match would toggle the sort while the user was committing a filter.

**No API surface change.** An earlier revision of this PR added `IScrollItemProvider` to both peers; it was removed. `FrameworkElementAutomationPeer::GetDefaultPattern` already vends a `ScrollItemAdapter` for every FE peer (`FrameworkElementAutomationPeer_Partial.cpp:477-496`), reached whenever `GetPatternCore` returns null (`AutomationPeer_Partial.cpp:1691-1697`), so rows and cells already supported ScrollItem. The override would also have been *weaker*: `StartBringIntoView()` passes `forceIntoView=false`, so it can be refused when an app disables automatic bring-into-view, whereas the adapter forces a non-animated `BringIntoView`. No IDL change, so nothing in `controls/dev/Generated` changes; both specs are updated to say so.

## Customer Impact

User-facing accessibility. A Narrator user gets correct row position and content (group-relative under grouping), a localized "cell" control type, audible group nesting, a keyboard path to sorting, and providers that stay stable across tree refreshes instead of dropping focus.

## Regression Potential

- [x] Medium risk — touches shared components or public APIs

The header tab-stop change adds Tab stops in the sortable-but-not-resizable configuration; it is guarded so no new stops appear when sorting is off. The peer caches change provider lifetime: peers are now held by the row / TableView peer until the next enumeration, keyed weakly and pruned on both the enumeration and the miss path. A keyboard sort does **not** rebuild the header band — `TableViewColumn::SetSortStateInternal` routes to `RefreshSortIndicators`, which patches the chevron in place — so focus survives the gesture.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] Existing tests pass locally — *builds clean* (`Microsoft.UI.Xaml.Controls.Tabular.vcxproj`, amd64chk, 0 warnings / 0 errors). There are **no TableView tests in the repo**, so there is nothing to regress and nothing asserting the new behaviour.

**Validated by UIA against the TableView sample** (amd64chk, unpackaged, rebuilt against a locally packed component so the fresh PRI was genuinely merged; measured with both the managed `System.Windows.Automation` client and the COM `IUIAutomation` client):

| Behaviour | Result |
|---|---|
| Row name composed from its cells | ✅ `"Al, Dev, London"` |
| Row `PositionInSet` / `SizeOfSet`, ungrouped | ✅ `1…150` |
| Group-relative under grouping | ✅ `pos 1…25` inside "Dev", not a global index |
| Group header `Level` | ✅ `1` |
| `IGridProvider::GetItem` ≡ tree child | ✅ identical RuntimeIds, stable across repeat calls |
| Cell ↔ header provider identity | ✅ same provider on repeat queries |
| `Column()` live across hide/show | ✅ 8 → 7 → 8 columns, coordinates re-map, identity holds |
| Header tab stop, sortable but not resizable | ✅ focusable; **not** focusable when neither sortable nor resizable |
| Header `PositionInSet` / `SizeOfSet` | ✅ `1…8 of 8`; a hidden column's header now reports `0`, previously `-1` |
| `tracker_ref` conversion | ✅ no identity regression, no chk assert |

**Still unverified — Enter/Space keyboard sort.** The validation session was RDP with no interactive desktop (`GetForegroundWindow()` returned 0, `SendInput` injected 0 events), so the gesture could not be driven. Posted `WM_KEYDOWN` reached `OnKeyDownForNavigation` for arrow-key resize but not for `VK_RETURN`, which is consistent with XAML's character/accelerator translation on an inactive window rather than a product defect — but it cannot be ruled either way from there. Tracked as [64037297](https://task.ms/64037297) and **this must be confirmed on an interactive machine before the PR leaves draft**, along with the Narrator pass.

## Out of scope — follow-ups

1. **No `ValueProperty` changed event on edit commit.** `TableViewCellAutomationPeer` implements `IValueProvider` (including a full `SetValue`), but nothing raises `ValuePatternIdentifiers::ValueProperty()`, so cached values go stale and a commit is silent. The cell-peer cache added here gives it a correct place to be raised from — the peer the client is actually connected to. ([63787021](https://task.ms/63787021), finding M22)
2. **The focusable header cell is not the rich header peer.** `TableViewColumnHeaderAutomationPeer` is only reachable through `GetColumnHeaders` / `GetColumnHeaderItems`; a user walking the header band reaches the plain `Grid`, whose generic peer has no sort help text, no `PositionInSet`, and no Invoke. Narrator scan mode issues a UIA `Invoke` rather than a keypress, so **Narrator still cannot sort** even with the keyboard fix here — confirmed during validation, where the focused header resolves to a `NamedContainerAutomationPeer`. The natural successor to this PR. ([63996581](https://task.ms/63996581))
3. ~~**Space should activate on `KeyUp`**~~ — **done here** ([63996583](https://task.ms/63996583)). Enter fires on key down; Space arms on key down and fires on key up via a new `KeyUp` handler, so a user can press Space, change their mind and move focus away without sorting. Still needs the keyboard confirmation in 64037297. ([63996583](https://task.ms/63996583))
4. **No `ITransformProvider` on column headers.** Resize is fully plumbed for pointer and keyboard, but a UIA client cannot resize a column or discover that it can. ([63996584](https://task.ms/63996584))
5. **Tabular's `.resw` strings never resolve.** `ResourceAccessor` reads the `Microsoft.UI.Xaml/Resources` subtree while the Tabular PRI indexes under `Microsoft.UI.Xaml.Controls.Tabular/Resources`, so the new cell control type — and every sort, group-header, resize and help-text string already shipping — silently degrades. The fix is in shared `ResourceHelper` infrastructure that MUXC also compiles, so it is not folded in here. ([64037296](https://task.ms/64037296))
6. **Possible high-contrast brush shadowing.** `TableView.xaml` defines root-level `TabularSurface*` brushes that may take precedence over the HighContrast values in `CommonStyles/TabularSurfaces_themeresources.xaml`. Needs an HC repro before changing anything. ([63996587](https://task.ms/63996587))

Previously listed here and now **folded into this PR**: the `tracker_ref` conversion for both peer caches ([63996585](https://task.ms/63996585)), the header peer's `-1` → `0` convention fix ([63996586](https://task.ms/63996586)), and Space-on-`KeyUp` ([63996583](https://task.ms/63996583)).

## Two accessibility bugs found while validating, and fixed here

Both were found by the validation pass on this branch — one is a hole in the feature this PR adds, the other is in a file this PR already touches.

**Rows built only from template columns announced nothing** ([64055747](https://task.ms/64055747)). The row-name composition uses `GetCellDisplayText(..., allowPeerCreation: false)` — correct, because it runs on every UIA name query across every cell — but template content yields nothing on that path and there was no fallback, so the whole name came back empty. Measured: **19 of 19 rows** on the sample's "Interactive cells" page had an empty name, which is precisely the case the composed name exists to fix. It now retries allowing peer creation (bounded to rows that would otherwise be nameless, and the peers it attaches make later queries cheap again), then falls back to the data item, matching `ListViewItemAutomationPeer`. Now 0 empty row names on every page.

**`IItemContainerProvider::FindItemByProperty` looped forever on a group header** ([64055746](https://task.ms/64055746)). `startAfter` resolved against `TableViewRow` only, so a `TableViewGroupHeader` left `startIndex` at `-1` and the search restarted at item 0 — which under grouping *is* that header. A client enumerating the container never advanced past the first group and would hang. Any realized repeater child now resolves, and an unresolvable `startAfter` returns null instead of silently restarting.


