### PR TITLE
Fix cross-boundary lifetime leaks: convert raw ComPtr peer fields to TrackerPtr

### DIFF
--- a/dxaml/xcp/dxaml/lib/ListViewBase_Partial.h
+++ b/dxaml/xcp/dxaml/lib/ListViewBase_Partial.h
@@ -149,7 +149,7 @@ namespace DirectUI
             TrackerPtr<xaml_primitives::ISelectorItem> m_tpHoldingItem;
 
             // Set before raising ItemClick event, cleared afterwards
-            ctl::ComPtr<xaml::IDependencyObject> m_spContainerBeingClicked;
+            TrackerPtr<xaml::IDependencyObject> m_spContainerBeingClicked;
 
             // The last location of the top-left corner of the drag visual. Only valid during a drag and drop
             // initiated via this ListViewBase. Relative to root visual.

--- a/dxaml/xcp/dxaml/lib/ListViewBase_Partial_Interaction.cpp
+++ b/dxaml/xcp/dxaml/lib/ListViewBase_Partial_Interaction.cpp
@@ -222,7 +222,7 @@ _Check_return_ HRESULT ListViewBase::OnItemPrimaryInteractionGesture(
 
     auto guard = wil::scope_exit([this]()
     {
-        m_spContainerBeingClicked = nullptr;
+        m_spContainerBeingClicked.Clear();
     });
 
     IFCPTR_RETURN(pItem);
@@ -237,7 +237,7 @@ _Check_return_ HRESULT ListViewBase::OnItemPrimaryInteractionGesture(
     // store the container as a suggestion so that any call to ContainerFromItem that is called from user code
     // during any of the below callouts, will be able to be more intelligent.
     ASSERT(m_spContainerBeingClicked.Get() == nullptr);
-    m_spContainerBeingClicked = pItem;
+    SetPtrValue(m_spContainerBeingClicked, pItem);
 
     // If we're not the ZoomedOutView of a SemanticZoom,
     // do a regular primary interaction.
@@ -325,7 +325,7 @@ _Check_return_ HRESULT ListViewBase::OnItemSecondaryInteractionGesture(
 
     auto guard = wil::scope_exit([this]()
     {
-        m_spContainerBeingClicked = nullptr;
+        m_spContainerBeingClicked.Clear();
     });
 
     IFCPTR_RETURN(pItem);
@@ -335,7 +335,7 @@ _Check_return_ HRESULT ListViewBase::OnItemSecondaryInteractionGesture(
     // store the container as a suggestion so that any call to ContainerFromItem that is called from user code
     // during any of the below callouts, will be able to be more intelligent.
     ASSERT(m_spContainerBeingClicked.Get() == nullptr);
-    m_spContainerBeingClicked = pItem;
+    SetPtrValue(m_spContainerBeingClicked, pItem);
 
     BOOLEAN isItemClickEnabled = FALSE;
     IFC_RETURN(get_IsItemClickEnabled(&isItemClickEnabled));

--- a/dxaml/xcp/dxaml/lib/ModernCollectionBasePanel_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/ModernCollectionBasePanel_Partial.cpp
@@ -121,7 +121,7 @@ _Check_return_ HRESULT ModernCollectionBasePanel::Initialize()
     {
         ctl::ComPtr<LayoutDataInfoProvider> spLayoutDataInfoProvider;
         IFC_RETURN(ctl::make(static_cast<IModernCollectionBasePanel*>(this), &spLayoutDataInfoProvider));
-        m_spLayoutDataInfoProvider = spLayoutDataInfoProvider;
+        SetPtrValue(m_spLayoutDataInfoProvider, spLayoutDataInfoProvider);
     }
 
     return S_OK;
@@ -135,13 +135,13 @@ DOUBLE ModernCollectionBasePanel::GetDefaultCacheLength()
 
 _Check_return_ HRESULT ModernCollectionBasePanel::SetLayoutStrategyBase(_In_ const ctl::ComPtr<xaml_controls::ILayoutStrategy>& spLayoutStrategy)
 {
-    m_spLayoutStrategy = spLayoutStrategy;
+    SetPtrValue(m_spLayoutStrategy, spLayoutStrategy);
     return m_spLayoutStrategy->SetLayoutDataInfoProvider(m_spLayoutDataInfoProvider.Get());
 }
 
 _Check_return_ HRESULT ModernCollectionBasePanel::GetLayoutStrategy(_Out_ ctl::ComPtr<xaml_controls::ILayoutStrategy>* pspLayoutStrategy)
 {
-    *pspLayoutStrategy = m_spLayoutStrategy;
+    *pspLayoutStrategy = m_spLayoutStrategy.Get();
     RRETURN(S_OK);
 }
 

--- a/dxaml/xcp/dxaml/lib/ModernCollectionBasePanel_Partial.h
+++ b/dxaml/xcp/dxaml/lib/ModernCollectionBasePanel_Partial.h
@@ -1567,7 +1567,7 @@ namespace DirectUI
         TransitionContextManager m_transitionContextManager;
         CacheManager m_cacheManager;
         ContainerManager m_containerManager;
-        ctl::ComPtr<xaml_controls::ILayoutStrategy> m_spLayoutStrategy;
+        TrackerPtr<xaml_controls::ILayoutStrategy> m_spLayoutStrategy;
         TrackerPtr<wfc::IObservableVector<IInspectable*>> m_tpObservableItemsSource;
         EventRegistrationToken m_observableItemsSourceChangedToken;
 
@@ -2541,7 +2541,7 @@ public:
         UINT m_containerCreatedCount;
 
         // Provides information about the data source for the layout strategies.
-        ctl::ComPtr<xaml_controls::ILayoutDataInfoProvider> m_spLayoutDataInfoProvider;
+        TrackerPtr<xaml_controls::ILayoutDataInfoProvider> m_spLayoutDataInfoProvider;
 
         // Iterator used for CCC's incremental visualization.
         ctl::ComPtr<ContainerContentChangingIterator> m_spContainerContentChangingIterator;

--- a/dxaml/xcp/dxaml/lib/SplitView_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/SplitView_Partial.cpp
@@ -632,7 +632,10 @@ SplitView::SetupOuterDismissLayer() noexcept
     {
         ctl::ComPtr<Grid> grid;
         IFC_RETURN(ctl::make<Grid>(&grid));
-        IFC_RETURN(grid.As(&m_dismissHostElement));
+
+        ctl::ComPtr<xaml_controls::IGrid> dismissHost;
+        IFC_RETURN(grid.As(&dismissHost));
+        SetPtrValue(m_dismissHostElement, dismissHost.Get());
 
         IFC_RETURN(m_dismissLayerPointerPressedEventHandler.AttachEventHandler(
             grid.Get(),
@@ -645,7 +648,10 @@ SplitView::SetupOuterDismissLayer() noexcept
         ctl::ComPtr<Popup> popup;
         IFC_RETURN(ctl::make(&popup));
         IFC_RETURN(popup->put_Child(m_dismissHostElement.Cast<Grid>()));
-        IFC_RETURN(popup.As(&m_outerDismissLayerPopup));
+
+        ctl::ComPtr<xaml_primitives::IPopup> popupAsIPopup;
+        IFC_RETURN(popup.As(&popupAsIPopup));
+        SetPtrValue(m_outerDismissLayerPopup, popupAsIPopup.Get());
     }
 
     static_cast<CPopup*>(m_outerDismissLayerPopup.Cast<DirectUI::Popup>()->GetHandle())->SetAssociatedIsland(VisualTree::GetXamlIslandRootForElement(GetHandle()));
@@ -660,7 +666,9 @@ SplitView::SetupOuterDismissLayer() noexcept
         }
         else
         {
-            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 6, &m_topDismissElement));
+            ctl::ComPtr<xaml_shapes::IPath> topPath;
+            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 6, &topPath));
+            SetPtrValue(m_topDismissElement, topPath.Get());
         }
 
         wf::Point points[] = { { 0.f, 0.f },{ windowBounds.Width, 0.f },{ windowBounds.Width, topRightCorner.Y }, topRightCorner, topLeftCorner,{ 0.f, topLeftCorner.Y } };
@@ -679,7 +687,9 @@ SplitView::SetupOuterDismissLayer() noexcept
         }
         else
         {
-            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 6, &m_bottomDismissElement));
+            ctl::ComPtr<xaml_shapes::IPath> bottomPath;
+            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 6, &bottomPath));
+            SetPtrValue(m_bottomDismissElement, bottomPath.Get());
         }
 
         wf::Point points[] = { { 0.f, bottomLeftCorner.Y }, bottomLeftCorner, bottomRightCorner,{ windowBounds.Width, bottomRightCorner.Y },{ windowBounds.Width, windowBounds.Height },{ 0.f, windowBounds.Height } };
