### PR TITLE
Enable auto-merge for Maestro dependency PRs

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -70,8 +70,11 @@ configuration:
             action: Synchronize
       - isActivitySender:
           user: dotnet-maestro[bot]
-      - targetsBranch:
-          branch: main
+      - or:
+        - targetsBranch:
+            branch: main
+        - targetsBranch:
+            branch: release/*
       - bodyContains:
           pattern: 'Begin:57be40db-9f69-47be-beb4-eb42d78d3d8b'
           isRegex: false

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -57,6 +57,31 @@ configuration:
       - closeIssue
 
 
+    - description: Enable validation and auto-merge for WindowsAppSDK Maestro PRs
+      triggerOnOwnActions: false
+      if:
+      - payloadType: Pull_Request
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Reopened
+        - isAction:
+            action: Synchronize
+      - isActivitySender:
+          user: dotnet-maestro[bot]
+      - targetsBranch:
+          branch: main
+      - bodyContains:
+          pattern: 'Begin:57be40db-9f69-47be-beb4-eb42d78d3d8b'
+          isRegex: false
+      then:
+      - addReply:
+          reply: /azp run
+      - enableAutoMerge:
+          mergeMethod: Squash
+
+
     - description: Enable auto merge
       if:
       - payloadType: Pull_Request


### PR DESCRIPTION
## Summary

Automatically starts Azure Pipelines validation and enables native auto-merge for WindowsAppSDK dependency PRs created by Maestro.

## Changes

Updates `.github/policies/resourceManagement.yml` with a narrowly scoped rule that applies only when:

- The PR is opened, reopened, or updated.
- The author is `dotnet-maestro[bot]`.
- The target branch is `main`.
- The PR contains the expected WindowsAppSDK Darc subscription marker.

For matching PRs, the policy:

- Posts `/azp run` to start Azure Pipelines validation.
- Enables GitHub-native squash auto-merge.

## Expected behavior

Matching Maestro dependency PRs are marked for auto-merge when created or updated. GitHub keeps the PR open until all required approvals and status checks, including `WinUI-GitHub-PR (OneBranch)`, have passed.

Other Maestro subscriptions and regular pull requests are unaffected.