### PR TITLE
Pillar C: thread-affine peer-release funnel diagnostic

### DIFF
--- a/dxaml/xcp/components/lifetime/lib/WeakReferenceSourceNoThreadId.cpp
+++ b/dxaml/xcp/components/lifetime/lib/WeakReferenceSourceNoThreadId.cpp
@@ -923,6 +923,19 @@ WeakReferenceSourceNoThreadId::OnFinalReleaseOffThread(_In_ bool allowOffThreadD
     // do the FinalRelease there
     if (FAILED(CheckThread()))
     {
+        // Pillar C - thread-affine release funnel. This is the single choke point that guarantees a peer's final
+        // release is completed on its owning (UI) thread: an off-thread release is either re-queued to the owning
+        // thread's UIAffinityReleaseQueue, or (only when no owning core is still registered, i.e. shutdown) deleted
+        // inline. Announce the move into the Releasing state so this off-thread funnel participates in the Pillar A
+        // peer-lifetime state machine. Non-fatal (compat-shim): validates the edge and records it for diagnostics.
+        // A peer that has already been disconnected derives to the terminal TornDown state (which has no legal edge
+        // to Releasing); skip the announcement in that case rather than assert on an illegal terminal transition.
+        const PeerLifetimeState currentPeerState = GetPeerLifetimeState();
+        if (currentPeerState != PeerLifetimeState::TornDown)
+        {
+            IGNOREHR(TransitionPeerState(currentPeerState, PeerLifetimeState::Releasing));
+        }
+
         // If we have an m_compositionWrapper, it's now a dangling pointer.  Clear it
         // so that we don't accidentally try to use it (such as in the AddRef that happens
         // during RTW_Peg walks).
@@ -940,6 +953,10 @@ WeakReferenceSourceNoThreadId::OnFinalReleaseOffThread(_In_ bool allowOffThreadD
         }
         else if (allowOffThreadDelete)
         {
+            // No owning core is still registered to marshal to (process/island shutdown). This is the only path
+            // that destroys a peer inline off its owning thread; the paired native destructor emits the
+            // DependencyObject_OffThreadDestruction telemetry (and, when enabled, fail-fasts) so this residual
+            // off-thread teardown remains observable.
             CStaticLock lock;
             // attempt an off thread release
             delete this;

--- a/dxaml/xcp/components/lifetime/unittests/FakeDXamlCore.h
+++ b/dxaml/xcp/components/lifetime/unittests/FakeDXamlCore.h
@@ -58,6 +58,10 @@ namespace DirectUI
         virtual void SetRTWTotalCompressedImageSize(std::uint64_t imageSize) override { m_rtwCompressedImageSize = imageSize; }
 
         BOOLEAN IsFinalReleaseQueueEmpty() { return m_finalReleaseQueue.size() == 0; }
+        // Pillar C test helpers: inspect/reset the off-thread final-release routing target without deleting the
+        // queued raw pointers (the queue does not own a reference in this fake).
+        size_t GetFinalReleaseQueueCount() const { return m_finalReleaseQueue.size(); }
+        void ClearFinalReleaseQueue() { m_finalReleaseQueue.clear(); }
         UINT32 GenerateRawElementProviderRuntimeId() override { ASSERT(false); return 0; }
 
         static IDXamlCore* GetCurrentDXamlCore() { return s_currentDXamlCore; }

--- a/dxaml/xcp/components/lifetime/unittests/LifetimeUnitTests.cpp
+++ b/dxaml/xcp/components/lifetime/unittests/LifetimeUnitTests.cpp
@@ -25,6 +25,28 @@ namespace
         STDMETHOD(FoundTrackerTarget)(IReferenceTrackerTarget *target) override { ++CallbacksCount; return S_OK; }
         unsigned CallbacksCount = 0;
     };
+
+    // Pillar C test peer: a minimal peer whose thread affinity and owning core can be controlled directly, so the
+    // off-thread final-release funnel (WeakReferenceSourceNoThreadId::OnFinalReleaseOffThread) can be exercised
+    // deterministically without standing up the full peer-registration / core-search machinery.
+    class ControllableThreadPeer
+        : public ctl::WeakReferenceSourceNoThreadId
+    {
+    public:
+        _Check_return_ HRESULT CheckThread() const override
+        {
+            return m_onOwningThread ? S_OK : RPC_E_WRONG_THREAD;
+        }
+
+        DirectUI::IDXamlCore* GetCoreForObject() override { return m_core; }
+
+        void SetOnOwningThread(bool value) { m_onOwningThread = value; }
+        void SetCore(DirectUI::IDXamlCore* core) { m_core = core; }
+
+    private:
+        bool m_onOwningThread = true;
+        DirectUI::IDXamlCore* m_core = nullptr;
+    };
 }
 
 namespace Windows { namespace UI { namespace Xaml { namespace Tests { namespace Lifetime {
@@ -237,10 +259,65 @@ namespace Windows { namespace UI { namespace Xaml { namespace Tests { namespace 
         return 0;
     }
 
+    // Pillar C - thread-affine release funnel.
+    // An off-thread final release must be marshaled to the owning core's release queue, never destroyed inline.
+    void LifetimeUnitTests::OffThreadFinalReleaseRoutesToOwningThread()
+    {
+        ctl::ComPtr<ControllableThreadPeer> peer;
+        THROW_IF_FAILED(ctl::ComObject<ControllableThreadPeer>::CreateInstance(peer.GetAddressOf()));
 
+        peer->SetCore(m_dxamlCore);
+        peer->SetOnOwningThread(false);
 
+        VERIFY_IS_TRUE(m_dxamlCore->IsFinalReleaseQueueEmpty());
 
-    
+        // allowOffThreadDelete = false: we assert the object is routed to the queue, and guarantee it is never
+        // deleted inline by this call (so the ComPtr below remains the sole owner).
+        const bool routed = peer->OnFinalReleaseOffThread(false /* allowOffThreadDelete */);
+
+        VERIFY_IS_TRUE(routed);
+        VERIFY_ARE_EQUAL(static_cast<size_t>(1), m_dxamlCore->GetFinalReleaseQueueCount());
+
+        // Cleanup: OnFinalReleaseOffThread set the ignore-releases guard (the object is "owned" by the queue).
+        // Undo it and drop the fake queue entry so the ComPtr can release/destroy normally on this (owning) thread.
+        peer->DisableIgnoreReleases();
+        m_dxamlCore->ClearFinalReleaseQueue();
+        peer->SetOnOwningThread(true);
+    }
+
+    // Pillar C - a final release already on the owning thread must proceed inline (not be routed).
+    void LifetimeUnitTests::OnThreadFinalReleaseIsNotRouted()
+    {
+        ctl::ComPtr<ControllableThreadPeer> peer;
+        THROW_IF_FAILED(ctl::ComObject<ControllableThreadPeer>::CreateInstance(peer.GetAddressOf()));
+
+        peer->SetCore(m_dxamlCore);
+        peer->SetOnOwningThread(true);
+
+        const bool routed = peer->OnFinalReleaseOffThread(false /* allowOffThreadDelete */);
+
+        VERIFY_IS_FALSE(routed);
+        VERIFY_IS_TRUE(m_dxamlCore->IsFinalReleaseQueueEmpty());
+    }
+
+    // Pillar C ties the off-thread funnel into the Pillar A peer-lifetime state machine by announcing the move into
+    // the Releasing state. Validate that this edge is legal from every state a peer can be in before release, and
+    // that Releasing is terminal-bound (only -> TornDown).
+    void LifetimeUnitTests::ReleasingIsALegalTransitionFromEveryPreReleaseState()
+    {
+        using PeerLifetimeState = ctl::WeakReferenceSourceNoThreadId::PeerLifetimeState;
+
+        VERIFY_IS_TRUE(ctl::WeakReferenceSourceNoThreadId::IsLegalPeerStateTransition(PeerLifetimeState::Detached, PeerLifetimeState::Releasing));
+        VERIFY_IS_TRUE(ctl::WeakReferenceSourceNoThreadId::IsLegalPeerStateTransition(PeerLifetimeState::Pegged, PeerLifetimeState::Releasing));
+        VERIFY_IS_TRUE(ctl::WeakReferenceSourceNoThreadId::IsLegalPeerStateTransition(PeerLifetimeState::Tracked, PeerLifetimeState::Releasing));
+
+        // Releasing only proceeds to teardown.
+        VERIFY_IS_TRUE(ctl::WeakReferenceSourceNoThreadId::IsLegalPeerStateTransition(PeerLifetimeState::Releasing, PeerLifetimeState::TornDown));
+
+        // A torn-down peer is terminal: it can never re-enter Releasing.
+        VERIFY_IS_FALSE(ctl::WeakReferenceSourceNoThreadId::IsLegalPeerStateTransition(PeerLifetimeState::TornDown, PeerLifetimeState::Releasing));
+    }
+
 } } } } }
 
 

--- a/dxaml/xcp/components/lifetime/unittests/LifetimeUnitTests.h
+++ b/dxaml/xcp/components/lifetime/unittests/LifetimeUnitTests.h
@@ -31,6 +31,18 @@ namespace Windows { namespace UI { namespace Xaml { namespace Tests { namespace 
             TEST_METHOD_PROPERTY(L"Description", L"Description")
         END_TEST_METHOD()
 
+        BEGIN_TEST_METHOD(OffThreadFinalReleaseRoutesToOwningThread)
+            TEST_METHOD_PROPERTY(L"Description", L"Pillar C: an off-thread final release is funneled to the owning core's release queue rather than destroyed inline.")
+        END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(OnThreadFinalReleaseIsNotRouted)
+            TEST_METHOD_PROPERTY(L"Description", L"Pillar C: a final release already on the owning thread is not routed and proceeds inline.")
+        END_TEST_METHOD()
+
+        BEGIN_TEST_METHOD(ReleasingIsALegalTransitionFromEveryPreReleaseState)
+            TEST_METHOD_PROPERTY(L"Description", L"Pillar C: the Releasing edge announced by the off-thread funnel is legal from every pre-release peer-lifetime state.")
+        END_TEST_METHOD()
+
     private:
 
         DirectUI::FakeDXamlCore* m_dxamlCore;

--- a/dxaml/xcp/components/runtimeEnabledFeatures/RuntimeFeatureData.cpp
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/RuntimeFeatureData.cpp
@@ -84,5 +84,7 @@ namespace RuntimeFeatureBehavior
         // If XAML dispatch is paused, then to allow process without creating the reentrancy guard, else to enable the reentrancy checks.
         { L"EnableReentrancyChecksAllowPaused", RuntimeEnabledFeature::EnableReentrancyChecksAllowPaused, false, 0, 0 },
         { L"ForcePerfOptIn", RuntimeEnabledFeature::ForcePerfOptIn, true /*opt-in by default in perf branch for now*/, 0, 1 },
+        // Pillar C: gates promotion of the native peer off-thread-destruction diagnostic to a hard fail-fast. Default off (telemetry-only) during rollout.
+        { L"FailFastOnOffThreadPeerDestruction", RuntimeEnabledFeature::FailFastOnOffThreadPeerDestruction, false, 0, 0 },
     };
 }

--- a/dxaml/xcp/components/runtimeEnabledFeatures/inc/RuntimeEnabledFeaturesEnum.h
+++ b/dxaml/xcp/components/runtimeEnabledFeatures/inc/RuntimeEnabledFeaturesEnum.h
@@ -76,6 +76,7 @@ namespace RuntimeFeatureBehavior
         ForceDWriteTypographicModel,        // overides DisableDWriteTypographicModel
         EnableReentrancyChecksAllowPaused, // If XAML dispatch is paused, then to allow process without creating the reentrancy guard, else to enable the reentrancy checks.
         ForcePerfOptIn, // Opts in to perf optimizations gated behind this flag (e.g. inline DO accessor in PropertyAccessPathStep).
+        FailFastOnOffThreadPeerDestruction, // Pillar C: promote the native peer off-thread-destruction diagnostic from telemetry-only to a hard fail-fast. Default off; flip on once telemetry confirms the off-thread destruction path is clean.
 
         // Insert new enum values before this one.
         // This is used to initialize the lengths of the

--- a/dxaml/xcp/core/core/elements/depends.cpp
+++ b/dxaml/xcp/core/core/elements/depends.cpp
@@ -45,6 +45,35 @@ CDependencyObject::~CDependencyObject()
 
     if (core)
     {
+        // Pillar C - thread-affine release funnel (failure mode P3).
+        //
+        // Native XAML objects are UI-thread (STA) affinitized, but a managed peer's final release can originate on
+        // the GC/finalizer thread. The framework marshals that release back to the owning thread through the
+        // UIAffinityReleaseQueue funnel (see WeakReferenceSourceNoThreadId::OnFinalReleaseOffThread). If we still
+        // reach the native destructor on the wrong thread, a marshaling contract was violated and we are about to
+        // tear down UI-thread-affine state off-thread - historically a silent-corruption / stowed-exception crash
+        // class (e.g. CCoreServices::ExecuteOnUIThread). Turn that silent corruption into a clean, buckettable
+        // signal. Telemetry is emitted unconditionally for observability; the hard fail-fast is gated behind a
+        // runtime feature (default off) so it can be promoted from telemetry-only to fail-fast once field data
+        // confirms the path is clean, matching the incremental rollout used by the other lifetime pillars.
+        if (core->GetThreadID() != ::GetCurrentThreadId())
+        {
+            TraceLoggingProviderWrite(
+                XamlTelemetry, "DependencyObject_OffThreadDestruction",
+                TraceLoggingUInt64(reinterpret_cast<uint64_t>(this), "ObjectPointer"),
+                TraceLoggingUInt16(static_cast<uint16_t>(GetTypeIndex()), "TypeIndex"),
+                TraceLoggingUInt32(core->GetThreadID(), "OwningThreadId"),
+                TraceLoggingUInt32(::GetCurrentThreadId(), "CurrentThreadId"),
+                TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+
+            static auto runtimeEnabledFeatureDetector = RuntimeFeatureBehavior::GetRuntimeEnabledFeatureDetector();
+            if (runtimeEnabledFeatureDetector->IsFeatureEnabled(
+                    RuntimeFeatureBehavior::RuntimeEnabledFeature::FailFastOnOffThreadPeerDestruction))
+            {
+                XAML_FAIL_FAST();
+            }
+        }
+
         // If this core object was marked as a GC root, unmark it,
         core->UnpegNoRefCoreObjectWithoutPeer(this);
 


### PR DESCRIPTION
## Pillar C — Thread-affine release funnel (failure mode P3)

Makes off-thread destruction of UI-thread-affine XAML peers a **clean, buckettable signal** instead of silent corruption, and ties the existing off-thread release funnel into the Pillar A peer-lifetime state machine.

### Background / ground truth
The framework **already** marshals off-thread final releases back to the owning (UI) thread: all three `OnFinalRelease` overrides funnel through `WeakReferenceSourceNoThreadId::OnFinalReleaseOffThread` → `IDXamlCore::QueueObjectForFinalRelease` → `UIAffinityReleaseQueue` (drained on the UI thread by the BuildTreeService/BudgetManager tick). So the funnel itself is not new. What was missing is the **diagnostic** that catches the case where a native peer nonetheless gets torn down on the wrong thread — historically a stowed-exception / silent-corruption crash class (e.g. `CCoreServices::ExecuteOnUIThread`).

### Changes
- **`~CDependencyObject()`** (`depends.cpp`): if the native destructor runs off the owning thread, emit `DependencyObject_OffThreadDestruction` telemetry **unconditionally**, and `XAML_FAIL_FAST()` **only when** the new `FailFastOnOffThreadPeerDestruction` runtime feature is enabled. Common (on-thread) path cost is a single thread-id compare.
- **`OnFinalReleaseOffThread()`** (`WeakReferenceSourceNoThreadId.cpp`): announce the `Releasing` transition through the Pillar A `TransitionPeerState` choke point, and document the residual inline off-thread `delete this` path (taken only at shutdown when no owning core is still registered).
- **Runtime feature** `FailFastOnOffThreadPeerDestruction` (enum + **default-off** data row): lets the hard fail-fast be promoted from telemetry-only to fail-fast after field data confirms the path is clean — the same incremental rollout used by the other lifetime pillars.
- **Lifetime unit tests** (3): off-thread final release routes to the owning core's release queue; on-thread release is not routed; `Releasing` is a legal edge from every pre-release peer-lifetime state.

### Why the fail-fast is gated (default off)
`~CDependencyObject` is the single most-executed teardown path in the framework, and there is a legitimate shutdown-only path (`allowOffThreadDelete` → inline `delete this` when no core is registered) that can reach the native destructor off-thread today. Shipping the crash **unconditionally** would regress those. Telemetry-first + gated fail-fast turns the crash class into observable data now and a hard signal when we flip the flag — consistent with the design doc's risk section and with Pillars A (non-fatal compat shim) and B (warn→error rollout).

### Validation
- Built clean (0 warnings / 0 errors, `amd64chk`): `xcpcore` (depends.cpp), `Microsoft.UI.Xaml.Lifetime` (funnel), `Microsoft.UI.Xaml.RuntimeEnabledFeatures` (flag), and the isolated lifetime test DLL.
- **TAEF: 13/13 lifetime tests pass**, including the 3 new Pillar C tests. Writing the tests also surfaced and fixed a real latent illegal-transition assert (`TornDown → Releasing`) that the guard now avoids.

Base branch: `user/protikbiswas/lifetime-tracker-fixes`.
