### PR TITLE
Fix DBG assert crash-loop in OnFinalRelease (guard TornDown -> Releasing)

### DIFF
--- a/dxaml/xcp/dxaml/lib/DependencyObject.cpp
+++ b/dxaml/xcp/dxaml/lib/DependencyObject.cpp
@@ -478,8 +478,15 @@ DependencyObject::OnFinalRelease()
 {
 #if DBG
     // Pillar A: the framework peer is entering final release. Announce the transition through the single
-    // choke point (observability only; this does not alter the release path).
-    IGNOREHR(TransitionPeerState(GetPeerLifetimeState(), ctl::WeakReferenceSourceNoThreadId::PeerLifetimeState::Releasing));
+    // choke point (observability only; this does not alter the release path). A peer that has already been
+    // disconnected derives to the terminal TornDown state, which has no legal edge to Releasing; skip the
+    // announcement in that case rather than assert on an illegal terminal transition (matches the guard in
+    // WeakReferenceSourceNoThreadId::OnFinalReleaseOffThread).
+    const auto currentPeerState = GetPeerLifetimeState();
+    if (currentPeerState != ctl::WeakReferenceSourceNoThreadId::PeerLifetimeState::TornDown)
+    {
+        IGNOREHR(TransitionPeerState(currentPeerState, ctl::WeakReferenceSourceNoThreadId::PeerLifetimeState::Releasing));
+    }
 #endif
 
     if (OnFinalReleaseOffThread())


### PR DESCRIPTION
## Problem

Build [157365538](https://microsoft.visualstudio.com/WinUI/_build/results?buildId=157365538&view=results) on `user/protikbiswas/lifetime-tracker-fixes` did not run slowly — it **crash-looped on a DBG assertion**. Every `RunTests` shard was canceled after hitting its ~100 min job timeout.

Evidence from one canceled shard (RunTests25H2 #2, log 2455):
- **269** `0xC0000420` (`STATUS_ASSERTION_FAILURE`) crashes in `Microsoft.UI.Xaml.dll`
- **152** test groups ended `[Failed]` across **unrelated** suites (WebView2Tests, etc.)
- Each assert killed and relaunched the test app (~5-10s) plus reruns → shards blew past the job timeout and were canceled.

## Root cause

`DependencyObject::OnFinalRelease()` (added on this branch) unconditionally announced `GetPeerLifetimeState() -> Releasing` via `TransitionPeerState`:

```cpp
IGNOREHR(TransitionPeerState(GetPeerLifetimeState(), ...::Releasing));
```

`TransitionPeerState` runs `ASSERT(IsLegalPeerStateTransition(from, to), ...)` in DBG. For any peer already disconnected from its core, `GetPeerLifetimeState()` derives to the **terminal `TornDown`** state, and `TornDown -> Releasing` is an illegal edge → the assert fires. Because every `DependencyObject` final-release hits this path, it affected all suites in chk test runs.

The sibling `WeakReferenceSourceNoThreadId::OnFinalReleaseOffThread` already guards against exactly this (`if (currentPeerState != PeerLifetimeState::TornDown)`); the `OnFinalRelease` announcement was missing the same guard.

## Fix

Add the same `TornDown` guard before announcing the `Releasing` transition. Observability-only; no change to the release path, and no retail impact (`TransitionPeerState` is a no-op outside `#if DBG`).
