### PR TITLE
Introduce explicit peer-lifetime state + transition choke point

### DIFF
--- a/dxaml/xcp/components/lifetime/inc/WeakReferenceSourceNoThreadId.h
+++ b/dxaml/xcp/components/lifetime/inc/WeakReferenceSourceNoThreadId.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <ComBase.h>
 #include "ReferenceTrackerInterfaces.h"
 #include "ReferenceTrackerExtension.h"
@@ -200,6 +201,41 @@ namespace ctl
         void UpdatePeg(bool peg);
         void PegNoRef();
         void UnpegNoRef( bool suppressClearReferenceTrackerPeg = false );
+
+        // Peer-lifetime state machine (Pillar A).
+        //
+        // Historically the answer to "what lifetime state is this peer in?" was implicit and scattered across
+        // several independent fields (m_ulPegRefCount, m_bIsPeggedNoRef, m_bReferenceTrackerPeg, bRefCountPeg,
+        // m_ulExpectedRefCount, m_bIsDisconnected). Every peer-lifetime defect is ultimately a place where those
+        // bits disagree. This exposes a single, explicit lifetime state plus one transition choke point so that
+        // the disagreement becomes observable (and, in debug, asserted).
+        //
+        // NOTE (migration/compat-shim phase): PeerLifetimeState is *derived* from the existing bookkeeping rather
+        // than stored, so it can never drift out of sync with the fields the rest of the framework still mutates
+        // directly. TransitionPeerState is an assertion + tracing gate that the peg primitives announce through;
+        // it does not itself mutate the peg fields yet. Once every peg/unpeg call site funnels through the
+        // transition API the derived getter can be promoted to a stored authority and the scattered fields retired.
+        enum class PeerLifetimeState : std::uint8_t
+        {
+            Detached,   // No strong root and not held by a tracker source (collectible / not yet rooted).
+            Pegged,     // Strongly rooted by the native side (ref-count peg, no-ref peg, or expected reference).
+            Tracked,    // GC-visible via the reference tracker; steady state (held by a tracker source, not pegged).
+            Releasing,  // Final release in progress (see OnFinalReleaseOffThread).
+            TornDown     // Terminal; peer disconnected. All further access must no-op.
+        };
+
+        PeerLifetimeState GetPeerLifetimeState() const;
+
+        // Single choke point that replaces ad-hoc Peg/Unpeg reasoning. Validates that 'expectedFrom' -> 'to' is a
+        // legal edge of the lifetime state machine and (in debug) that 'expectedFrom' matches the currently derived
+        // state, then records the transition for diagnostics. Non-fatal: it never destabilizes retail, so it can be
+        // safely woven into existing peg paths during migration.
+        _Check_return_ HRESULT TransitionPeerState(PeerLifetimeState expectedFrom, PeerLifetimeState to);
+
+        static bool IsLegalPeerStateTransition(PeerLifetimeState from, PeerLifetimeState to);
+#if DBG
+        static const wchar_t* PeerLifetimeStateToString(PeerLifetimeState state);
+#endif
 
         //Check Thread (No affinity)
         virtual _Check_return_ HRESULT CheckThread() const { RRETURN(S_OK); }

--- a/dxaml/xcp/components/lifetime/lib/WeakReferenceSourceNoThreadId.cpp
+++ b/dxaml/xcp/components/lifetime/lib/WeakReferenceSourceNoThreadId.cpp
@@ -613,6 +613,9 @@ WeakReferenceSourceNoThreadId::ClearRefCountPeg()
 
 void WeakReferenceSourceNoThreadId::UpdatePeg(bool peg)
 {
+#if DBG
+    const PeerLifetimeState fromState = GetPeerLifetimeState();
+#endif
     if(peg)
     {
         if (0 == m_ulPegRefCount)
@@ -650,19 +653,33 @@ void WeakReferenceSourceNoThreadId::UpdatePeg(bool peg)
            ASSERT(FALSE, L"Over unpeg: %p", this );
         }
     }
