### PR TITLE
Add custom error messages to E_INVALIDARG in NumberBox, ScrollPresenter, SnapPoint, and XamlPredicate

### DIFF
--- a/controls/dev/NumberBox/NumberBox.cpp
+++ b/controls/dev/NumberBox/NumberBox.cpp
@@ -313,7 +313,7 @@ void NumberBox::ValidateNumberFormatter(winrt::INumberFormatter2 value)
     // NumberFormatter also needs to be an INumberParser
     if (!value.try_as<winrt::INumberParser>())
     {
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(L"NumberFormatter must implement both INumberFormatter2 and INumberParser.");
     }
 }
 

--- a/controls/dev/ScrollPresenter/ScrollPresenter.cpp
+++ b/controls/dev/ScrollPresenter/ScrollPresenter.cpp
@@ -3732,7 +3732,10 @@ void ScrollPresenter::ValidateZoomFactoryBoundary(double value)
 {
     if (!IsZoomFactorBoundaryValid(value))
     {
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"Zoom-factor boundary must be finite; received %1!s!.",
+                winrt::to_hstring(value).c_str()));
     }
 }
 
@@ -3761,7 +3764,10 @@ void ScrollPresenter::ValidateAnchorRatio(double value)
 {
     if (!IsAnchorRatioValid(value))
     {
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"Anchor ratio must be NaN or between 0 and 1 inclusive; received %1!s!.",
+                winrt::to_hstring(value).c_str()));
     }
 }
 

--- a/controls/dev/ScrollPresenter/ScrollPresenterAutomationPeer.cpp
+++ b/controls/dev/ScrollPresenter/ScrollPresenterAutomationPeer.cpp
@@ -138,7 +138,11 @@ void ScrollPresenterAutomationPeer::SetScrollPercent(double horizontalPercent, d
     if ((scrollHorizontally && (horizontalPercent < s_minimumPercent || horizontalPercent > s_maximumPercent)) ||
         (scrollVertically && (verticalPercent < s_minimumPercent || verticalPercent > s_maximumPercent)))
     {
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"Scroll percent is out of range: horizontal=%1!s!, vertical=%2!s!; expected -1 or 0..100.",
+                winrt::to_hstring(horizontalPercent).c_str(),
+                winrt::to_hstring(verticalPercent).c_str()));
     }
 
     auto scrollPresenter = winrt::get_self<ScrollPresenter>(GetScrollPresenter());

--- a/controls/dev/ScrollPresenter/ScrollPresenterPrivate.cpp
+++ b/controls/dev/ScrollPresenter/ScrollPresenterPrivate.cpp
@@ -109,7 +109,7 @@ void ScrollPresenter::RegisterAnchorCandidate(winrt::UIElement const& element)
 
     if (!element)
     {
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(L"Anchor candidate cannot be null.");
     }
 
     if (!isnan(HorizontalAnchorRatio()) || !isnan(VerticalAnchorRatio()))
@@ -140,7 +140,7 @@ void ScrollPresenter::UnregisterAnchorCandidate(winrt::UIElement const& element)
 
     if (!element)
     {
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(L"Anchor candidate cannot be null.");
     }
 
     const winrt::UIElement anchorCandidate = element;

--- a/controls/dev/ScrollPresenter/ScrollingAnchorRequestedEventArgs.cpp
+++ b/controls/dev/ScrollPresenter/ScrollingAnchorRequestedEventArgs.cpp
@@ -40,7 +40,10 @@ void ScrollingAnchorRequestedEventArgs::AnchorElement(winrt::UIElement const& va
     }
     else
     {
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"AnchorElement must be a descendant of the ScrollPresenter content; element '%1!s!' is not a valid anchor candidate.",
+                winrt::get_class_name(anchorElement).c_str()));
     }
 }
 

--- a/controls/dev/ScrollPresenter/SnapPoint.cpp
+++ b/controls/dev/ScrollPresenter/SnapPoint.cpp
@@ -514,8 +514,10 @@ void ScrollSnapPoint::Combine(
     }
     else
     {
-        // TODO: Provide custom error message
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"Cannot combine ScrollSnapPoint with snap point type '%1!s!'.",
+                winrt::get_class_name(snapPoint).c_str()));
     }
 }
 
@@ -800,8 +802,11 @@ std::tuple<double, double> RepeatedScrollSnapPoint::DetermineActualApplicableZon
     // We only need to check the nextSnapPoint because of the symmetry in the algorithm.
     if (nextSnapPoint && *static_cast<SnapPointBase*>(this) == (nextSnapPoint))
     {
-        // TODO: Provide custom error message
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"Adjacent repeated ScrollSnapPoints cannot have the same range [%1!s!, %2!s!].",
+                winrt::to_hstring(ActualStart()).c_str(),
+                winrt::to_hstring(ActualEnd()).c_str()));
     }
 
     return actualApplicableZoneReturned;
@@ -984,8 +989,12 @@ double RepeatedScrollSnapPoint::Influence(double edgeOfMidpoint) const
     else
     {
         // Snap points are not allowed within the bounds (Start thru End) of repeated snap points
-        // TODO: Provide custom error message
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"A snap point at %1!s! cannot lie inside repeated ScrollSnapPoint range [%2!s!, %3!s!].",
+                winrt::to_hstring(edgeOfMidpoint).c_str(),
+                winrt::to_hstring(actualStart).c_str(),
+                winrt::to_hstring(actualEnd).c_str()));
     }
     return 0.0;
 }
