### PR TITLE
Restore wchar_t compatibility aliases

### DIFF
--- a/dxaml/xcp/components/animation/TimeManager.cpp
+++ b/dxaml/xcp/components/animation/TimeManager.cpp
@@ -4,6 +4,20 @@
 #include "precomp.h"
 #include "TimeMgr.h"
 
+// Temporary compatibility aliases for dependencies built with /Zc:wchar_t-.
+// This repo uses /Zc:wchar_t, so native wchar_t callers need to resolve the
+// legacy unsigned-short ConnectAnimation symbols.
+#  if defined(_M_X64) || defined(_M_ARM64EC) || defined(_M_ARM64)
+#    pragma comment(linker, "/alternatename:?ConnectAnimation@CompositionAnimationHelper@@QEAAJPEAUICompositionObject@Composition@UI@Microsoft@ABI@@PEB_WPEAUICompositionAnimation@3456@PEAPEAUICompositionAnimationController@@@Z=?ConnectAnimation@CompositionAnimationHelper@@QEAAJPEAUICompositionObject@Composition@UI@Microsoft@ABI@@PEBGPEAUICompositionAnimation@3456@PEAPEAUICompositionAnimationController@@@Z")
+#
+#    if defined(_M_ARM64EC)
+#      pragma comment(linker, "/alternatename:?ConnectAnimation@CompositionAnimationHelper@@$$hQEAAJPEAUICompositionObject@Composition@UI@Microsoft@ABI@@PEB_WPEAUICompositionAnimation@3456@PEAPEAUICompositionAnimationController@@@Z=?ConnectAnimation@CompositionAnimationHelper@@$$hQEAAJPEAUICompositionObject@Composition@UI@Microsoft@ABI@@PEBGPEAUICompositionAnimation@3456@PEAPEAUICompositionAnimationController@@@Z")
+#    endif
+#
+#  elif defined(_M_IX86)
+#    pragma comment(linker, "/alternatename:?ConnectAnimation@CompositionAnimationHelper@@QAEJPAUICompositionObject@Composition@UI@Microsoft@ABI@@PB_WPAUICompositionAnimation@3456@PAPAUICompositionAnimationController@@@Z=?ConnectAnimation@CompositionAnimationHelper@@QAEJPAUICompositionObject@Composition@UI@Microsoft@ABI@@PBGPAUICompositionAnimation@3456@PAPAUICompositionAnimationController@@@Z")
+#  endif
+
 #include <TranslateTransform.h>
 #include "animation.h"
 #include <palcore.h>

--- a/dxaml/xcp/components/animation/TimeManager.cpp
+++ b/dxaml/xcp/components/animation/TimeManager.cpp
@@ -4,9 +4,11 @@
 #include "precomp.h"
 #include "TimeMgr.h"
 
-// Temporary compatibility aliases for dependencies built with /Zc:wchar_t-.
-// This repo uses /Zc:wchar_t, so native wchar_t callers need to resolve the
-// legacy unsigned-short ConnectAnimation symbols.
+// Temporary wchar_t mangling compatibility shim for microsoft.internal.winuidetails NuGet package.
+// The NuGet was compiled with /Zc:wchar_t- (wchar_t = unsigned short).
+// This repo now uses /Zc:wchar_t (wchar_t = native type).
+// These aliases let our code resolve ConnectAnimation from the NuGet's Internal2.lib.
+// Remove once the NuGet is rebuilt with native wchar_t.
 #  if defined(_M_X64) || defined(_M_ARM64EC) || defined(_M_ARM64)
 #    pragma comment(linker, "/alternatename:?ConnectAnimation@CompositionAnimationHelper@@QEAAJPEAUICompositionObject@Composition@UI@Microsoft@ABI@@PEB_WPEAUICompositionAnimation@3456@PEAPEAUICompositionAnimationController@@@Z=?ConnectAnimation@CompositionAnimationHelper@@QEAAJPEAUICompositionObject@Composition@UI@Microsoft@ABI@@PEBGPEAUICompositionAnimation@3456@PEAPEAUICompositionAnimationController@@@Z")
 #

