### PR TITLE
Add correlated XAML launch phase markers

### DIFF
--- a/docs/design-notes/launch-phase-markers.md
+++ b/docs/design-notes/launch-phase-markers.md
@@ -1,0 +1,100 @@
+# XAML launch boundary observations
+
+For the underlying startup paths, see [Startup for Xaml](startup-overview.md).
+
+`Microsoft-Windows-XAML` (`531a35ab-63ce-4bcf-aa98-f88c7a89e455`) emits the
+TraceLogging event `LaunchPhaseTransition` at six native boundaries. The event
+uses level 0 and keyword 0. The provider must still be enabled; filtering, late
+capture, truncation and event loss can leave incomplete observations.
+
+## Boundaries and canonical intervals
+
+| Ordinal | Boundary |
+| --- | --- |
+| 1 | Entry to `FrameworkApplicationFactory::StartImpl`. |
+| 2 | Immediately before the core's first native `OnLaunchedProtected` callback. |
+| 3 | Return from that callback, before unhandled-error reporting. |
+| 4 | Before `UpdateLayout` in the first qualifying launch draw attempt. |
+| 5 | The selected post-layout boundary in `NWDrawTree`, before the window-destroyed check. |
+| 6 | At draw-attempt cleanup, after frame-end telemetry, when `pFrameDrawn` is true. |
+
+| Phase label | Boundaries | Meaning |
+| --- | --- | --- |
+| FrameworkInitialization | 1 to 2 | Elapsed startup entry to callback entry, including application construction and other app work on that path. Not pure framework CPU time. |
+| ApplicationInitialization | 2 to 3 | Synchronous native callback span, including any nested message pumping. Not all asynchronous initialization. |
+| FirstFrameScheduling | 3 to 4 | Elapsed callback return to the selected initial-layout entry. Not solely scheduler work. |
+| InitialLayout | 4 to 5 | Elapsed initial-layout entry to the post-layout boundary, including intervening callbacks and possibly retries. Not just `UpdateLayout` duration. |
+| FirstFrameProduction | 5 to 6 | Elapsed post-layout boundary to qualifying draw cleanup, including callbacks, waits and possibly later draw attempts. Not pure rendering time. |
+
+Phase values are `None=0`, the five labels above in order (`1..5`),
+`Complete=6`, and `Aborted=7`. `PreviousPhase` and `NextPhase` label the canonical
+sides of a boundary; they do **not** assert a transition in an ordered runtime
+state machine.
+
+`Ordinal` is a boundary identifier, **not** a chronological sequence number.
+Application code can pump messages during `OnLaunched`, so a valid observation
+order is `1,2,4,5,6,3`. The producer does not delay or suppress real frame
+boundaries to manufacture ordered intervals. Retain actual event timestamps.
+Derive the five-phase partition only when all six boundaries are captured once,
+correlated to the same initialization, in chronological ordinal order, and the
+callback returned successfully. Otherwise report the observed partial/nonlinear
+sequence, not negative durations, guessed boundaries or a loss diagnosis.
+
+Marker 3 uses `NextPhase=Aborted` for a failed HRESULT. This describes callback
+failure only; it neither terminates nor resets the independent frame observations.
+Marker 6's `Complete` means the draw observation was reached, not successful app
+launch. `Result` is the callback HRESULT at boundary 3 and the current draw HRESULT
+at boundary 6 (which can fail after submission); it is zero elsewhere.
+
+Some asynchronous overrides return at an incomplete await, while completed awaits
+may not yield. Continuations can run in later intervals, across retries or after
+boundary 6. No marker establishes async completion, presentation, window-specific
+first pixels, app readiness or input responsiveness. In particular, synchronous
+`CompositionTarget.Rendered` handlers run before boundary 6.
+
+## Identity, scope and repeated work
+
+`StartupId` and `CoreId` are nonzero numeric identities unique within a loaded
+instance of this XAML producer. Scope them to the trace, process lifetime and
+producer-module lifetime; do not join across processes or module reloads.
+
+At boundary 1, `CoreId=0`: the core does not yet exist. A thread-local startup
+scope lets the first core constructed on that thread claim the `StartupId`
+once. Its later events carry that token and its independent `CoreId`.
+`EntryKind=1` (`ApplicationStart`) identifies this association. Normal first
+desktop `Application.Start` initialization is the supported full six-boundary
+scenario; a start that fails before core/callback construction stays partial.
+
+`EntryKind=2` (`CoreInitialization`) and `NoApplicationStart` identify a core
+without that association. Standalone islands, additional cores, reinitialization
+under an already-claimed startup scope and startup on another thread produce
+independent partial sequences. In particular, the UWP cross-thread path does not
+inherit the startup token. Never infer an equivalent marker 1 for these paths or
+attach their observations to the most recent process-wide `Application.Start`.
+
+Only the first `OnLaunched` invocation and first qualifying layout/production/draw
+boundaries are recorded per core lifetime. Warm activations and
+`StartApplication` content replacement do not reset these latches. Multiple
+windows/islands can share a core; these are core-scoped, not per-window phases.
+The callback's return retains its original identity even if app code destroys or
+replaces the core, without extending the core's lifetime.
+
+`DrawAttemptId` counts `NWDrawTree` attempts in this core until boundary 6.
+Boundaries 4/5/6 include the attempt ID; other boundaries use zero.
+`FrameNumber` is the submission counter at attempt entry, not an attempt count
+or proof of presentation, and is zero for boundaries 1/2/3. A retry can have the
+same `FrameNumber` but a different `DrawAttemptId`. Boundaries 4 and 5 are not
+repeated on retries; the intervals can therefore include work from later attempts.
+
+`Flags` is a bitmask of producer observations, accumulated while the core exists:
+
+| Bit | Meaning |
+| --- | --- |
+| `0x1` NoApplicationStart | No startup scope was associated with this core. This does not mean ETW lost marker 1. |
+| `0x2` NonCanonicalOrder | The producer reached a boundary other than the next canonical ordinal. |
+| `0x4` CallbackFailed | The first callback returned a failed HRESULT. |
+| `0x8` MultipleDrawAttempts | A frame-side boundary occurred in an attempt other than boundary 4's attempt. |
+| `0x10` CoreUnavailableAtCallbackReturn | The original core was absent or replaced at callback return; its return event uses a saved identity. |
+
+Flags are not predictions: a callback can fail after an already-observed frame
+completion. Missing captured events cannot be diagnosed solely from these flags.

--- a/docs/design-notes/launch-phase-markers.md
+++ b/docs/design-notes/launch-phase-markers.md
@@ -2,10 +2,31 @@
 
 For the underlying startup paths, see [Startup for Xaml](startup-overview.md).
 
-`Microsoft-Windows-XAML` (`531a35ab-63ce-4bcf-aa98-f88c7a89e455`) emits the
-TraceLogging event `LaunchPhaseTransition` at six native boundaries. The event
-uses level 0 and keyword 0. The provider must still be enabled; filtering, late
-capture, truncation and event loss can leave incomplete observations.
+`Microsoft-Windows-XAML-Profiler` (`A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D`)
+emits the TraceLogging event `LaunchPhaseTransition` at six native boundaries
+in profiler-enabled builds. The event uses level 0 and keyword 0. The provider
+must still be enabled; filtering, late capture, truncation and event loss can
+leave incomplete observations.
+
+## Compile-time availability
+
+All launch instrumentation is guarded by `XAMLPROFILER_ENABLED`, the existing
+profiler macro driven by `XamlProfilerEnabled` in `dxaml\Xaml.Cpp.Props`.
+The property is off by default. Follow
+[Activating the framework-side profiler](../../tools/XamlProfiler/docs/activateframework.md)
+to opt into a profiler build; do not define the macro independently of the build
+property, which also controls source inclusion.
+
+When disabled, the launch implementation and test sources are excluded, and
+the compiler sees no launch declarations, core member, TLS/counters, startup
+scope, or callback/frame instrumentation. This is compile-time removal, not a
+runtime no-op. Existing standard XAML telemetry is unaffected.
+
+When compiled in, launch state continues to advance even if no ETW session is
+listening. Starting a capture late does not restart the launch sequence.
+Consumers must subscribe to the profiler provider above; this event is not
+emitted by the ordinary `Microsoft-Windows-XAML` provider. Missing launch events
+can mean the producer was not compiled into that binary, not necessarily event loss.
 
 ## Boundaries and canonical intervals
 