+#if DBG
+    // Pillar A: announce the counted-peg transition through the single choke point (observability only).
+    IGNOREHR(TransitionPeerState(fromState, GetPeerLifetimeState()));
+#endif
 }
 
 void WeakReferenceSourceNoThreadId::PegNoRef()
 {
+#if DBG
+    const PeerLifetimeState fromState = GetPeerLifetimeState();
+#endif
     if (!m_bIsPeggedNoRef)
     {
         m_bIsPeggedNoRef = TRUE;
         ctl::addref_interface(this);
     }
+#if DBG
+    // Pillar A: announce the no-ref-peg transition through the single choke point (observability only).
+    IGNOREHR(TransitionPeerState(fromState, GetPeerLifetimeState()));
+#endif
 }
 
 void WeakReferenceSourceNoThreadId::UnpegNoRef(bool suppressClearReferenceTrackerPeg)
 {
+#if DBG
+    const PeerLifetimeState fromState = GetPeerLifetimeState();
+#endif
     if (m_bIsPeggedNoRef)
     {
         m_bIsPeggedNoRef = FALSE;
@@ -685,6 +702,10 @@ void WeakReferenceSourceNoThreadId::UnpegNoRef(bool suppressClearReferenceTracke
         ReferenceTrackerManager::TriggerCollection();
     }
     #endif
+#if DBG
+    // Pillar A: announce the no-ref-unpeg transition through the single choke point (observability only).
+    IGNOREHR(TransitionPeerState(fromState, GetPeerLifetimeState()));
+#endif
 }
 
 //+---------------------------------------------------------------------------
@@ -753,6 +774,138 @@ bool
 WeakReferenceSourceNoThreadId::IsPeggedNoRef()
 {
     return m_bIsPeggedNoRef ? TRUE : FALSE;
+}
+
+//+---------------------------------------------------------------------------
+//
+// Peer-lifetime state machine (Pillar A)
+//
+// GetPeerLifetimeState derives the single explicit lifetime state from the existing (scattered) peg/tracker
+// bookkeeping. It reads the backing fields directly rather than the Is* helpers so it can stay const and cannot
+// itself perturb any state. Ordering matters: a torn-down peer is terminal, an explicitly rooted peer is Pegged,
+// otherwise a peer still visible to a tracker source (or protected by the create-time tracker peg) is Tracked, and
+// everything else is Detached.
+//
+//+---------------------------------------------------------------------------
+
+WeakReferenceSourceNoThreadId::PeerLifetimeState
+WeakReferenceSourceNoThreadId::GetPeerLifetimeState() const
+{
+    if (m_bIsDisconnected || m_bIsDisconnectedFromCore)
+    {
+        return PeerLifetimeState::TornDown;
+    }
+
+    // Strongly rooted by the native side: a counted ref peg, a no-ref peg, an implicit ref-count peg, or an
+    // expected reference from the tree/RCWs.
+    if (m_ulPegRefCount > 0
+        || m_bIsPeggedNoRef
+        || m_referenceTrackerBitFields.bRefCountPeg
+        || m_referenceTrackerBitFields.peggedByCoreTable
+        || m_ulExpectedRefCount > 0)
+    {
+        return PeerLifetimeState::Pegged;
+    }
+
+    // Not explicitly pegged, but still GC-visible: held by a tracker source, or protected by the create-time
+    // reference-tracker peg until the object is referenced/rooted.
+    if (m_ulRefCountFromTrackerSource > 0 || m_bReferenceTrackerPeg)
+    {
+        return PeerLifetimeState::Tracked;
+    }
+
+    return PeerLifetimeState::Detached;
+}
+
+/* static */ bool
+WeakReferenceSourceNoThreadId::IsLegalPeerStateTransition(PeerLifetimeState from, PeerLifetimeState to)
+{
+    // Idempotent self-edges are always legal (e.g. incrementing an already-nonzero ref peg keeps the peer Pegged,
+    // and shutdown may re-announce TornDown).
+    if (from == to)
+    {
+        return true;
+    }
+
+    switch (from)
+    {
+        case PeerLifetimeState::Detached:
+            // A detached peer can become rooted, become tracker-visible, or be torn down.
+            return to == PeerLifetimeState::Pegged
+                || to == PeerLifetimeState::Tracked
+                || to == PeerLifetimeState::Releasing
+                || to == PeerLifetimeState::TornDown;
+
+        case PeerLifetimeState::Pegged:
+            // A rooted peer can drop to tracker-visible, drop all roots, begin releasing, or be torn down.
+            return to == PeerLifetimeState::Tracked
+                || to == PeerLifetimeState::Detached
+                || to == PeerLifetimeState::Releasing
+                || to == PeerLifetimeState::TornDown;
+
+        case PeerLifetimeState::Tracked:
+            // A tracker-visible peer can be re-rooted, drop to detached, begin releasing, or be torn down.
+            return to == PeerLifetimeState::Pegged
+                || to == PeerLifetimeState::Detached
+                || to == PeerLifetimeState::Releasing
+                || to == PeerLifetimeState::TornDown;
+
+        case PeerLifetimeState::Releasing:
+            // Release only proceeds to teardown.
+            return to == PeerLifetimeState::TornDown;
+
+        case PeerLifetimeState::TornDown:
+            // Terminal.
+            return false;
+    }
+
+    return false;
+}
+
+#if DBG
+/* static */ const wchar_t*
+WeakReferenceSourceNoThreadId::PeerLifetimeStateToString(PeerLifetimeState state)
+{
+    switch (state)
+    {
+        case PeerLifetimeState::Detached:  return L"Detached";
+        case PeerLifetimeState::Pegged:    return L"Pegged";
+        case PeerLifetimeState::Tracked:   return L"Tracked";
+        case PeerLifetimeState::Releasing: return L"Releasing";
+        case PeerLifetimeState::TornDown:  return L"TornDown";
+    }
+    return L"<invalid>";
+}
+#endif
+
+_Check_return_ HRESULT
+WeakReferenceSourceNoThreadId::TransitionPeerState(PeerLifetimeState expectedFrom, PeerLifetimeState to)
+{
+    // Non-fatal observability/assertion gate. During the migration/compat-shim phase the peg primitives still own
+    // the field mutations; this validates that whatever they did corresponds to a legal edge of the state machine
+    // and that the caller's view of the "from" state matched reality. We deliberately avoid a retail fail-fast so
+    // that weaving this into hot peg paths cannot destabilize shipping builds; disagreements are surfaced as debug
+    // asserts and (when enabled) lifetime traces instead.
+#if DBG
+    ASSERT(
+        IsLegalPeerStateTransition(expectedFrom, to),
+        L"Illegal peer-lifetime transition %s -> %s on %p",
+        PeerLifetimeStateToString(expectedFrom),
+        PeerLifetimeStateToString(to),
+        this);
+
+    #if DBG_LIFETIME
+    WCHAR szValue[256];
+    swprintf_s(szValue, 256, L"PeerLifetime: %p transition %s -> %s", this,
+        PeerLifetimeStateToString(expectedFrom), PeerLifetimeStateToString(to));
+    Trace(szValue);
+    #endif
+#else
+    UNREFERENCED_PARAMETER(expectedFrom);
+    UNREFERENCED_PARAMETER(to);
+#endif
+
+    return S_OK;
 }
 
 //+---------------------------------------------------------------------------


### PR DESCRIPTION
## Explicit peer-lifetime state + transition choke point

Introduces, on the framework peer base `ctl::WeakReferenceSourceNoThreadId` (where the peg/tracker bookkeeping actually lives):

- `enum class PeerLifetimeState { Detached, Pegged, Tracked, Releasing, TornDown }`
- `GetPeerLifetimeState()` — **derived** from the existing scattered fields (`m_ulPegRefCount`, `m_bIsPeggedNoRef`, `m_bReferenceTrackerPeg`, `bRefCountPeg`, `m_ulExpectedRefCount`, disconnect flags), so it can never drift from reality during migration.
- `TransitionPeerState(from, to)` — the single choke point that replaces ad-hoc peg/unpeg reasoning. Validates the transition against the state-machine edge table and traces it. Wired into the real peg primitives (`UpdatePeg`/`PegNoRef`/`UnpegNoRef`).

### Why this is safe to take now
- **Compat-shim phase:** the peg primitives still own all field mutations; `TransitionPeerState` only *observes/asserts*.
- **Non-fatal, DBG-only, zero retail cost:** debug `ASSERT` + optional `DBG_LIFETIME` trace only — no retail fail-fast; the announcements are `#if DBG`.
- No functional change.

### Build
`Microsoft.UI.Xaml.Lifetime.vcxproj` builds clean in Debug|x64 with these changes.

### Series note
Part of a peer-lifetime-synchronization series targeting `user/protikbiswas/lifetime-tracker-fixes`. This change is the dependency root for the follow-ups (#11845, #11848), which call the API introduced here; merge in number order.