--- a/dxaml/xcp/components/base/LoadLibraryAbs.cpp
+++ b/dxaml/xcp/components/base/LoadLibraryAbs.cpp
@@ -4,9 +4,11 @@
 #include "precomp.h"
 #include "LoadLibraryAbs.h"
 
-// Temporary compatibility aliases for dependencies built with /Zc:wchar_t-.
-// This repo uses /Zc:wchar_t, so legacy unsigned-short callers need to resolve
-// the native wchar_t GetModuleHandleExWAbs symbol.
+// Temporary wchar_t mangling compatibility shim for microsoft.internal.winuidetails NuGet package.
+// The NuGet was compiled with /Zc:wchar_t- (wchar_t = unsigned short).
+// This repo now uses /Zc:wchar_t (wchar_t = native type).
+// These aliases let the NuGet's InputHelpers.obj resolve GetModuleHandleExWAbs.
+// Remove once the NuGet is rebuilt with native wchar_t.
 #  if defined(_M_X64) || defined(_M_ARM64EC) || defined(_M_ARM64)
 #    pragma comment(linker, "/alternatename:?GetModuleHandleExWAbs@@YAHKPEBGPEAPEAUHINSTANCE__@@@Z=?GetModuleHandleExWAbs@@YAHKPEB_WPEAPEAUHINSTANCE__@@@Z")
 #

--- a/dxaml/xcp/components/base/LoadLibraryAbs.cpp
+++ b/dxaml/xcp/components/base/LoadLibraryAbs.cpp
@@ -4,6 +4,20 @@
 #include "precomp.h"
 #include "LoadLibraryAbs.h"
 
+// Temporary compatibility aliases for dependencies built with /Zc:wchar_t-.
+// This repo uses /Zc:wchar_t, so legacy unsigned-short callers need to resolve
+// the native wchar_t GetModuleHandleExWAbs symbol.
+#  if defined(_M_X64) || defined(_M_ARM64EC) || defined(_M_ARM64)
+#    pragma comment(linker, "/alternatename:?GetModuleHandleExWAbs@@YAHKPEBGPEAPEAUHINSTANCE__@@@Z=?GetModuleHandleExWAbs@@YAHKPEB_WPEAPEAUHINSTANCE__@@@Z")
+#
+#    if defined(_M_ARM64EC)
+#      pragma comment(linker, "/alternatename:?GetModuleHandleExWAbs@@$$hYAHKPEBGPEAPEAUHINSTANCE__@@@Z=?GetModuleHandleExWAbs@@$$hYAHKPEB_WPEAPEAUHINSTANCE__@@@Z")
+#    endif
+#
+#  elif defined(_M_IX86)
+#    pragma comment(linker, "/alternatename:?GetModuleHandleExWAbs@@YGHKPBGPAPAUHINSTANCE__@@@Z=?GetModuleHandleExWAbs@@YGHKPB_WPAPAUHINSTANCE__@@@Z")
+#  endif
+
 #include <windows.h>
 #include <string>
 #include <minerror.h>


### PR DESCRIPTION
## PR Type

- [x] Bugfix

## Description

### Current Behavior

Dependencies built with `/Zc:wchar_t-` can reference legacy `unsigned short` symbol names that are not resolved by WinUI builds using native `wchar_t`.

### New Behavior

Restores architecture-specific linker aliases for `ConnectAnimation` and `GetModuleHandleExWAbs` so both symbol forms resolve across x64, ARM64, ARM64EC, and x86 builds. Later improvements in the affected files remain unchanged.

## Customer Impact

Prevents link failures when compatible dependencies use the alternate `wchar_t` representation. There is no public API or runtime behavior change.

## Regression Potential

- [x] Low risk - isolated change, limited scope

The change only adds linker aliases for existing symbols and does not alter their implementations.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] Existing tests pass locally

Built the affected `Microsoft.UI.Xaml` runtime project successfully with zero warnings and zero errors.

## Screenshots

Not applicable.