### PR TITLE
Fix NavigationView lifetime leak: sever GC-invisible strong self-cycles

### DIFF
--- a/controls/dev/NavigationView/NavigationView.cpp
+++ b/controls/dev/NavigationView/NavigationView.cpp
@@ -224,8 +224,28 @@ NavigationView::NavigationView()
 
     m_selectionModel.SingleSelect(true);
     m_selectionModel.Source(m_selectionModelSource);
-    m_selectionChangedRevoker = m_selectionModel.SelectionChanged(winrt::auto_revoke, { this, &NavigationView::OnSelectionModelSelectionChanged });
-    m_childrenRequestedRevoker = m_selectionModel.ChildrenRequested(winrt::auto_revoke, { this, &NavigationView::OnSelectionModelChildrenRequested });
+    // Bind the SelectionModel callbacks weakly. m_selectionModel is a plain (non-tracker) strong field owned by this
+    // NavigationView, and a strong { this, ... } delegate would form a NavigationView -> m_selectionModel -> delegate
+    // -> NavigationView cycle that the reference-tracker GC cannot see (SelectionModel is not a ReferenceTracker peer).
+    // That cycle is only broken in ~NavigationView(), which can never run while the cycle keeps the peer alive, so the
+    // NavigationView (and everything it roots) leaks. A weak delegate breaks the cycle; the handler simply no-ops once
+    // this NavigationView has been collected. Use the make_weak lambda form (not get_weak()) per the note above.
+    m_selectionChangedRevoker = m_selectionModel.SelectionChanged(winrt::auto_revoke,
+        [weakThis](const winrt::SelectionModel& selectionModel, const winrt::SelectionModelSelectionChangedEventArgs& e)
+        {
+            if (auto strongThis = weakThis.get())
+            {
+                winrt::get_self<NavigationView>(strongThis)->OnSelectionModelSelectionChanged(selectionModel, e);
+            }
+        });
+    m_childrenRequestedRevoker = m_selectionModel.ChildrenRequested(winrt::auto_revoke,
+        [weakThis](const winrt::SelectionModel& selectionModel, const winrt::SelectionModelChildrenRequestedEventArgs& e)
+        {
+            if (auto strongThis = weakThis.get())
+            {
+                winrt::get_self<NavigationView>(strongThis)->OnSelectionModelChildrenRequested(selectionModel, e);
+            }
+        });
 
     m_navigationViewItemsFactory = winrt::make_self<NavigationViewItemsFactory>();
 
@@ -3581,7 +3601,11 @@ void NavigationView::UpdateLeftNavigationOnlyVisualState(bool useTransitions)
 void NavigationView::SetNavigationViewItemBaseRevokers(const winrt::NavigationViewItemBase& nvib)
 {
     auto nvibRevokers = winrt::make_self<NavigationViewItemBaseRevokers>();
-    nvibRevokers->visibilityRevoker = RegisterPropertyChanged(nvib, winrt::UIElement::VisibilityProperty(), { this, &NavigationView::OnNavigationViewItemBaseVisibilityPropertyChanged });
+    // Bind weakly: the revokers object is parked on the item's own DP (s_NavigationViewItemBaseRevokersProperty) and the
+    // item is strongly held by m_itemsWithRevokerObjects, so a strong { this, ... } delegate forms a
+    // NavigationView -> item -> revokers -> NavigationView cycle that the tracker GC cannot see. It is only broken in
+    // ~NavigationView() (via ClearAllNavigationViewItemBaseRevokers), which can never run while the cycle roots the peer.
+    nvibRevokers->visibilityRevoker = RegisterPropertyChanged(nvib, winrt::UIElement::VisibilityProperty(), { get_weak(), &NavigationView::OnNavigationViewItemBaseVisibilityPropertyChanged });
     nvib.SetValue(s_NavigationViewItemBaseRevokersProperty, nvibRevokers.as<winrt::IInspectable>());
     m_itemsWithRevokerObjects.insert(nvib);
 }