@@ -698,7 +708,9 @@ SplitView::SetupOuterDismissLayer() noexcept
         }
         else
         {
-            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 4, &m_leftDismissElement));
+            ctl::ComPtr<xaml_shapes::IPath> leftPath;
+            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 4, &leftPath));
+            SetPtrValue(m_leftDismissElement, leftPath.Get());
         }
 
         wf::Point points[] = { { 0.f, topLeftCorner.Y }, topLeftCorner, bottomLeftCorner,{ 0.f, bottomLeftCorner.Y } };
@@ -717,7 +729,9 @@ SplitView::SetupOuterDismissLayer() noexcept
         }
         else
         {
-            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 4, &m_rightDismissElement));
+            ctl::ComPtr<xaml_shapes::IPath> rightPath;
+            IFC_RETURN(CreatePolygonalPath(m_dismissHostElement.Get(), 4, &rightPath));
+            SetPtrValue(m_rightDismissElement, rightPath.Get());
         }
 
         wf::Point points[] = { topRightCorner,{ windowBounds.Width, topRightCorner.Y },{ windowBounds.Width, bottomRightCorner.Y }, bottomRightCorner };

--- a/dxaml/xcp/dxaml/lib/SplitView_Partial.h
+++ b/dxaml/xcp/dxaml/lib/SplitView_Partial.h
@@ -101,12 +101,12 @@ namespace DirectUI
         //
         // We defer creation of these elements when the SplitView takes up the full window,
         // which is the common case.  Some apps, such as Spartan, have the SplitView nested.