--- a/docs/design-notes/startup-overview.md
+++ b/docs/design-notes/startup-overview.md
@@ -19,6 +19,9 @@ Note that UWP mode is not supported publicly, we only keep it running because te
 Refer to the [Startup Flow Diagram](#startup-flow-diagram) at the bottom of this page to see a graphical overview of the
 important steps in the initialization process.
 
+For the six ETW launch boundaries and their five canonical intervals, see
+[XAML launch boundary observations](launch-phase-markers.md).
+
 There are four pieces to startup:
   1. DXamlCore initialization (DirectUI::DXamlCore::InitializeImpl)
   2. CJupiterWindow initialization (DirectUI::DXamlCore::ConfigureJupiterWindow)

--- a/dxaml/xcp/components/base/XamlLaunchTrace.cpp
+++ b/dxaml/xcp/components/base/XamlLaunchTrace.cpp
@@ -2,9 +2,14 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "precomp.h"
+
+#ifndef XAMLPROFILER_ENABLED
+#error "XamlLaunchTrace.cpp requires XAMLPROFILER_ENABLED; keep its ClCompile entry conditioned on XamlProfilerEnabled."
+#endif
+
 #include <atomic>
 #include <XamlLaunchPhase.h>
-#include <XamlTelemetry.h>
+#include <XamlProfilerTracing.h>
 
 namespace
 {
@@ -43,7 +48,7 @@ XamlLaunchStartupScope::XamlLaunchStartupScope() noexcept
     observation.entryKind = XamlLaunchEntryKind::ApplicationStart;
     observation.nextPhase = XamlLaunchPhase::FrameworkInitialization;
     observation.ordinal = 1;
-    XamlTelemetry::LaunchPhaseTransition(observation);
+    XamlProfilerTracing::LaunchPhaseTransition(observation);
 }
 
 XamlLaunchStartupScope::~XamlLaunchStartupScope()
@@ -104,7 +109,7 @@ XamlLaunchObservation XamlLaunchTrace::EndOnLaunched(
     auto observation = callbackStart;
     SetCallbackResult(observation, result);
     observation.flags |= static_cast<uint32_t>(XamlLaunchObservationFlags::CoreUnavailableAtCallbackReturn);
-    XamlTelemetry::LaunchPhaseTransition(observation);
+    XamlProfilerTracing::LaunchPhaseTransition(observation);
     return observation;
 }
 
@@ -164,5 +169,5 @@ void XamlLaunchTrace::WriteBoundary(
     m_observation.frameNumber = frameNumber;
     m_observation.drawAttemptId = drawAttemptId;
     m_observation.result = result;
-    XamlTelemetry::LaunchPhaseTransition(m_observation);
+    XamlProfilerTracing::LaunchPhaseTransition(m_observation);
 }

--- a/dxaml/xcp/components/base/XamlLaunchTrace.cpp
+++ b/dxaml/xcp/components/base/XamlLaunchTrace.cpp
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "precomp.h"
+#include <atomic>
+#include <XamlLaunchPhase.h>
+#include <XamlTelemetry.h>
+
+namespace
+{
+    std::atomic<uint64_t> s_nextLaunchIdentity{0};
+
+    uint64_t NextLaunchIdentity() noexcept
+    {
+        return s_nextLaunchIdentity.fetch_add(1, std::memory_order_relaxed) + 1;
+    }
+
+    void SetCallbackResult(XamlLaunchObservation& observation, uint32_t result) noexcept
+    {
+        observation.previousPhase = XamlLaunchPhase::ApplicationInitialization;
+        observation.nextPhase = FAILED(static_cast<HRESULT>(result)) ?
+            XamlLaunchPhase::Aborted : XamlLaunchPhase::FirstFrameScheduling;
+        observation.ordinal = 3;
+        observation.frameNumber = 0;
+        observation.drawAttemptId = 0;
+        observation.result = result;
+        if (FAILED(static_cast<HRESULT>(result)))
+        {
+            observation.flags |= static_cast<uint32_t>(XamlLaunchObservationFlags::CallbackFailed);
+        }
+    }
+}
+
+thread_local XamlLaunchStartupScope* XamlLaunchStartupScope::s_current = nullptr;
+
+XamlLaunchStartupScope::XamlLaunchStartupScope() noexcept
+    : m_previous(s_current)
+    , m_startupId(NextLaunchIdentity())
+{
+    s_current = this;
+    XamlLaunchObservation observation;
+    observation.startupId = m_startupId;
+    observation.entryKind = XamlLaunchEntryKind::ApplicationStart;
+    observation.nextPhase = XamlLaunchPhase::FrameworkInitialization;
+    observation.ordinal = 1;
+    XamlTelemetry::LaunchPhaseTransition(observation);
+}
+
+XamlLaunchStartupScope::~XamlLaunchStartupScope()
+{
+    s_current = m_previous;
+}
+
+XamlLaunchTrace::XamlLaunchTrace() noexcept
+{
+    m_observation.coreId = NextLaunchIdentity();
+    auto scope = XamlLaunchStartupScope::s_current;
+    if (scope && !scope->m_claimed)
+    {
+        scope->m_claimed = true;
+        m_observation.startupId = scope->m_startupId;
+        m_observation.entryKind = XamlLaunchEntryKind::ApplicationStart;
+    }
+    else
+    {
+        m_observation.startupId = m_observation.coreId;
+        m_observation.flags = static_cast<uint32_t>(XamlLaunchObservationFlags::NoApplicationStart);
+    }
+}
+
+XamlLaunchObservation XamlLaunchTrace::BeginOnLaunched() noexcept
+{
+    // Warm activations do not start a new core-initialization sequence.
+    if (m_callbackStarted)
+    {
+        return {};
+    }
+
+    m_callbackStarted = true;
+    WriteBoundary(XamlLaunchPhase::FrameworkInitialization, XamlLaunchPhase::ApplicationInitialization, 2);
+    return m_observation;
+}
+
+XamlLaunchObservation XamlLaunchTrace::EndOnLaunched(
+    const XamlLaunchObservation& callbackStart,
+    XamlLaunchTrace* currentCoreTrace,
+    uint32_t result) noexcept
+{
+    if (callbackStart.ordinal == 0)
+    {
+        return {};
+    }
+
+    if (currentCoreTrace && currentCoreTrace->m_observation.coreId == callbackStart.coreId)
+    {
+        SetCallbackResult(currentCoreTrace->m_observation, result);
+        currentCoreTrace->WriteBoundary(
+            XamlLaunchPhase::ApplicationInitialization, currentCoreTrace->m_observation.nextPhase, 3, 0, 0, result);
+        return currentCoreTrace->m_observation;
+    }
+
+    // App code can tear down or replace the core. Retain only value-type identity
+    // across the callout, and never attach its return to the replacement core.
+    auto observation = callbackStart;
+    SetCallbackResult(observation, result);
+    observation.flags |= static_cast<uint32_t>(XamlLaunchObservationFlags::CoreUnavailableAtCallbackReturn);
+    XamlTelemetry::LaunchPhaseTransition(observation);
+    return observation;
+}
+
+uint64_t XamlLaunchTrace::BeginDrawAttempt() noexcept
+{
+    return m_frameCompleted ? 0 : ++m_drawAttemptId;
+}
+
+void XamlLaunchTrace::BeginLayout(uint32_t frameNumber, uint64_t drawAttemptId) noexcept
+{
+    if (m_layoutAttemptId == 0)
+    {
+        m_layoutAttemptId = drawAttemptId;
+        WriteBoundary(XamlLaunchPhase::FirstFrameScheduling, XamlLaunchPhase::InitialLayout, 4, frameNumber, drawAttemptId);
+    }
+}
+
+void XamlLaunchTrace::BeginProduction(uint32_t frameNumber, uint64_t drawAttemptId) noexcept
+{
+    if (m_layoutAttemptId != 0 && !m_productionStarted)
+    {
+        m_productionStarted = true;
+        WriteBoundary(XamlLaunchPhase::InitialLayout, XamlLaunchPhase::FirstFrameProduction, 5, frameNumber, drawAttemptId);
+    }
+}
+
+void XamlLaunchTrace::EndDraw(uint32_t frameNumber, uint64_t drawAttemptId, bool frameDrawn, uint32_t result) noexcept
+{
+    if (m_productionStarted && !m_frameCompleted && frameDrawn)
+    {
+        m_frameCompleted = true;
+        WriteBoundary(XamlLaunchPhase::FirstFrameProduction, XamlLaunchPhase::Complete, 6, frameNumber, drawAttemptId, result);
+    }
+}
+
+void XamlLaunchTrace::WriteBoundary(
+    XamlLaunchPhase previousPhase,
+    XamlLaunchPhase nextPhase,
+    uint32_t ordinal,
+    uint32_t frameNumber,
+    uint64_t drawAttemptId,
+    uint32_t result) noexcept
+{
+    if (ordinal != m_lastOrdinal + 1)
+    {
+        m_observation.flags |= static_cast<uint32_t>(XamlLaunchObservationFlags::NonCanonicalOrder);
+    }
+    if (m_layoutAttemptId != 0 && drawAttemptId != 0 && drawAttemptId != m_layoutAttemptId)
+    {
+        m_observation.flags |= static_cast<uint32_t>(XamlLaunchObservationFlags::MultipleDrawAttempts);
+    }
+
+    m_lastOrdinal = ordinal;
+    m_observation.previousPhase = previousPhase;
+    m_observation.nextPhase = nextPhase;
+    m_observation.ordinal = ordinal;
+    m_observation.frameNumber = frameNumber;
+    m_observation.drawAttemptId = drawAttemptId;
+    m_observation.result = result;
+    XamlTelemetry::LaunchPhaseTransition(m_observation);
+}

--- a/dxaml/xcp/components/base/inc/XamlProfilerTracing.h
+++ b/dxaml/xcp/components/base/inc/XamlProfilerTracing.h
@@ -5,14 +5,13 @@
 
 #include <TraceLoggingInterop.h>
 
-// XamlProfiler tree-tracking instrumentation is compiled into chk/Debug builds only
-// (XAMLPROFILER_ENABLED is defined alongside DBG when Configuration==Debug; see
-// Xaml.Cpp.Targets / LibraryCompile.props). In retail/fre builds this entire header is
-// empty, and the matching WucVisualTreeProfiler.cpp is excluded from the build, so the
-// profiler adds zero code/size to shipping binaries. Every consumer #includes this header
-// (and its call sites) inside its own #ifdef XAMLPROFILER_ENABLED, matching the
-// SwipeTestHooks convention.
+// XamlProfiler tree and launch instrumentation is opt-in through XamlProfilerEnabled
+// (off by default; see Xaml.Cpp.Props). Xaml.Cpp.Targets / LibraryCompile.props define
+// XAMLPROFILER_ENABLED when enabled. Dedicated profiler sources are excluded when off;
+// consumers guard their includes, declarations and call sites with the same macro.
 #ifdef XAMLPROFILER_ENABLED
+
+#include <XamlLaunchPhase.h>
 
 class CDependencyObject;
 
@@ -33,7 +32,7 @@ uint64_t XamlProfilerGetPeerHandle(_In_opt_ const CDependencyObject* obj) noexce
 // measured on demand. 0 when obj is null. Defined in uielement.cpp alongside XamlProfilerGetPeerHandle.
 uint64_t XamlProfilerGetCoreSize(_In_opt_ const CDependencyObject* obj) noexcept;
 
-// TraceLogging provider for XAML Profiler tree-tracking events.
+// TraceLogging provider for XAML Profiler tree-tracking and launch events.
 // These events allow an out-of-process profiler to reconstruct and diff the logical tree,
 // visual tree, and composition tree over the lifetime of the host process.
 //
@@ -50,6 +49,24 @@ class XamlProfilerTracing final : public TelemetryBase
     IMPLEMENT_TELEMETRY_CLASS(XamlProfilerTracing, XamlProfilerLogging);
 
 public:
+
+    // Level/keyword zero does not bypass provider enablement or guarantee delivery.
+    static void LaunchPhaseTransition(const XamlLaunchObservation& observation) noexcept
+    {
+        TraceLoggingProviderWrite(
+            XamlProfilerTracing, "LaunchPhaseTransition",
+            TraceLoggingUInt32(static_cast<uint32_t>(observation.previousPhase), "PreviousPhase"),
+            TraceLoggingUInt32(static_cast<uint32_t>(observation.nextPhase), "NextPhase"),
+            TraceLoggingUInt32(observation.ordinal, "Ordinal"),
+            TraceLoggingUInt32(observation.frameNumber, "FrameNumber"),
+            TraceLoggingUInt64(observation.startupId, "StartupId"),
+            TraceLoggingUInt64(observation.coreId, "CoreId"),
+            TraceLoggingUInt32(static_cast<uint32_t>(observation.entryKind), "EntryKind"),
+            TraceLoggingUInt64(observation.drawAttemptId, "DrawAttemptId"),
+            TraceLoggingUInt32(observation.flags, "Flags"),
+            TraceLoggingUInt32(observation.result, "Result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_LOG_ALWAYS));
+    }
 
     // =====================================================================
     // Logical Tree Events

--- a/dxaml/xcp/components/base/inc/XamlTelemetry.h
+++ b/dxaml/xcp/components/base/inc/XamlTelemetry.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <TraceLoggingInterop.h>
+#include <XamlLaunchPhase.h>
 
 // Uncomment to trace allocations via ETW
 //#define TRACE_ALLOC 1
@@ -30,6 +31,24 @@ class XamlTelemetry final : public TelemetryBase
     IMPLEMENT_TELEMETRY_CLASS(XamlTelemetry, XamlTelemetryLogging);
 
 public:
+
+    // Level/keyword zero does not bypass provider enablement or guarantee delivery.
+    static void LaunchPhaseTransition(const XamlLaunchObservation& observation) noexcept
+    {
+        TraceLoggingProviderWrite(
+            XamlTelemetry, "LaunchPhaseTransition",
+            TraceLoggingUInt32(static_cast<uint32_t>(observation.previousPhase), "PreviousPhase"),
+            TraceLoggingUInt32(static_cast<uint32_t>(observation.nextPhase), "NextPhase"),
+            TraceLoggingUInt32(observation.ordinal, "Ordinal"),
+            TraceLoggingUInt32(observation.frameNumber, "FrameNumber"),
+            TraceLoggingUInt64(observation.startupId, "StartupId"),
+            TraceLoggingUInt64(observation.coreId, "CoreId"),
+            TraceLoggingUInt32(static_cast<uint32_t>(observation.entryKind), "EntryKind"),
+            TraceLoggingUInt64(observation.drawAttemptId, "DrawAttemptId"),
+            TraceLoggingUInt32(observation.flags, "Flags"),
+            TraceLoggingUInt32(observation.result, "Result"),
+            TraceLoggingLevel(WINEVENT_LEVEL_LOG_ALWAYS));
+    }
 
     // Calling into a public API
     DEFINE_TRACELOGGING_EVENT_PARAM4(PublicApiCall,

--- a/dxaml/xcp/components/base/inc/XamlTelemetry.h
+++ b/dxaml/xcp/components/base/inc/XamlTelemetry.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <TraceLoggingInterop.h>
-#include <XamlLaunchPhase.h>
 
 // Uncomment to trace allocations via ETW
 //#define TRACE_ALLOC 1
@@ -31,24 +30,6 @@ class XamlTelemetry final : public TelemetryBase
     IMPLEMENT_TELEMETRY_CLASS(XamlTelemetry, XamlTelemetryLogging);
 
 public:
-
-    // Level/keyword zero does not bypass provider enablement or guarantee delivery.
-    static void LaunchPhaseTransition(const XamlLaunchObservation& observation) noexcept
-    {
-        TraceLoggingProviderWrite(
-            XamlTelemetry, "LaunchPhaseTransition",
-            TraceLoggingUInt32(static_cast<uint32_t>(observation.previousPhase), "PreviousPhase"),
-            TraceLoggingUInt32(static_cast<uint32_t>(observation.nextPhase), "NextPhase"),
-            TraceLoggingUInt32(observation.ordinal, "Ordinal"),
-            TraceLoggingUInt32(observation.frameNumber, "FrameNumber"),
-            TraceLoggingUInt64(observation.startupId, "StartupId"),
-            TraceLoggingUInt64(observation.coreId, "CoreId"),
-            TraceLoggingUInt32(static_cast<uint32_t>(observation.entryKind), "EntryKind"),
-            TraceLoggingUInt64(observation.drawAttemptId, "DrawAttemptId"),
-            TraceLoggingUInt32(observation.flags, "Flags"),
-            TraceLoggingUInt32(observation.result, "Result"),
-            TraceLoggingLevel(WINEVENT_LEVEL_LOG_ALWAYS));
-    }
 
     // Calling into a public API
     DEFINE_TRACELOGGING_EVENT_PARAM4(PublicApiCall,

--- a/dxaml/xcp/components/base/lib/Microsoft.UI.Xaml.Base.vcxproj
+++ b/dxaml/xcp/components/base/lib/Microsoft.UI.Xaml.Base.vcxproj
@@ -24,11 +24,11 @@
         <ClCompile Include="..\FloatUtil.cpp"/>
         <ClCompile Include="..\bit_vector.cpp"/>
         <ClCompile Include="..\DesignMode.cpp"/>
-        <ClCompile Include="..\XamlLaunchTrace.cpp"/>
+        <ClCompile Condition="'$(XamlProfilerEnabled)'=='true'" Include="..\XamlLaunchTrace.cpp"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ClInclude Include="$(XcpPath)\inc\XamlLaunchPhase.h"/>
+        <ClInclude Condition="'$(XamlProfilerEnabled)'=='true'" Include="$(XcpPath)\inc\XamlLaunchPhase.h"/>
         <ClInclude Condition="'$(XamlProfilerEnabled)'=='true'" Include="..\inc\XamlProfilerTracing.h"/>
     </ItemGroup>
 

--- a/dxaml/xcp/components/base/lib/Microsoft.UI.Xaml.Base.vcxproj
+++ b/dxaml/xcp/components/base/lib/Microsoft.UI.Xaml.Base.vcxproj
@@ -24,9 +24,11 @@
         <ClCompile Include="..\FloatUtil.cpp"/>
         <ClCompile Include="..\bit_vector.cpp"/>
         <ClCompile Include="..\DesignMode.cpp"/>
+        <ClCompile Include="..\XamlLaunchTrace.cpp"/>
     </ItemGroup>
 
     <ItemGroup>
+        <ClInclude Include="$(XcpPath)\inc\XamlLaunchPhase.h"/>
         <ClInclude Condition="'$(XamlProfilerEnabled)'=='true'" Include="..\inc\XamlProfilerTracing.h"/>
     </ItemGroup>
 

--- a/dxaml/xcp/components/base/unittests/Microsoft.UI.Xaml.Tests.Isolated.Base.vcxproj
+++ b/dxaml/xcp/components/base/unittests/Microsoft.UI.Xaml.Tests.Isolated.Base.vcxproj
@@ -26,12 +26,14 @@
         <ClInclude Include="SmartPointerUnitTests.h"/>
         <ClInclude Include="ThreadLocalStorageUnitTests.h"/>
         <ClInclude Include="VectorTreeUnitTests.h"/>
+        <ClInclude Include="XamlLaunchTraceUnitTests.h"/>
 
         <ClCompile Include="CompactInlineVectorUnitTests.cpp"/>
         <ClCompile Include="SmartPointerUnitTests.cpp"/>
         <ClCompile Include="ThreadLocalStorageUnitTests.cpp"/>
         <ClCompile Include="VectorTreeUnitTests.cpp"/>
         <ClCompile Include="BitVectorUnitTests.cpp"/>
+        <ClCompile Include="XamlLaunchTraceUnitTests.cpp"/>
     </ItemGroup>
 
     <ItemDefinitionGroup>

--- a/dxaml/xcp/components/base/unittests/Microsoft.UI.Xaml.Tests.Isolated.Base.vcxproj
+++ b/dxaml/xcp/components/base/unittests/Microsoft.UI.Xaml.Tests.Isolated.Base.vcxproj
@@ -26,14 +26,14 @@
         <ClInclude Include="SmartPointerUnitTests.h"/>
         <ClInclude Include="ThreadLocalStorageUnitTests.h"/>
         <ClInclude Include="VectorTreeUnitTests.h"/>
-        <ClInclude Include="XamlLaunchTraceUnitTests.h"/>
+        <ClInclude Condition="'$(XamlProfilerEnabled)'=='true'" Include="XamlLaunchTraceUnitTests.h"/>
 
         <ClCompile Include="CompactInlineVectorUnitTests.cpp"/>
         <ClCompile Include="SmartPointerUnitTests.cpp"/>
         <ClCompile Include="ThreadLocalStorageUnitTests.cpp"/>
         <ClCompile Include="VectorTreeUnitTests.cpp"/>
         <ClCompile Include="BitVectorUnitTests.cpp"/>
-        <ClCompile Include="XamlLaunchTraceUnitTests.cpp"/>
+        <ClCompile Condition="'$(XamlProfilerEnabled)'=='true'" Include="XamlLaunchTraceUnitTests.cpp"/>
     </ItemGroup>
 
     <ItemDefinitionGroup>

--- a/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.cpp
+++ b/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.cpp
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "precomp.h"
+#include "XamlLaunchTraceUnitTests.h"
+#include <XamlLaunchPhase.h>
+#include <thread>
+
+namespace Windows { namespace UI { namespace Xaml { namespace Tests { namespace Base {
+
+    namespace
+    {
+        bool HasFlag(const XamlLaunchObservation& observation, XamlLaunchObservationFlags flag)
+        {
+            return (observation.flags & static_cast<uint32_t>(flag)) != 0;
+        }
+
+        void Draw(XamlLaunchTrace& trace)
+        {
+            const auto attempt = trace.BeginDrawAttempt();
+            trace.BeginLayout(1, attempt);
+            trace.BeginProduction(1, attempt);
+            trace.EndDraw(1, attempt, true, S_OK);
+        }
+    }
+
+    void XamlLaunchTraceUnitTests::LinearBoundaries()
+    {
+        XamlLaunchStartupScope startup;
+        XamlLaunchTrace trace;
+        const auto callback = trace.BeginOnLaunched();
+        VERIFY_ARE_EQUAL(2u, callback.ordinal);
+        VERIFY_IS_TRUE(callback.entryKind == XamlLaunchEntryKind::ApplicationStart);
+        VERIFY_IS_TRUE(callback.startupId != 0 && callback.coreId != 0);
+        VERIFY_ARE_NOT_EQUAL(callback.startupId, callback.coreId);
+        VERIFY_ARE_EQUAL(3u, XamlLaunchTrace::EndOnLaunched(callback, &trace, S_OK).ordinal);
+
+        const auto attempt = trace.BeginDrawAttempt();
+        trace.BeginLayout(1, attempt);
+        VERIFY_ARE_EQUAL(4u, trace.GetLastObservation().ordinal);
+        trace.BeginProduction(1, attempt);
+        VERIFY_ARE_EQUAL(5u, trace.GetLastObservation().ordinal);
+        trace.EndDraw(1, attempt, true, S_OK);
+        const auto completed = trace.GetLastObservation();
+        VERIFY_ARE_EQUAL(6u, completed.ordinal);
+        VERIFY_ARE_EQUAL(0u, completed.flags);
+        VERIFY_ARE_EQUAL(callback.startupId, completed.startupId);
+        VERIFY_ARE_EQUAL(callback.coreId, completed.coreId);
+        VERIFY_ARE_EQUAL(attempt, completed.drawAttemptId);
+    }
+
+    void XamlLaunchTraceUnitTests::RenderingBeforeCallbackReturn()
+    {
+        for (const HRESULT result : { S_OK, E_FAIL })
+        {
+            XamlLaunchStartupScope startup;
+            XamlLaunchTrace trace;
+            const auto callback = trace.BeginOnLaunched();
+            Draw(trace);
+            VERIFY_ARE_EQUAL(6u, trace.GetLastObservation().ordinal);
+            VERIFY_IS_TRUE(HasFlag(trace.GetLastObservation(), XamlLaunchObservationFlags::NonCanonicalOrder));
+
+            const auto returned = XamlLaunchTrace::EndOnLaunched(callback, &trace, static_cast<uint32_t>(result));
+            VERIFY_ARE_EQUAL(3u, returned.ordinal);
+            VERIFY_IS_TRUE(HasFlag(returned, XamlLaunchObservationFlags::NonCanonicalOrder));
+            VERIFY_ARE_EQUAL(FAILED(result), HasFlag(returned, XamlLaunchObservationFlags::CallbackFailed));
+            VERIFY_ARE_EQUAL(uint64_t{0}, trace.BeginDrawAttempt());
+        }
+    }
+
+    void XamlLaunchTraceUnitTests::CallbackFailureDoesNotStopFrameObservations()
+    {
+        XamlLaunchStartupScope startup;
+        XamlLaunchTrace trace;
+        const auto callback = trace.BeginOnLaunched();
+        const auto returned = XamlLaunchTrace::EndOnLaunched(callback, &trace, static_cast<uint32_t>(E_FAIL));
+        VERIFY_IS_TRUE(returned.nextPhase == XamlLaunchPhase::Aborted);
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(E_FAIL), returned.result);
+        Draw(trace);
+        VERIFY_IS_TRUE(trace.GetLastObservation().nextPhase == XamlLaunchPhase::Complete);
+        VERIFY_IS_TRUE(HasFlag(trace.GetLastObservation(), XamlLaunchObservationFlags::CallbackFailed));
+    }
+
+    void XamlLaunchTraceUnitTests::RetriesKeepBoundaryAndAttemptIdentity()
+    {
+        for (const bool productionInFirstAttempt : { false, true })
+        {
+            XamlLaunchStartupScope startup;
+            XamlLaunchTrace trace;
+            const auto callback = trace.BeginOnLaunched();
+            XamlLaunchTrace::EndOnLaunched(callback, &trace, S_OK);
+            const auto firstAttempt = trace.BeginDrawAttempt();
+            trace.BeginLayout(1, firstAttempt);
+            if (productionInFirstAttempt)
+            {
+                trace.BeginProduction(1, firstAttempt);
+            }
+            trace.EndDraw(1, firstAttempt, false, S_OK);
+            const auto lastBoundary = trace.GetLastObservation();
+
+            const auto secondAttempt = trace.BeginDrawAttempt();
+            VERIFY_ARE_EQUAL(firstAttempt + 1, secondAttempt);
+            trace.BeginLayout(1, secondAttempt);
+            VERIFY_ARE_EQUAL(lastBoundary.ordinal, trace.GetLastObservation().ordinal);
+            trace.BeginProduction(1, secondAttempt);
+            VERIFY_ARE_EQUAL(5u, trace.GetLastObservation().ordinal);
+            trace.EndDraw(1, secondAttempt, true, S_OK);
+            VERIFY_ARE_EQUAL(6u, trace.GetLastObservation().ordinal);
+            VERIFY_ARE_EQUAL(secondAttempt, trace.GetLastObservation().drawAttemptId);
+            VERIFY_ARE_EQUAL(1u, trace.GetLastObservation().frameNumber);
+            VERIFY_IS_TRUE(HasFlag(trace.GetLastObservation(), XamlLaunchObservationFlags::MultipleDrawAttempts));
+            VERIFY_IS_FALSE(HasFlag(trace.GetLastObservation(), XamlLaunchObservationFlags::NonCanonicalOrder));
+        }
+    }
+
+    void XamlLaunchTraceUnitTests::IndependentCoreLifetimes()
+    {
+        XamlLaunchTrace standalone;
+        VERIFY_IS_TRUE(HasFlag(standalone.GetLastObservation(), XamlLaunchObservationFlags::NoApplicationStart));
+        XamlLaunchStartupScope startup;
+        XamlLaunchObservation first;
+        {
+            XamlLaunchTrace trace;
+            first = trace.BeginOnLaunched();
+            VERIFY_IS_TRUE(first.entryKind == XamlLaunchEntryKind::ApplicationStart);
+        }
+        XamlLaunchTrace replacement;
+        const auto second = replacement.BeginOnLaunched();
+        VERIFY_IS_TRUE(second.entryKind == XamlLaunchEntryKind::CoreInitialization);
+        VERIFY_IS_TRUE(HasFlag(second, XamlLaunchObservationFlags::NoApplicationStart));
+        VERIFY_ARE_NOT_EQUAL(first.startupId, second.startupId);
+        VERIFY_ARE_NOT_EQUAL(first.coreId, second.coreId);
+        VERIFY_ARE_NOT_EQUAL(standalone.GetLastObservation().coreId, second.coreId);
+    }
+
+    void XamlLaunchTraceUnitTests::StartupScopeIsThreadLocal()
+    {
+        XamlLaunchStartupScope startup;
+        XamlLaunchObservation otherThread;
+        std::thread worker([&otherThread]
+        {
+            XamlLaunchTrace trace;
+            otherThread = trace.BeginOnLaunched();
+        });
+        worker.join();
+
+        XamlLaunchTrace trace;
+        const auto currentThread = trace.BeginOnLaunched();
+        VERIFY_IS_TRUE(currentThread.entryKind == XamlLaunchEntryKind::ApplicationStart);
+        VERIFY_IS_TRUE(otherThread.entryKind == XamlLaunchEntryKind::CoreInitialization);
+        VERIFY_IS_TRUE(HasFlag(otherThread, XamlLaunchObservationFlags::NoApplicationStart));
+        VERIFY_ARE_NOT_EQUAL(currentThread.startupId, otherThread.startupId);
+        VERIFY_ARE_NOT_EQUAL(currentThread.coreId, otherThread.coreId);
+    }
+
+    void XamlLaunchTraceUnitTests::NestedStartupScopes()
+    {
+        XamlLaunchStartupScope outer;
+        XamlLaunchObservation innerObservation;
+        {
+            XamlLaunchStartupScope inner;
+            XamlLaunchTrace innerTrace;
+            innerObservation = innerTrace.BeginOnLaunched();
+        }
+        XamlLaunchTrace outerTrace;
+        const auto outerObservation = outerTrace.BeginOnLaunched();
+        VERIFY_IS_TRUE(innerObservation.entryKind == XamlLaunchEntryKind::ApplicationStart);
+        VERIFY_IS_TRUE(outerObservation.entryKind == XamlLaunchEntryKind::ApplicationStart);
+        VERIFY_ARE_NOT_EQUAL(innerObservation.startupId, outerObservation.startupId);
+    }
+
+    void XamlLaunchTraceUnitTests::CallbackReturnAfterCoreReplacement()
+    {
+        XamlLaunchStartupScope startup;
+        XamlLaunchObservation callback;
+        {
+            XamlLaunchTrace original;
+            callback = original.BeginOnLaunched();
+        }
+        XamlLaunchTrace replacement;
+        const auto replacementBefore = replacement.GetLastObservation();
+        const auto returned = XamlLaunchTrace::EndOnLaunched(callback, &replacement, static_cast<uint32_t>(E_FAIL));
+        VERIFY_ARE_EQUAL(callback.startupId, returned.startupId);
+        VERIFY_ARE_EQUAL(callback.coreId, returned.coreId);
+        VERIFY_ARE_EQUAL(3u, returned.ordinal);
+        VERIFY_IS_TRUE(HasFlag(returned, XamlLaunchObservationFlags::CoreUnavailableAtCallbackReturn));
+        VERIFY_IS_TRUE(HasFlag(returned, XamlLaunchObservationFlags::CallbackFailed));
+        VERIFY_ARE_EQUAL(replacementBefore.ordinal, replacement.GetLastObservation().ordinal);
+        VERIFY_ARE_EQUAL(replacementBefore.flags, replacement.GetLastObservation().flags);
+
+        const auto withoutCore = XamlLaunchTrace::EndOnLaunched(callback, nullptr, S_OK);
+        VERIFY_ARE_EQUAL(callback.coreId, withoutCore.coreId);
+        VERIFY_IS_TRUE(HasFlag(withoutCore, XamlLaunchObservationFlags::CoreUnavailableAtCallbackReturn));
+    }
+
+    void XamlLaunchTraceUnitTests::WarmActivationAndLaterFramesDoNotRestart()
+    {
+        XamlLaunchStartupScope startup;
+        XamlLaunchTrace trace;
+        const auto callback = trace.BeginOnLaunched();
+        XamlLaunchTrace::EndOnLaunched(callback, &trace, S_OK);
+        Draw(trace);
+
+        const auto laterCallback = trace.BeginOnLaunched();
+        VERIFY_ARE_EQUAL(0u, laterCallback.ordinal);
+        XamlLaunchTrace::EndOnLaunched(laterCallback, &trace, static_cast<uint32_t>(E_FAIL));
+        Draw(trace);
+        VERIFY_ARE_EQUAL(6u, trace.GetLastObservation().ordinal);
+        VERIFY_ARE_EQUAL(0u, trace.GetLastObservation().flags);
+        VERIFY_ARE_EQUAL(callback.coreId, trace.GetLastObservation().coreId);
+    }
+
+    void XamlLaunchTraceUnitTests::DrawCleanupFailureIsPreserved()
+    {
+        XamlLaunchStartupScope startup;
+        XamlLaunchTrace trace;
+        const auto callback = trace.BeginOnLaunched();
+        XamlLaunchTrace::EndOnLaunched(callback, &trace, S_OK);
+        const auto attempt = trace.BeginDrawAttempt();
+        trace.BeginLayout(1, attempt);
+        trace.BeginProduction(1, attempt);
+        trace.EndDraw(1, attempt, true, static_cast<uint32_t>(E_FAIL));
+        VERIFY_ARE_EQUAL(6u, trace.GetLastObservation().ordinal);
+        VERIFY_ARE_EQUAL(static_cast<uint32_t>(E_FAIL), trace.GetLastObservation().result);
+    }
+
+} } } } }

--- a/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.cpp
+++ b/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.cpp
@@ -2,6 +2,11 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 #include "precomp.h"
+
+#ifndef XAMLPROFILER_ENABLED
+#error "XamlLaunchTraceUnitTests.cpp requires XAMLPROFILER_ENABLED; keep its ClCompile entry conditioned on XamlProfilerEnabled."
+#endif
+
 #include "XamlLaunchTraceUnitTests.h"
 #include <XamlLaunchPhase.h>
 #include <thread>

--- a/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.h
+++ b/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#ifdef XAMLPROFILER_ENABLED
+
 #include "WexTestClass.h"
 
 namespace Windows { namespace UI { namespace Xaml { namespace Tests { namespace Base {
@@ -26,3 +28,5 @@ namespace Windows { namespace UI { namespace Xaml { namespace Tests { namespace 
     };
 
 } } } } }
+
+#endif // XAMLPROFILER_ENABLED

--- a/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.h
+++ b/dxaml/xcp/components/base/unittests/XamlLaunchTraceUnitTests.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include "WexTestClass.h"
+
+namespace Windows { namespace UI { namespace Xaml { namespace Tests { namespace Base {
+
+    class XamlLaunchTraceUnitTests
+    {
+    public:
+        BEGIN_TEST_CLASS(XamlLaunchTraceUnitTests)
+        END_TEST_CLASS()
+
+        TEST_METHOD(LinearBoundaries);
+        TEST_METHOD(RenderingBeforeCallbackReturn);
+        TEST_METHOD(CallbackFailureDoesNotStopFrameObservations);
+        TEST_METHOD(RetriesKeepBoundaryAndAttemptIdentity);
+        TEST_METHOD(IndependentCoreLifetimes);
+        TEST_METHOD(StartupScopeIsThreadLocal);
+        TEST_METHOD(NestedStartupScopes);
+        TEST_METHOD(CallbackReturnAfterCoreReplacement);
+        TEST_METHOD(WarmActivationAndLaterFramesDoNotRestart);
+        TEST_METHOD(DrawCleanupFailureIsPreserved);
+    };
+
+} } } } }

--- a/dxaml/xcp/core/dll/xcpcore.cpp
+++ b/dxaml/xcp/core/dll/xcpcore.cpp
@@ -6326,7 +6326,9 @@ CCoreServices::NWDrawTree(
     TraceFrameBegin();
 
     XUINT32 frameNumber = m_uFrameNumber;
+#ifdef XAMLPROFILER_ENABLED
     const auto launchDrawAttempt = m_launchTrace.BeginDrawAttempt();
+#endif
     TraceLoggingProviderWrite(
         XamlTelemetry, "CoreServices_Frame",
         TraceLoggingBoolean(true, "IsStart"),
@@ -6441,10 +6443,12 @@ CCoreServices::NWDrawTree(
         pLayoutManager = VisualTree::GetLayoutManagerForElement(pVisualRoot);
         IFCPTR(pLayoutManager);
 
+#ifdef XAMLPROFILER_ENABLED
         if (m_isFirstFrameAfterAppStart)
         {
             m_launchTrace.BeginLayout(frameNumber, launchDrawAttempt);
         }
+#endif
 
         // IMPORTANT: This is a synchronous callout to app code that could change state.
         {
@@ -6609,7 +6613,9 @@ CCoreServices::NWDrawTree(
         GetInputServices()->GetKeyTipManager().NotifyFiniteAnimationIsRunning(this, hasActiveFiniteAnimations);
     }
 
+#ifdef XAMLPROFILER_ENABLED
     m_launchTrace.BeginProduction(frameNumber, launchDrawAttempt);
+#endif
 
     // NOTE: No user code callbacks should be made beyond this point.
     // It's possible that one of the previous user-code callbacks closed the Window.
@@ -6951,7 +6957,9 @@ Cleanup:
         m_pendingFirstFrameTraceLoggingEvent = false;
     }
 
+#ifdef XAMLPROFILER_ENABLED
     m_launchTrace.EndDraw(frameNumber, launchDrawAttempt, *pFrameDrawn, static_cast<uint32_t>(hr));
+#endif
 
     SetVisibilityToggled(FALSE); // clear the flag, any processing based on it should be complete by now.
 

--- a/dxaml/xcp/core/dll/xcpcore.cpp
+++ b/dxaml/xcp/core/dll/xcpcore.cpp
@@ -6326,6 +6326,7 @@ CCoreServices::NWDrawTree(
     TraceFrameBegin();
 
     XUINT32 frameNumber = m_uFrameNumber;
+    const auto launchDrawAttempt = m_launchTrace.BeginDrawAttempt();
     TraceLoggingProviderWrite(
         XamlTelemetry, "CoreServices_Frame",
         TraceLoggingBoolean(true, "IsStart"),
@@ -6439,6 +6440,11 @@ CCoreServices::NWDrawTree(
 
         pLayoutManager = VisualTree::GetLayoutManagerForElement(pVisualRoot);
         IFCPTR(pLayoutManager);
+
+        if (m_isFirstFrameAfterAppStart)
+        {
+            m_launchTrace.BeginLayout(frameNumber, launchDrawAttempt);
+        }
 
         // IMPORTANT: This is a synchronous callout to app code that could change state.
         {
@@ -6602,6 +6608,8 @@ CCoreServices::NWDrawTree(
     {
         GetInputServices()->GetKeyTipManager().NotifyFiniteAnimationIsRunning(this, hasActiveFiniteAnimations);
     }
+
+    m_launchTrace.BeginProduction(frameNumber, launchDrawAttempt);
 
     // NOTE: No user code callbacks should be made beyond this point.
     // It's possible that one of the previous user-code callbacks closed the Window.
@@ -6942,6 +6950,8 @@ Cleanup:
             TraceLoggingKeyword(MICROSOFT_KEYWORD_MEASURES));
         m_pendingFirstFrameTraceLoggingEvent = false;
     }
+
+    m_launchTrace.EndDraw(frameNumber, launchDrawAttempt, *pFrameDrawn, static_cast<uint32_t>(hr));
 
     SetVisibilityToggled(FALSE); // clear the flag, any processing based on it should be complete by now.
 

--- a/dxaml/xcp/core/inc/corep.h
+++ b/dxaml/xcp/core/inc/corep.h
@@ -31,6 +31,7 @@
 #include "ImageProvider.h"
 #include "AsyncImageFactory.h"
 #include "ResourceLookupLogger.h"
+#include "XamlLaunchPhase.h"
 
 #include "AutomationEventsHelper.h"
 
@@ -1097,6 +1098,7 @@ public:
 
     _Check_return_ HRESULT StartApplication(_In_ CApplication *pApplication);
     _Check_return_ HRESULT RaisePendingLoadedRequests();
+    XamlLaunchTrace& GetLaunchTrace() noexcept { return m_launchTrace; }
 
 // Get the default template for ContentPresenter
     const xref_ptr<CDisplayMemberTemplate>& GetDefaultContentPresenterTemplate();
@@ -2222,6 +2224,7 @@ public:
     XUINT64                     m_qpcDrawMainTreeStart;
 
     bool                        m_isFirstFrameAfterAppStart;
+    XamlLaunchTrace              m_launchTrace;
 
     // Core objects which are GC roots. These objects don't have FX peers
     // so GC cannot walk them as roots from the FX peers. Instead GC will

--- a/dxaml/xcp/core/inc/corep.h
+++ b/dxaml/xcp/core/inc/corep.h
@@ -31,7 +31,9 @@
 #include "ImageProvider.h"
 #include "AsyncImageFactory.h"
 #include "ResourceLookupLogger.h"
+#ifdef XAMLPROFILER_ENABLED
 #include "XamlLaunchPhase.h"
+#endif
 
 #include "AutomationEventsHelper.h"
 
@@ -1098,7 +1100,9 @@ public:
 
     _Check_return_ HRESULT StartApplication(_In_ CApplication *pApplication);
     _Check_return_ HRESULT RaisePendingLoadedRequests();
+#ifdef XAMLPROFILER_ENABLED
     XamlLaunchTrace& GetLaunchTrace() noexcept { return m_launchTrace; }
+#endif
 
 // Get the default template for ContentPresenter
     const xref_ptr<CDisplayMemberTemplate>& GetDefaultContentPresenterTemplate();
@@ -2224,7 +2228,9 @@ public:
     XUINT64                     m_qpcDrawMainTreeStart;
 
     bool                        m_isFirstFrameAfterAppStart;
+#ifdef XAMLPROFILER_ENABLED
     XamlLaunchTrace              m_launchTrace;
+#endif
 
     // Core objects which are GC roots. These objects don't have FX peers
     // so GC cannot walk them as roots from the FX peers. Instead GC will

--- a/dxaml/xcp/dxaml/lib/FrameworkApplication_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/FrameworkApplication_Partial.cpp
@@ -26,6 +26,7 @@
 #include <DesktopWindowImpl.h>
 #include <Microsoft.UI.Dispatching.Interop.h>
 #include <Microsoft.Windows.ApplicationModel.Resources.h>
+#include <XamlLaunchPhase.h>
 
 using namespace RuntimeFeatureBehavior;
 using namespace DirectUI;
@@ -162,6 +163,7 @@ _Check_return_ HRESULT FrameworkApplication::RemoveIslandImpl(_In_ xaml_hosting:
 // See startup-overview.md for details
 _Check_return_ HRESULT FrameworkApplicationFactory::StartImpl(_In_opt_ xaml::IApplicationInitializationCallback* pCallback)
 {
+    XamlLaunchStartupScope launchScope;
     g_spApplicationInitializationCallback = pCallback;
 
     // Determine which AppPolicyWindowingModel the application is using.
@@ -881,7 +883,15 @@ _Check_return_ HRESULT FrameworkApplication::InvokeOnLaunchActivated(
     IFC_RETURN(launchActivatedEventArgs->put_UWPLaunchActivatedEventArgs(uwpLaunchActivatedEventArgs));
 
     // Invoke the application's custom Application.OnLaunched method
+    const auto launchCallback = DXamlCore::GetCurrent()->GetHandle()->GetLaunchTrace().BeginOnLaunched();
     HRESULT hr = FrameworkApplication::GetCurrentNoRef()->OnLaunchedProtected(launchActivatedEventArgs.Get());
+
+    // Reacquire instead of retaining a core pointer across application code.
+    auto currentCore = DXamlCore::GetCurrentNoCreate();
+    auto currentCoreHandle = currentCore ? currentCore->GetHandle() : nullptr;
+    XamlLaunchTrace::EndOnLaunched(
+        launchCallback, currentCoreHandle ? &currentCoreHandle->GetLaunchTrace() : nullptr, static_cast<uint32_t>(hr));
+
     if (FAILED(hr))
     {
         IGNOREHR(ErrorHelper::ReportUnhandledError(hr));

--- a/dxaml/xcp/dxaml/lib/FrameworkApplication_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/FrameworkApplication_Partial.cpp
@@ -26,7 +26,9 @@
 #include <DesktopWindowImpl.h>
 #include <Microsoft.UI.Dispatching.Interop.h>
 #include <Microsoft.Windows.ApplicationModel.Resources.h>
+#ifdef XAMLPROFILER_ENABLED
 #include <XamlLaunchPhase.h>
+#endif
 
 using namespace RuntimeFeatureBehavior;
 using namespace DirectUI;
@@ -163,7 +165,9 @@ _Check_return_ HRESULT FrameworkApplication::RemoveIslandImpl(_In_ xaml_hosting:
 // See startup-overview.md for details
 _Check_return_ HRESULT FrameworkApplicationFactory::StartImpl(_In_opt_ xaml::IApplicationInitializationCallback* pCallback)
 {
+#ifdef XAMLPROFILER_ENABLED
     XamlLaunchStartupScope launchScope;
+#endif
     g_spApplicationInitializationCallback = pCallback;
 
     // Determine which AppPolicyWindowingModel the application is using.
@@ -883,14 +887,18 @@ _Check_return_ HRESULT FrameworkApplication::InvokeOnLaunchActivated(
     IFC_RETURN(launchActivatedEventArgs->put_UWPLaunchActivatedEventArgs(uwpLaunchActivatedEventArgs));
 
     // Invoke the application's custom Application.OnLaunched method
+#ifdef XAMLPROFILER_ENABLED
     const auto launchCallback = DXamlCore::GetCurrent()->GetHandle()->GetLaunchTrace().BeginOnLaunched();
+#endif
     HRESULT hr = FrameworkApplication::GetCurrentNoRef()->OnLaunchedProtected(launchActivatedEventArgs.Get());
 
+#ifdef XAMLPROFILER_ENABLED
     // Reacquire instead of retaining a core pointer across application code.
     auto currentCore = DXamlCore::GetCurrentNoCreate();
     auto currentCoreHandle = currentCore ? currentCore->GetHandle() : nullptr;
     XamlLaunchTrace::EndOnLaunched(
         launchCallback, currentCoreHandle ? &currentCoreHandle->GetLaunchTrace() : nullptr, static_cast<uint32_t>(hr));
+#endif
 
     if (FAILED(hr))
     {

--- a/dxaml/xcp/inc/XamlLaunchPhase.h
+++ b/dxaml/xcp/inc/XamlLaunchPhase.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#ifdef XAMLPROFILER_ENABLED
+
 #include <cstdint>
 
 // Labels for observed boundaries, not a state machine. See docs/design-notes/launch-phase-markers.md.
@@ -106,3 +108,5 @@ private:
     bool m_productionStarted = false;
     bool m_frameCompleted = false;
 };
+
+#endif // XAMLPROFILER_ENABLED

--- a/dxaml/xcp/inc/XamlLaunchPhase.h
+++ b/dxaml/xcp/inc/XamlLaunchPhase.h
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+
+#include <cstdint>
+
+// Labels for observed boundaries, not a state machine. See docs/design-notes/launch-phase-markers.md.
+enum class XamlLaunchPhase : uint32_t
+{
+    None = 0,
+    FrameworkInitialization = 1,
+    ApplicationInitialization = 2,
+    FirstFrameScheduling = 3,
+    InitialLayout = 4,
+    FirstFrameProduction = 5,
+    Complete = 6,
+    Aborted = 7
+};
+
+enum class XamlLaunchEntryKind : uint32_t
+{
+    ApplicationStart = 1,
+    CoreInitialization = 2
+};
+
+enum class XamlLaunchObservationFlags : uint32_t
+{
+    None = 0,
+    NoApplicationStart = 0x1,
+    NonCanonicalOrder = 0x2,
+    CallbackFailed = 0x4,
+    MultipleDrawAttempts = 0x8,
+    CoreUnavailableAtCallbackReturn = 0x10
+};
+
+struct XamlLaunchObservation
+{
+    uint64_t startupId = 0;
+    uint64_t coreId = 0;
+    XamlLaunchEntryKind entryKind = XamlLaunchEntryKind::CoreInitialization;
+    XamlLaunchPhase previousPhase = XamlLaunchPhase::None;
+    XamlLaunchPhase nextPhase = XamlLaunchPhase::None;
+    uint32_t ordinal = 0;
+    uint32_t frameNumber = 0;
+    uint64_t drawAttemptId = 0;
+    uint32_t flags = 0;
+    uint32_t result = 0;
+};
+
+// Associates only the first core created on this thread with this Application.Start.
+// Other threads and subsequent cores have independent, explicitly partial sequences.
+class XamlLaunchStartupScope final
+{
+public:
+    XamlLaunchStartupScope() noexcept;
+    ~XamlLaunchStartupScope();
+
+    XamlLaunchStartupScope(const XamlLaunchStartupScope&) = delete;
+    XamlLaunchStartupScope& operator=(const XamlLaunchStartupScope&) = delete;
+
+private:
+    friend class XamlLaunchTrace;
+    static thread_local XamlLaunchStartupScope* s_current;
+    XamlLaunchStartupScope* m_previous;
+    uint64_t m_startupId;
+    bool m_claimed = false;
+};
+
+// UI-thread-owned observations for one core lifetime. Callback and frame completion
+// are independent: a nested message pump can produce a frame before callback return.
+class XamlLaunchTrace final
+{
+public:
+    XamlLaunchTrace() noexcept;
+    XamlLaunchTrace(const XamlLaunchTrace&) = delete;
+    XamlLaunchTrace& operator=(const XamlLaunchTrace&) = delete;
+
+    XamlLaunchObservation BeginOnLaunched() noexcept;
+    static XamlLaunchObservation EndOnLaunched(
+        const XamlLaunchObservation& callbackStart,
+        XamlLaunchTrace* currentCoreTrace,
+        uint32_t result) noexcept;
+
+    uint64_t BeginDrawAttempt() noexcept;
+    void BeginLayout(uint32_t frameNumber, uint64_t drawAttemptId) noexcept;
+    void BeginProduction(uint32_t frameNumber, uint64_t drawAttemptId) noexcept;
+    void EndDraw(uint32_t frameNumber, uint64_t drawAttemptId, bool frameDrawn, uint32_t result) noexcept;
+
+    const XamlLaunchObservation& GetLastObservation() const noexcept { return m_observation; }
+
+private:
+    void WriteBoundary(
+        XamlLaunchPhase previousPhase,
+        XamlLaunchPhase nextPhase,
+        uint32_t ordinal,
+        uint32_t frameNumber = 0,
+        uint64_t drawAttemptId = 0,
+        uint32_t result = 0) noexcept;
+
+    XamlLaunchObservation m_observation;
+    uint64_t m_drawAttemptId = 0;
+    uint64_t m_layoutAttemptId = 0;
+    uint32_t m_lastOrdinal = 1;
+    bool m_callbackStarted = false;
+    bool m_productionStarted = false;
+    bool m_frameCompleted = false;
+};

--- a/tools/XamlProfiler/docs/activateframework.md
+++ b/tools/XamlProfiler/docs/activateframework.md
@@ -18,11 +18,12 @@ which is driven by **one MSBuild property, `XamlProfilerEnabled`**, declared in
 sees any of it: **zero code, zero binary size, zero ETW events.**
 
 - **Off (default):** `XamlProfilerEnabled` is `false`, so `XAMLPROFILER_ENABLED`
-  is never defined, the dedicated `.cpp` is not compiled, and no events are emitted.
+  is never defined, the dedicated profiler sources are not compiled, and no profiler
+  events are emitted.
 - **On:** flip the flag to `true` (one line) and rebuild.
 
-The property is **force-disabled outside `Configuration==Debug`**, so retail/fre
-builds never get the producer even if the flag is left on.
+The normal project settings disable the property outside `Configuration==Debug`,
+so retail/fre builds do not get the producer when the local flag is left on.
 
 ---
 
@@ -39,14 +40,14 @@ builds never get the producer even if the flag is left on.
 - **To turn ON:** change the first line's value to `true`, then rebuild.
 - **To turn OFF:** change it back to `false` (the default).
 
-The second line is a guard: it re-forces `false` in any non-Debug configuration,
-so enabling the profiler can never leak into a retail/fre build.
+The second line resets the local setting to `false` in non-Debug configurations.
+Do not override the property globally to `true` for a shipping build.
 
 ---
 
 ## What the property drives (no manual edits needed here)
 
-`XamlProfilerEnabled` gates three build sites via `Condition="'$(XamlProfilerEnabled)'=='true'"`.
+`XamlProfilerEnabled` gates the build sites below via `Condition="'$(XamlProfilerEnabled)'=='true'"`.
 You should not need to touch these — they follow the single switch above.
 
 ### Site 1 — macro define (`<PreprocessorDefinitions>`)
@@ -64,37 +65,51 @@ Two define sites exist because `DBG=1` itself is defined in both `Xaml.Cpp.Targe
 and `LibraryCompile.props`; `XAMLPROFILER_ENABLED` mirrors that reach so every
 consumer project gets the macro.
 
-### Site 3 — the dedicated `.cpp` compilation
+### Dedicated `.cpp` compilation
 **File:** `dxaml\xcp\components\comptree\lib\Microsoft.UI.Xaml.CompTree.vcxproj`
 ```xml
 <ClCompile Condition="'$(XamlProfilerEnabled)'=='true'" Include="..\WucVisualTreeProfiler.cpp"/>
 ```
-`WucVisualTreeProfiler.cpp` is the only dedicated profiler translation unit. It has
-a top-of-file `#error` safeguard that fires if it is ever compiled with
-`XAMLPROFILER_ENABLED` undefined — because all three sites share the same
-`XamlProfilerEnabled` property, they now stay in sync automatically.
+**File:** `dxaml\xcp\components\base\lib\Microsoft.UI.Xaml.Base.vcxproj`
+```xml
+<ClCompile Condition="'$(XamlProfilerEnabled)'=='true'" Include="..\XamlLaunchTrace.cpp"/>
+```
+Both production translation units have a top-of-file `#error` safeguard that fires
+if compiled with `XAMLPROFILER_ENABLED` undefined. Source inclusion and the macro
+definitions share the same `XamlProfilerEnabled` property.
+
+The launch test source and header in
+`dxaml\xcp\components\base\unittests\Microsoft.UI.Xaml.Tests.Isolated.Base.vcxproj`
+are conditioned on that property too. The launch test class is registered only in
+profiler-enabled builds; other Base tests are unaffected.
+
+The launch producer uses the existing `Microsoft-Windows-XAML-Profiler` provider,
+not the standard XAML provider. Its core member, TLS/counters, startup scope, and
+callback/frame calls are all guarded, not replaced with always-present no-ops.
+See [XAML launch boundary observations](../../../docs/design-notes/launch-phase-markers.md)
+for the event contract.
 
 ### Cosmetic (header project-membership, no build effect)
-Two `ClInclude` entries (in `Microsoft.UI.Xaml.CompTree.vcxproj` and
-`Microsoft.UI.Xaml.Base.vcxproj`) are also gated on the property. Headers are never
-compiled and are self-guarded (`#ifdef XAMLPROFILER_ENABLED` around their whole body),
-so these only affect Solution Explorer / project membership.
+Profiler-specific `ClInclude` entries are gated on the property as well. Headers
+are not independent compilation units; their declarations are self-guarded with
+`#ifdef XAMLPROFILER_ENABLED`. The project entries control project membership,
+while the header guards and guarded includes provide compilation exclusion.
 
 ---
 
 ## Verifying the switch works
 
 1. Set `XamlProfilerEnabled` to `false` (default).
-2. Build: `.\initrun.ps1 build.cmd mux /q`
-   - A clean build with the profiler removed should succeed, and the output
-     `Microsoft.ui.xaml.dll` is measurably smaller than the profiler-on build
-     (~50 KB) — physical proof the code was excluded.
-   - If it fails with the `#error` from `WucVisualTreeProfiler.cpp`, the
-     `XamlProfilerEnabled` guard is out of sync (should not happen with the single
-     property).
-3. Attach the profiler / collect a trace → **no XamlProfiler events** should appear.
-4. Set `XamlProfilerEnabled` to `true`, rebuild → the DLL returns to full size and
-   events flow again.
+2. Build: `.\Build.cmd mux /i x64chk /q`. Confirm the dedicated profiler sources
+   are absent from evaluated compile items and profiler declarations/state/calls
+   are absent from preprocessed code. A profiler-only source's `#error` indicates
+   out-of-sync build settings.
+3. Confirm profiler event metadata is absent from the resulting DLL. Binary size
+   alone, or an empty ETW capture, is not proof that state and calls were removed.
+4. Set `XamlProfilerEnabled` to `true` and rebuild consistently, including tests.
+   Confirm the launch test class is present and passes, and that subscribed
+   profiler events are delivered. Use separate outputs or rebuild when switching
+   modes so stale objects or precompiled headers cannot mask a problem.
 
 ---
 
@@ -103,5 +118,5 @@ so these only affect Solution Explorer / project membership.
 - The profiler is scoped to `Configuration==Debug` (chk) via the guard line in
   `Xaml.Cpp.Props`. To ship the profiler in a specific fre flavor, adjust that guard
   rather than the individual sites.
-- All three build sites and the two cosmetic header entries reference the single
+- All build sites and profiler-specific header entries reference the single
   `XamlProfilerEnabled` property, so there is exactly one place to change.


### PR DESCRIPTION
## Fixes

No tracking issue was provided for this diagnostic instrumentation change.

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other: native ETW launch diagnostics

## Description

### Current Behavior

Startup and frame telemetry do not provide an explicit, correlated set of six
native boundaries for the five launch-phase intervals. Inferring these intervals
from unrelated events can mix initialization lifetimes or hide reentrant rendering
and repeated draw attempts.

### New Behavior

Adds the `LaunchPhaseTransition` TraceLogging event to the existing
`Microsoft-Windows-XAML-Profiler` provider
(`A1B2C3D4-E5F6-4A5B-9C8D-7E6F5A4B3C2D`) at six native boundaries:
`Application.Start` entry, first native `OnLaunched` entry/return, initial layout
entry, the selected post-layout boundary, and qualifying draw-attempt cleanup.

The complete producer is compiled only when the existing `XAMLPROFILER_ENABLED`
macro is defined by `XamlProfilerEnabled`. The property remains **off by default**,
including Debug. Disabled builds exclude the launch implementation and tests,
declarations, per-core state, TLS/counters, and callback/frame work; they do not
use always-present no-op objects. Existing standard XAML telemetry is unchanged,
and this event is not emitted through the ordinary `Microsoft-Windows-XAML`
provider. No new build switch or provider is introduced.

The canonical labels remain `FrameworkInitialization`,
`ApplicationInitialization`, `FirstFrameScheduling`, `InitialLayout`, and
`FirstFrameProduction`.

- Correlate startup and core lifetimes using `StartupId`, `CoreId`, and
  `EntryKind`. The first core constructed within the same-thread startup scope
  claims the startup token once.
- Keep callback and frame observations independent. Ordinals identify boundaries,
  not guaranteed chronological order; nested message pumping can produce a frame
  before `OnLaunched` returns.
- Record draw-attempt identity, callback/draw HRESULTs, and flags for partial
  initialization, noncanonical order, callback failure, retries, or core
  replacement during the callback.
- Preserve callback identity without retaining a core pointer across application
  code. Do not restart the sequence for warm activations or content replacement.
- Add focused isolated tests and document the event contract in
  `docs/design-notes/launch-phase-markers.md`, linked from the startup overview.

Full six-boundary correlation is supported for first desktop `Application.Start`
initialization. Standalone islands, secondary/reinitialized cores, and cross-thread
startup paths are explicitly partial. Consumers should derive the five-phase
partition only from complete, correlated, chronologically ordered observations
with a successful callback result.

These are elapsed-time observations, not exclusive framework/application CPU
ownership. They do not establish async initialization completion, presentation,
per-window first pixels, app readiness, or input responsiveness. Level/keyword
zero does not guarantee provider enablement or event delivery.

## Customer Impact

Opt-in diagnostic instrumentation only; no intended scheduling, rendering, public
API, or UI behavior changes. Normal builds contain no launch producer. In enabled
builds, the additional identity and flags let performance tools report incomplete
or nonlinear startup observations instead of inventing timings. Consumers must
subscribe to the profiler provider; missing events may mean instrumentation was
not compiled in, rather than event loss.

## Regression Potential

- [ ] Low risk - isolated change, limited scope
- [x] Medium risk - touches shared core initialization and the frame path
- [ ] High risk - architectural or breaking API change

When compiled in, state is owned by the core's UI thread. A relaxed atomic counter
allocates numeric identities; no additional core/application lifetime is retained.
Frame-side boundary latches remain independent of callback return and survive
retries. State advances even without an ETW listener so late capture cannot restart
the launch sequence. The existing switch defaults and both macro-definition paths
are unchanged.

## How Has This Been Tested?

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
- [x] Targeted existing Base isolated tests pass locally (not the full repository suite)

- **x64 Debug, default off:** MUX and Base test builds succeeded. Evaluated compile
  items omit the launch source and test; TAEF lists no launch class. The two
  existing TLS tests pass.
- **x64 Debug, profiler enabled:** rebuilt the native graph and Base tests with
  consistent `/p:XamlProfilerEnabled=true`; **12 selected tests passed**, covering
  all ten launch cases and two existing TLS cases.
- **x64 Release, profiler default off:** native MUX build succeeded using the
  repository-supported `/nopgo` developer option. The normal PGO-enabled build is
  blocked locally by an unavailable matching PGO package; this is not evidence of
  a successful PGO shipping build.
- Actual-compiler preprocessing of `xcpcore.cpp` and
  `FrameworkApplication_Partial.cpp` contains no launch state/calls in disabled
  Debug or Release. Enabled preprocessing retains them. Dedicated source
  membership and DLL event metadata have matching off/on results; this is not
  based on DLL size alone.
- **Synthetic ETW smoke:** only `LinearBoundaries` ran in an owned, suspended-then-
  resumed TAEF `/inproc` process. Both provider PID filters were installed before
  resuming. Decoded six profiler events and zero ordinary-provider launch events,
  with the exact ten unsigned fields/order/widths (52 bytes), expected identities
  and values, level/keyword zero, no loss, and successful test exit. The owned
  session/process were cleaned up.
- Cases cover linear boundaries, rendering before callback return, callback
  failure, retries before/after the production boundary, independent core
  lifetimes, thread-local and nested startup scopes, teardown/replacement during
  the callback, warm activations/later frames, and failed draw cleanup.

No user application was captured. The synthetic capture proves helper-producer
routing and schema, not real-app ordering, measured launch timing, presentation,
or readiness. Other architectures and the full repository suite have not been
run locally.

The initial GitHub Actions `PR Build` workflow
([run 34328047638](https://github.com/microsoft/microsoft-ui-xaml/actions/runs/34328047638))
reported success, but all six jobs executed **Skip disabled PR Build validation**;
their native build steps were skipped. Those green jobs are not native
multi-architecture build evidence. Actual native CI remains outstanding.