@@ -3592,10 +3616,12 @@ void NavigationView::SetNavigationViewItemRevokers(const winrt::NavigationViewIt
     {
         if (auto const revokersAsNVIBR = revokers.try_as<NavigationViewItemBaseRevokers>()) 
         {
-            revokersAsNVIBR->keyDownRevoker = nvi.KeyDown(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemKeyDown });
-            revokersAsNVIBR->gotFocusRevoker = nvi.GotFocus(winrt::auto_revoke, { this, &NavigationView::OnNavigationViewItemOnGotFocus });
-            revokersAsNVIBR->isSelectedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItemBase::IsSelectedProperty(), { this, &NavigationView::OnNavigationViewItemIsSelectedPropertyChanged });
-            revokersAsNVIBR->isExpandedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItem::IsExpandedProperty(), { this, &NavigationView::OnNavigationViewItemExpandedPropertyChanged });
+            // Bind weakly to break the NavigationView -> item -> revokers -> NavigationView strong cycle (see
+            // SetNavigationViewItemBaseRevokers). Handlers no-op if the NavigationView has already been collected.
+            revokersAsNVIBR->keyDownRevoker = nvi.KeyDown(winrt::auto_revoke, { get_weak(), &NavigationView::OnNavigationViewItemKeyDown });
+            revokersAsNVIBR->gotFocusRevoker = nvi.GotFocus(winrt::auto_revoke, { get_weak(), &NavigationView::OnNavigationViewItemOnGotFocus });
+            revokersAsNVIBR->isSelectedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItemBase::IsSelectedProperty(), { get_weak(), &NavigationView::OnNavigationViewItemIsSelectedPropertyChanged });
+            revokersAsNVIBR->isExpandedRevoker = RegisterPropertyChanged(nvi, winrt::NavigationViewItem::IsExpandedProperty(), { get_weak(), &NavigationView::OnNavigationViewItemExpandedPropertyChanged });
         }
     }
 }


### PR DESCRIPTION
## What

Fixes the `StressNavigationViewMenuChurn` lifetime leak (LifetimeStressTestSuite): the `NavigationView` and its first menu item are reported *still alive after forced collection* on every iteration, all 3 OS.

## Root cause

Two **entirely native strong reference cycles** that the reference-tracker GC cannot see. Each is severed only in `~NavigationView()` — which can **never run**, because the cycle itself keeps the peer alive (self-defeating cleanup).

**Cycle A — roots the NavigationView**
```
NavigationView -> m_selectionModel (plain, non-tracker strong field)
               -> SelectionChanged / ChildrenRequested delegate bound { this }  (strong)
               -> NavigationView
```
`SelectionModel` is not a `ReferenceTracker` peer, so the delegate's strong `this` is a GC-invisible edge. Revoked only under `if (isFromDestructor)`; `OnUnloaded` never touches it.

**Cycle B — roots the first realized item (FirstItem = MenuItems[0])**
```
NavigationView -> m_itemsWithRevokerObjects (raw std::set of strong item refs)
               -> NavigationViewItem -> revokers object (parked on a DP)
               -> KeyDown/GotFocus/IsSelected/IsExpanded/Visibility delegates { this } (strong)
               -> NavigationView
```
Bulk-cleared only in the destructor.

## Fix

Break both cycles **at the binding site** by making the internal delegates **weak** — the handler no-ops once the `NavigationView` is collected, and no strong cycle forms in the first place. Behavior while the control is alive is unchanged.

- **Constructor:** bind `SelectionModel` `SelectionChanged`/`ChildrenRequested` via the existing `make_weak(static_cast<NavigationView>(*this))` lambda pattern already used in this ctor (the file documents a `get_weak()`-in-ctor refcount hazard, so the lambda form is used here).
- **`SetNavigationViewItemBaseRevokers` / `SetNavigationViewItemRevokers`:** bind the per-item `Visibility`/`KeyDown`/`GotFocus`/`IsSelected`/`IsExpanded` handlers with `{ get_weak(), ... }` — the weak-delegate form already proven in `InkToolbar.cpp` and `TableView.cpp` for both `UIElement` events and `winrt::DependencyPropertyChangedCallback`.

Unchanged (already correct): the item→NavigationView back-pointer (`NavigationViewItemBase::m_navigationView` is already a `winrt::weak_ref`) and the global title-bar handler (already revoked in `OnUnloaded`).

## Why the 4 pillars didn't catch/fix this

The leaking edges are a **hand-written non-generated field** (`m_selectionModel`), a **raw STL container** (`std::set`), and **delegate bindings** — none of which Pillar B's storage codegen governs, and its `PeerComPtrFieldCheck` lint is dormant + trait-scoped to peer types (won't flag `SelectionModel`/`std::set`/a delegate). Pillars A/C/D are observability / off-thread / teardown-reentrancy and don't change reference strength. Fixing this requires a per-control binding-site change — this PR.

## Validation

- Static: weak-delegate forms match proven usages in `InkToolbar.cpp` / `TableView.cpp`; revoker types and handler signatures unchanged.
- ⚠️ Not yet built/run locally (chk build + TAEF UI suite). **Expected result:** `NavigationView` + `FirstItem` become collectable and the `StressNavigationViewMenuChurn` non-gating leak warnings disappear — to be confirmed by a LifetimeStressTestSuite run on this branch.