-        ctl::ComPtr<xaml_primitives::IPopup>    m_outerDismissLayerPopup;
-        ctl::ComPtr<xaml_controls::IGrid>                 m_dismissHostElement;
-        ctl::ComPtr<xaml_shapes::IPath>                   m_topDismissElement;
-        ctl::ComPtr<xaml_shapes::IPath>                   m_bottomDismissElement;
-        ctl::ComPtr<xaml_shapes::IPath>                   m_leftDismissElement;
-        ctl::ComPtr<xaml_shapes::IPath>                   m_rightDismissElement;
+        TrackerPtr<xaml_primitives::IPopup>    m_outerDismissLayerPopup;
+        TrackerPtr<xaml_controls::IGrid>                 m_dismissHostElement;
+        TrackerPtr<xaml_shapes::IPath>                   m_topDismissElement;
+        TrackerPtr<xaml_shapes::IPath>                   m_bottomDismissElement;
+        TrackerPtr<xaml_shapes::IPath>                   m_leftDismissElement;
+        TrackerPtr<xaml_shapes::IPath>                   m_rightDismissElement;
 
         ctl::EventPtr<UIElementPointerPressedEventCallback>     m_dismissLayerPointerPressedEventHandler;
 

--- a/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.cpp
@@ -164,10 +164,10 @@ ToggleSwitch::OnApplyTemplate()
 
     m_tpCurtainBounds.Clear();
     m_tpCurtainClip.Clear();