@@ -1020,8 +1029,11 @@ void RepeatedScrollSnapPoint::Combine(
     winrt::SnapPointBase const& snapPoint) const
 {
     // Snap points are not allowed within the bounds (Start thru End) of repeated snap points
-    // TODO: Provide custom error message
-    throw winrt::hresult_error(E_INVALIDARG);
+    throw winrt::hresult_invalid_argument(
+        StringUtil::FormatString(
+            L"Cannot combine a snap point with repeated ScrollSnapPoint range [%1!s!, %2!s!].",
+            winrt::to_hstring(ActualStart()).c_str(),
+            winrt::to_hstring(ActualEnd()).c_str()));
 }
 
 int RepeatedScrollSnapPoint::SnapCount() const
@@ -1404,8 +1416,10 @@ void ZoomSnapPoint::Combine(
     }
     else
     {
-        // TODO: Provide custom error message
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"Cannot combine ZoomSnapPoint with snap point type '%1!s!'.",
+                winrt::get_class_name(snapPoint).c_str()));
     }
 }
 
@@ -1688,8 +1702,11 @@ std::tuple<double, double> RepeatedZoomSnapPoint::DetermineActualApplicableZone(
     // We only need to check the nextSnapPoint because of the symmetry in the algorithm.
     if (nextSnapPoint && *static_cast<SnapPointBase*>(this) == (nextSnapPoint))
     {
-        // TODO: Provide custom error message
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"Adjacent repeated ZoomSnapPoints cannot have the same range [%1!s!, %2!s!].",
+                winrt::to_hstring(m_start).c_str(),
+                winrt::to_hstring(m_end).c_str()));
     }
 
     return actualApplicableZoneReturned;
@@ -1844,8 +1861,12 @@ double RepeatedZoomSnapPoint::Influence(double edgeOfMidpoint) const
     else
     {
         // Snap points are not allowed within the bounds (Start thru End) of repeated snap points
-        // TODO: Provide custom error message
-        throw winrt::hresult_error(E_INVALIDARG);
+        throw winrt::hresult_invalid_argument(
+            StringUtil::FormatString(
+                L"A snap point at %1!s! cannot lie inside repeated ZoomSnapPoint range [%2!s!, %3!s!].",
+                winrt::to_hstring(edgeOfMidpoint).c_str(),
+                winrt::to_hstring(m_start).c_str(),
+                winrt::to_hstring(m_end).c_str()));
     }
     return 0.0;
 }
@@ -1880,8 +1901,11 @@ void RepeatedZoomSnapPoint::Combine(
     winrt::SnapPointBase const& snapPoint) const
 {
     // Snap points are not allowed within the bounds (Start thru End) of repeated snap points
-    // TODO: Provide custom error message
-    throw winrt::hresult_error(E_INVALIDARG);
+    throw winrt::hresult_invalid_argument(
+        StringUtil::FormatString(
+            L"Cannot combine a snap point with repeated ZoomSnapPoint range [%1!s!, %2!s!].",
+            winrt::to_hstring(m_start).c_str(),
+            winrt::to_hstring(m_end).c_str()));
 }
 
 int RepeatedZoomSnapPoint::SnapCount() const

--- a/dxaml/xcp/core/core/elements/XamlPredicate.cpp
+++ b/dxaml/xcp/core/core/elements/XamlPredicate.cpp
@@ -55,7 +55,10 @@ bool IsApiContractPresent_Evaluate(std::vector<xstring_ptr> args)
     }
     else
     {
-        THROW_HR(E_INVALIDARG);
+        THROW_HR_MSG(
+            E_INVALIDARG,
+            "IsApiContractPresent received %zu arguments; expected 2 or 3.",
+            args.size());
     }
 
     return !!isPresent;
@@ -85,7 +88,10 @@ bool IsPropertyPresent_Evaluate(std::vector<xstring_ptr> args)
     }
     else
     {
-        THROW_HR(E_INVALIDARG);
+        THROW_HR_MSG(
+            E_INVALIDARG,
+            "IsPropertyPresent received %zu arguments; expected 2.",
+            args.size());
     }
 
     return !!isPresent;
@@ -114,7 +120,10 @@ bool IsTypePresent_Evaluate(std::vector<xstring_ptr> args)
     }
     else
     {
-        THROW_HR(E_INVALIDARG);
+        THROW_HR_MSG(
+            E_INVALIDARG,
+            "IsTypePresent received %zu arguments; expected 1.",
+            args.size());
     }
 
     return !!isPresent;


### PR DESCRIPTION
## Fixes

Helps fix #10322 (keep the issue open post-merge)

## PR Type

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Description

This PR adds custom error messages to the E_INVALIDARG HRESULTs in NumberBox, ScrollPresenter, SnapPoint, and XamlPredicate classes.

### Current Behavior
When these exceptions are thrown, the generic error message ("One or more arguments are invalid") is shown to the user.

### New Behavior
When these exceptions are thrown, a message explaining why the error was thrown is presented with relevant variables.

## Customer Impact

When users hit E_INVALIDARG in these classes, they will be better able to diagnose their code and resolve bugs faster.

## Regression Potential

- [X] Low risk — isolated change, limited scope
- [ ] Medium risk — touches shared components or public APIs
- [ ] High risk — architectural or breaking API change

## How Has This Been Tested?

<!-- Describe how you validated your changes. -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [ ] Existing tests pass locally

This PR was written with the assistance of AI.