### PR TITLE
Fix XamlSystemBaseType constructibility

### DIFF
--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_TypeInfoPass1Impl.cs
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_TypeInfoPass1Impl.cs
@@ -139,21 +139,21 @@ namespace winrt::");
                     "\r\n    bool XamlSystemBaseType::IsArray() const\r\n    {\r\n        throw ::winrt::hr" +
                     "esult_not_implemented {};\r\n    }\r\n\r\n    bool XamlSystemBaseType::IsCollection() " +
                     "const\r\n    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n    b" +
-                    "ool XamlSystemBaseType::IsConstructible() const\r\n    {\r\n        throw ::winrt::h" +
-                    "result_not_implemented {};\r\n    }\r\n\r\n    bool XamlSystemBaseType::IsDictionary()" +
-                    " const\r\n    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n    " +
-                    "bool XamlSystemBaseType::IsMarkupExtension() const\r\n    {\r\n        throw ::winrt" +
-                    "::hresult_not_implemented {};\r\n    }\r\n\r\n    bool XamlSystemBaseType::IsEnum() co" +
-                    "nst\r\n    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n    boo" +
-                    "l XamlSystemBaseType::IsSystemType() const\r\n    {\r\n        throw ::winrt::hresul" +
-                    "t_not_implemented {};\r\n    }\r\n\r\n    bool XamlSystemBaseType::IsBindable() const\r" +
-                    "\n    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n    IXamlTy" +
-                    "pe XamlSystemBaseType::ItemType() const\r\n    {\r\n        throw ::winrt::hresult_n" +
-                    "ot_implemented {};\r\n    }\r\n\r\n    IXamlType XamlSystemBaseType::KeyType() const\r\n" +
-                    "    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n    IXamlTyp" +
-                    "e XamlSystemBaseType::BoxedType() const\r\n    {\r\n        throw ::winrt::hresult_n" +
-                    "ot_implemented {};\r\n    }\r\n\r\n    TypeName XamlSystemBaseType::UnderlyingType() c" +
-                    "onst\r\n    {\r\n        return { _fullName, TypeKind::Primitive };\r\n    }\r\n\r\n    ");
+                    "ool XamlSystemBaseType::IsConstructible() const\r\n    {\r\n        return false;\r\n " +
+                    "   }\r\n\r\n    bool XamlSystemBaseType::IsDictionary() const\r\n    {\r\n        throw " +
+                    "::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n    bool XamlSystemBaseType::IsMa" +
+                    "rkupExtension() const\r\n    {\r\n        throw ::winrt::hresult_not_implemented {};" +
+                    "\r\n    }\r\n\r\n    bool XamlSystemBaseType::IsEnum() const\r\n    {\r\n        throw ::w" +
+                    "inrt::hresult_not_implemented {};\r\n    }\r\n\r\n    bool XamlSystemBaseType::IsSyste" +
+                    "mType() const\r\n    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r" +
+                    "\n\r\n    bool XamlSystemBaseType::IsBindable() const\r\n    {\r\n        throw ::winrt" +
+                    "::hresult_not_implemented {};\r\n    }\r\n\r\n    IXamlType XamlSystemBaseType::ItemTy" +
+                    "pe() const\r\n    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n" +
+                    "    IXamlType XamlSystemBaseType::KeyType() const\r\n    {\r\n        throw ::winrt:" +
+                    ":hresult_not_implemented {};\r\n    }\r\n\r\n    IXamlType XamlSystemBaseType::BoxedTy" +
+                    "pe() const\r\n    {\r\n        throw ::winrt::hresult_not_implemented {};\r\n    }\r\n\r\n" +
+                    "    TypeName XamlSystemBaseType::UnderlyingType() const\r\n    {\r\n        return {" +
+                    " _fullName, TypeKind::Primitive };\r\n    }\r\n\r\n    ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Projection(KnownNamespaces.WindowsFoundation)));
             this.Write(@"::IInspectable XamlSystemBaseType::ActivateInstance() const
     {

--- a/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_TypeInfoPass1Impl.tt
+++ b/src/XamlCompiler/BuildTasks/Microsoft/Xaml/XamlCompiler/CodeGenerators/CppWinRT/CppWinRT_TypeInfoPass1Impl.tt
@@ -239,7 +239,7 @@ namespace winrt::<#=Colonize(ProjectInfo.RootNamespace)#>::implementation
 
     bool XamlSystemBaseType::IsConstructible() const
     {
-        throw ::winrt::hresult_not_implemented {};
+        return false;
     }
 
     bool XamlSystemBaseType::IsDictionary() const


### PR DESCRIPTION
## Fixes

<!-- Link either the public GitHub issue or the internal issue this PR addresses. Remove the unused line. -->
<!-- PRs without a linked issue may be closed unless they are minor documentation/typo fixes. -->

Fixes #11812 
Internal Issue: https://task.ms/<ado-bug-id>

## PR Type

<!-- Check the type of change. Limit each PR to one type when possible. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

<!-- Describe your changes in detail. -->
XamlSystemBaseType represents a system type for which the generated metadata provider does not emit activation metadata. XamlUserType::IsConstructible() already reports constructibility based on the presence of an activator, while XamlSystemBaseType::IsConstructible() currently throws E_NOTIMPL. This becomes invalid when the type is returned to another metadata provider, because provider resolution explicitly queries IsConstructible() to distinguish usable metadata from a return-type stub or incomplete candidate.
### Current Behavior
<!-- How does this work today? -->

### New Behavior
<!-- How will it work after this PR? -->

## Customer Impact

<!-- How does this change affect end users? Is it user-facing or infra changes? -->

## Regression Potential

<!-- Could this change cause regressions? What areas might be affected? -->

- [x] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

## Screenshots (if appropriate)

<!-- If you are making visual changes, include before/after screenshots. -->