-    m_spCurtainTransform = nullptr;
+    m_spCurtainTransform.Clear();
     m_tpKnob.Clear();
     m_tpKnobBounds.Clear();
-    m_spKnobTransform = nullptr;
+    m_spKnobTransform.Clear();
     m_tpThumb.Clear();
     m_tpHeaderPresenter.Clear();
 
@@ -194,7 +194,8 @@ ToggleSwitch::OnApplyTemplate()
         ctl::ComPtr<xaml_media::ITransform> spCurtainRenderTransform;
 
         IFC(spCurtainIUIElement->get_RenderTransform(&spCurtainRenderTransform));
-        m_spCurtainTransform = spCurtainRenderTransform.AsOrNull<ITranslateTransform>();
+        ctl::ComPtr<ITranslateTransform> spCurtainTranslateTransform = spCurtainRenderTransform.AsOrNull<ITranslateTransform>();
+        SetPtrValue(m_spCurtainTransform, spCurtainTranslateTransform.Get());
     }
 
     spKnobIUIElement = spKnobIDependencyObject.AsOrNull<xaml::IUIElement>();
@@ -203,7 +204,8 @@ ToggleSwitch::OnApplyTemplate()
         ctl::ComPtr<xaml_media::ITransform> spKnobRenderTransform;
 
         IFC(spKnobIUIElement->get_RenderTransform(&spKnobRenderTransform));
-        m_spKnobTransform = spKnobRenderTransform.AsOrNull<ITranslateTransform>();
+        ctl::ComPtr<ITranslateTransform> spKnobTranslateTransform = spKnobRenderTransform.AsOrNull<ITranslateTransform>();
+        SetPtrValue(m_spKnobTransform, spKnobTranslateTransform.Get());
     }
 
     if (spThumbIUIElement)

--- a/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.h
+++ b/dxaml/xcp/dxaml/lib/ToggleSwitch_Partial.h
@@ -180,9 +180,9 @@ namespace DirectUI
 
         // The translate transforms from template parts.
 
-        ctl::ComPtr<xaml_media::ITranslateTransform> m_spKnobTransform;
+        TrackerPtr<xaml_media::ITranslateTransform> m_spKnobTransform;
 
-        ctl::ComPtr<xaml_media::ITranslateTransform> m_spCurtainTransform;
+        TrackerPtr<xaml_media::ITranslateTransform> m_spCurtainTransform;
 
         EventRegistrationToken m_dragStarted{};
         

--- a/dxaml/xcp/dxaml/lib/UIElement_Partial.cpp
+++ b/dxaml/xcp/dxaml/lib/UIElement_Partial.cpp
@@ -3346,7 +3346,9 @@ _Check_return_ HRESULT UIElement::get_InteractionsImpl(_Out_ wfc::IVector<xaml::
     {
         ctl::ComPtr<InteractionCollection> interactionCollection;
         IFC_RETURN(ctl::make(this, &interactionCollection));
-        IFC_RETURN(interactionCollection.As(&m_interactions));
+        ctl::ComPtr<wfc::IVector<xaml::InteractionBase*>> spInteractions;
+        IFC_RETURN(interactionCollection.As(&spInteractions));
+        SetPtrValue(m_interactions, spInteractions);
     }
 
     IFC_RETURN(m_interactions.CopyTo(interactions));

--- a/dxaml/xcp/dxaml/lib/UIElement_Partial.h
+++ b/dxaml/xcp/dxaml/lib/UIElement_Partial.h
@@ -900,7 +900,7 @@ namespace DirectUI
             std::unique_ptr<VirtualizationInformation> m_pVirtualizationInformation;
 
 #if WI_IS_FEATURE_PRESENT(Feature_Xaml2018)
-            ctl::ComPtr<wfc::IVector<xaml::InteractionBase*>> m_interactions;
+            TrackerPtr<wfc::IVector<xaml::InteractionBase*>> m_interactions;
 #endif // WI_IS_FEATURE_PRESENT(Feature_Xaml2018)
     };
 }


### PR DESCRIPTION
## Summary

Peer classes must store strong cross-boundary references (to XAML `DependencyObject` / projected-interface peers) in a **`TrackerPtr`** set through **`SetPtrValue`**, so the edge is registered into the peer's `m_trackers` list and reported during the reference-tracker walk. A raw `ctl::ComPtr` bumps the COM *actual* refcount but not the *expected* count and is invisible to the GC walk — permanently over-pegging the object and its entire subtree (**leak**), and on error paths it can invert into a premature free (**use-after-free**).

This PR converts the **high-confidence object-reference violations** found by a lifetime scan of `dxaml/xcp/dxaml/lib` to the tracked pattern.


## Fixes
https://task.ms/64008525

## Changes

| Control | Fields converted |
|---|---|
| **SplitView** | `m_outerDismissLayerPopup`, `m_dismissHostElement`, `m_topDismissElement`, `m_bottomDismissElement`, `m_leftDismissElement`, `m_rightDismissElement` |
| **ToggleSwitch** | `m_spKnobTransform`, `m_spCurtainTransform` |
| **ListViewBase** | `m_spContainerBeingClicked` |
| **ModernCollectionBasePanel** | `m_spLayoutStrategy`, `m_spLayoutDataInfoProvider` |
| **UIElement** | `m_interactions` (type-erased `IVector<InteractionBase*>` peer collection, feature-gated `Feature_Xaml2018`) |

Each conversion is the same mechanical triple:
- **Declaration:** `ctl::ComPtr<T>` → `TrackerPtr<T>`
- **Assignment:** `m_x = value;` → `SetPtrValue(m_x, value);`
- **Null-out:** `m_x = nullptr;` → `m_x.Clear();`

Read sites are unchanged — `TrackerPtr` supports `operator->`, `operator bool`, `Get()`, `Cast()`, `As()`, and `CopyTo()`. Registered `TrackerPtr` fields are walked automatically via the base-class `m_trackers`, so no manual `OnReferenceTrackerWalk` edits are needed.

## Intentionally excluded: event-handler delegate fields

The lifetime scan also flags nine event-handler fields stored as `ctl::ComPtr` — **ComboBox** (2), **MediaTransportControls** (4), and **ToolTip** (3). These are **deliberately left as `ComPtr`**; they are scanner false-positives, not leaks, for two independent reasons:

1. **They hold WinRT *delegate* objects, not peers, and capture their owner weakly.** Each handler is built over a weak self-reference (`ctl::AsWeak(this, &wrThis)`) and resolves it per-invocation (`wrThis.As<T>(&owner)`). There is therefore **no strong cross-boundary cycle** back to the control — the field cannot pin a peer subtree, so `TrackerPtr` participation buys nothing.
2. **They require `handledEventsToo`.** Registration uses `AddHandler(handler.Get(), TRUE /* handledEventsToo */)`, and the stored delegate is needed later for the matching `RemoveHandler`. The tracked event abstractions (`EventPtr` / `WeakEventPtr`) **cannot express `handledEventsToo`**, so converting them would drop handled events and regress behavior. `MediaTransportControls` documents this constraint in-source.

Converting these would change behavior with zero leak benefit, so they remain `ComPtr` by design.

## Notes for reviewers

Per-field lifetime review is warranted: a raw `ComPtr` can be legitimately balanced (e.g. the element is parented into the tree, supplying the expected ref), so each conversion changes teardown ordering and should be validated against the reference-tracker stress/leak audits.
